### PR TITLE
Renamed the vllm-sim package to match the new name llm-d-inference-sim

### DIFF
--- a/pkg/llm-d-inference-sim/defs.go
+++ b/pkg/llm-d-inference-sim/defs.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Definitions of all sturctures used by vLLM simultor
 // Contains the main simulator class and all definitions related to request/response for all supported APIs
-package vllmsim
+package llmdinferencesim
 
 import (
 	"fmt"

--- a/pkg/llm-d-inference-sim/metrics.go
+++ b/pkg/llm-d-inference-sim/metrics.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Contains functions related to prometheus metrics
 
-package vllmsim
+package llmdinferencesim
 
 import (
 	"strconv"

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package vllmsim implements the vLLM simulator.
-package vllmsim
+package llmdinferencesim
 
 import (
 	"context"

--- a/pkg/llm-d-inference-sim/simulator_test.go
+++ b/pkg/llm-d-inference-sim/simulator_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vllmsim
+package llmdinferencesim
 
 import (
 	"context"

--- a/pkg/llm-d-inference-sim/streaming.go
+++ b/pkg/llm-d-inference-sim/streaming.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vllmsim
+package llmdinferencesim
 
 import (
 	"bufio"

--- a/pkg/llm-d-inference-sim/utils.go
+++ b/pkg/llm-d-inference-sim/utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vllmsim
+package llmdinferencesim
 
 import (
 	"math/rand"

--- a/pkg/llm-d-inference-sim/utils_test.go
+++ b/pkg/llm-d-inference-sim/utils_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vllmsim
+package llmdinferencesim
 
 import (
 	"strings"

--- a/pkg/llm-d-inference-sim/vllm_sim_suite_test.go
+++ b/pkg/llm-d-inference-sim/vllm_sim_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vllmsim
+package llmdinferencesim
 
 import (
 	"testing"


### PR DESCRIPTION
Renamed the vllm-sim package to match the new name llm-d-inference-sim.