### PR TITLE
A couple small Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-vllm-sim:
 
 .PHONY: build-vllm-sim-linux
 build-vllm-sim-linux:
-	GOOS=linux GOARCH=amd64 go build -o bin/linux/ ${PACKAGE_VLLM_SIM}
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/linux/ ${PACKAGE_VLLM_SIM}
 
 .PHONY: build-vllm-sim-image
 build-vllm-sim-image: build-vllm-sim-linux


### PR DESCRIPTION
* Allows overriding the container-runtime in the `Makefile` to anything docker compatible (e.g. `podman`) without changing the previous default behavior.
* Disabled CGO builds for compatibility with alpine