### PR TITLE
Makefile: Adds image-build-and-push Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,10 @@ SHELL := /usr/bin/env bash
 
 # Defaults
 PROJECT_NAME ?= llm-d-inference-sim
-IMAGE_TAG_BASE ?= ghcr.io/llm-d/$(PROJECT_NAME)
+REGISTRY ?= ghcr.io/llm-d
+IMAGE_TAG_BASE ?= $(REGISTRY)/$(PROJECT_NAME)
 SIM_TAG ?= dev
 IMG = $(IMAGE_TAG_BASE):$(SIM_TAG)
-
-
 CONTAINER_TOOL := $(shell { command -v docker >/dev/null 2>&1 && echo docker; } || { command -v podman >/dev/null 2>&1 && echo podman; } || echo "")
 BUILDER := $(shell command -v buildah >/dev/null 2>&1 && echo buildah || echo $(CONTAINER_TOOL))
 PLATFORMS ?= linux/amd64 # linux/arm64 # linux/s390x,linux/ppc64le
@@ -66,6 +65,9 @@ build: check-go ##
 	go build -o bin/$(PROJECT_NAME) cmd/$(PROJECT_NAME)/main.go
 
 ##@ Container Build/Push
+
+.PHONY: image-build-and-push
+image-build-and-push: image-build image-push ## Build and push Docker image $(IMG) to registry
 
 .PHONY:	image-build
 image-build: check-container-tool ## Build Docker image ## Build Docker image using $(CONTAINER_TOOL)

--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ To build a Docker image of the vLLM Simulator, run:
 make image-build
 ```
 Please note that the default image tag is `ghcr.io/llm-d/llm-d-inference-sim:dev`. <br>
-The following environment variables can be used to change the image tag: `SIM_TAG`, `IMAGE_TAG_BASE` or `IMG`.
+The following environment variables can be used to change the image tag: `REGISTRY`, `SIM_TAG`, `IMAGE_TAG_BASE` or `IMG`.
 
 ### Running
 To run the vLLM Simulator image under Docker, run:
 ```bash
 docker run --rm --publish 8000:8000 ghcr.io/llm-d/llm-d-inference-sim:dev  --port 8000 --model "Qwen/Qwen2.5-1.5B-Instruct" --lora "tweet-summary-0,tweet-summary-1"
 ```
-**Note:** If you want to run the vLLM Simulator with the latest release version, in the above docker command replace `dev` with the current release which can be found on [github](./releases).
+**Note:** To run the vLLM Simulator with the latest release version, in the above docker command replace `dev` with the current release which can be found on [GitHub](https://github.com/llm-d/llm-d-inference-sim/pkgs/container/llm-d-inference-sim).
 
 **Note:** The above command exposes the simulator on port 8000, and serves the Qwen/Qwen2.5-1.5B-Instruct model.
 


### PR DESCRIPTION
- Adds the `REGISTRY` env var so users can push the image to registries other than `ghcr.io/llm-d`.
- Adds an `image-build-and-push` target to build and push the image.