### PR TITLE
feat: Create a minimal multi-architecture docker image

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Build image
       run: |
         docker buildx build \
-          --platform linux/amd64 \
+          --platform linux/amd64,linux/arm64 \
           -t ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }} \
           --push .
       shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ COPY . .
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin/llm-d-inference-sim cmd/cmd.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
+# Use ubi9 as a minimal base image to package the manager binary
+# Refer to https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5 for more details
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/bin/llm-d-inference-sim /app/llm-d-inference-sim

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bi
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/bin/llm-d-inference-sim /app/llm-d-inference-sim
 USER 65532:65532


### PR DESCRIPTION
This PR changes the base image used to create a smaller docker image. In addition it will now build a multi-architecture image that is for Linux on both amd64 and arm64.

Fix: #40 