### PR TITLE
feat: When creating a new image of the vLLM simulator always add a tag of latest

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -35,5 +35,6 @@ runs:
         docker buildx build \
           --platform linux/amd64,linux/arm64 \
           -t ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }} \
+          -t ${{ inputs.registry }}/${{ inputs.image-name }}:latest \
           --push .
       shell: bash


### PR DESCRIPTION
This PR adds an extra tag of latest to the build of the image of the simulator

fix: #46 