### PR TITLE
make linters happy

### DIFF
--- a/cmd/vllm-sim/main.go
+++ b/cmd/vllm-sim/main.go
@@ -31,7 +31,7 @@ func main() {
 	// setup logger and context with graceful shutdown
 	logger := klog.Background()
 	ctx := klog.NewContext(context.Background(), logger)
-	ctx = signals.SetupSignalHandler(ctx)
+	_ = signals.SetupSignalHandler(ctx) // ctx is not used further
 
 	logger.Info("Start vllm simulator")
 

--- a/pkg/vllm-sim/defs.go
+++ b/pkg/vllm-sim/defs.go
@@ -57,7 +57,7 @@ type VllmSimulator struct {
 	// runningLoras is a collection of running loras, key of lora's name, value is number of requests using this lora
 	runningLoras sync.Map
 	// waitingLoras will represent collection of loras defined in requests in the queue - Not implemented yet
-	waitingLoras sync.Map
+	//waitingLoras sync.Map
 	nRunningReqs int64
 	// loraInfo is prometheus gauge
 	loraInfo *prometheus.GaugeVec

--- a/pkg/vllm-sim/simulator.go
+++ b/pkg/vllm-sim/simulator.go
@@ -81,29 +81,29 @@ func (s *VllmSimulator) parseCommandParams() error {
 
 	// validate parsed values
 	if s.model == "" {
-		return fmt.Errorf("Model parameter is empty")
+		return fmt.Errorf("model parameter is empty")
 	}
 	if s.mode != modeEcho && s.mode != modeRandom {
-		return fmt.Errorf("Invalid mode '%s', valid values are 'random' and 'echo'", s.mode)
+		return fmt.Errorf("invalid mode '%s', valid values are 'random' and 'echo'", s.mode)
 	}
 	if s.port <= 0 {
-		return fmt.Errorf("Invalid port '%d'", s.port)
+		return fmt.Errorf("invalid port '%d'", s.port)
 	}
 	if s.interTokenLatency < 0 {
-		return fmt.Errorf("Inter token latency cannot be negative")
+		return fmt.Errorf("inter-token latency cannot be negative")
 	}
 	if s.timeToFirstToken < 0 {
-		return fmt.Errorf("Time to first token cannot be negative")
+		return fmt.Errorf("time to first token cannot be negative")
 	}
 	if s.maxLoras < 1 {
-		return fmt.Errorf("Max loras cannot be less than 1")
+		return fmt.Errorf("max loras cannot be less than 1")
 	}
 	if s.maxCpuLoras == 0 {
 		// max cpu loras by default is same as max loras
 		s.maxCpuLoras = s.maxLoras
 	}
 	if s.maxCpuLoras < 1 {
-		return fmt.Errorf("Max CPU loras cannot be less than 1")
+		return fmt.Errorf("max CPU loras cannot be less than 1")
 	}
 
 	return nil
@@ -135,7 +135,9 @@ func (s *VllmSimulator) startServer() error {
 	if err != nil {
 		return err
 	}
-	defer listener.Close()
+	defer func() {
+		_ = listener.Close()
+	}()
 
 	return server.Serve(listener)
 }

--- a/pkg/vllm-sim/streaming.go
+++ b/pkg/vllm-sim/streaming.go
@@ -78,8 +78,8 @@ func (s *VllmSimulator) sendStreamingResponse(isChatCompletion bool, ctx *fastht
 		}
 
 		// finish sse events stream
-		fmt.Fprint(w, "data: [DONE]\n\n")
-		w.Flush()
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+		_ = w.Flush()
 
 		s.responseSentCallback(model)
 	})
@@ -130,8 +130,8 @@ func (s *VllmSimulator) sendChunk(isChatCompletion bool, w *bufio.Writer, creati
 		return err
 	}
 
-	fmt.Fprintf(w, "data: %s\n\n", data)
-	w.Flush()
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+	_ = w.Flush()
 
 	return nil
 }


### PR DESCRIPTION
Address linters requirements

- ignoring error return values - assign to `_` (e.g., error was not being used or could not be handled)
- lower case messages
- ignore assign to `ctx` variable which is unused after
- comment out unused variables in struct (instead of removing altogether - can be resurrected)