### PR TITLE
Adds Kubernetes Deployment Manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,19 @@ make build
 ```
 
 ### Running
-To run the router in a standalone test environment, run:
+To run the vLLM simulator in a standalone test environment, run:
 ```bash
 ./bin/llm-d-inference-sim --model my_model --port 8000
 ```
 
+## Kubernetes testing
 
+To run the vLLM simulator in a Kubernetes cluster, run:
+```bash
+kubectl apply -f manifests/deployment.yaml
+```
+
+To verify the deployment is available, run:
+```bash
+kubectl get deployment vllm-llama3-8b-instruct
+```

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-llama3-8b-instruct
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: vllm-llama3-8b-instruct
+  template:
+    metadata:
+      labels:
+        app: vllm-llama3-8b-instruct
+    spec:
+      containers:
+      - args:
+        - --model
+        - meta-llama/Llama-3.1-8B-Instruct
+        - --port
+        - "8000"
+        - --max-loras
+        - "2"
+        - --lora
+        - food-review-1
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.1.0
+        imagePullPolicy: IfNotPresent
+        name: vllm-sim
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP


### PR DESCRIPTION
Adds a Kubernetes deployment manifest for running the simulator in a Kubernetes cluster. The manifest configuration is consistent with the [upstream vLLM manifests](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/config/manifests/vllm).