### PR TITLE
add usage metrics to streamed responses

### DIFF
--- a/pkg/llm-d-inference-sim/defs.go
+++ b/pkg/llm-d-inference-sim/defs.go
@@ -133,6 +133,7 @@ type baseCompletionRequest struct {
 	StreamOptions streamOptions `json:"stream_options"`
 	// Model defines Model name to use for "inference", could be base Model name or one of available LoRA adapters
 	Model string `json:"model"`
+	Usage *bool `json:"usage,omitempty"`
 }
 
 func (b *baseCompletionRequest) isStream() bool {
@@ -144,7 +145,7 @@ func (b *baseCompletionRequest) getModel() string {
 }
 
 func (b *baseCompletionRequest) includeUsage() bool {
-	return !b.Stream || b.StreamOptions.IncludeUsage
+	return b.StreamOptions.IncludeUsage || (b.Usage != nil && *b.Usage)
 }
 
 // completionRequest interface representing both completion request types (text and chat)


### PR DESCRIPTION
Really handy tool! Noticed I wasn't seeing usage metrics on streaming responses, small PR to fix.

Some notes on testing:

```bash
./bin/llm-d-inference-sim --model meta-llama/Llama-3.1-8B-Instruct --port 8000
```

Test completion w/ `{usage: true}`:

```bash
curl -H 'Content-Type: application/json' \
     -X POST http://localhost:8000/v1/chat/completions \
     -d '{
           "model": "meta-llama/Llama-3.1-8B-Instruct",
           "messages": [{"role": "user", "content": "Test"}],
           "max_tokens": 50,
           "stream": true,
           "usage": true
         }'
```

Test completion w/ [OpenAI style](https://platform.openai.com/docs/guides/streaming-responses?api-mode=chat) `stream` + `stream_options` params:

```bash
curl -H 'Content-Type: application/json' \
     -X POST http://localhost:8000/v1/chat/completions \
     -d '{
           "model": "meta-llama/Llama-3.1-8B-Instruct",
           "messages": [{"role": "user", "content": "Test"}],
           "max_tokens": 50,
           "stream": true,
           "stream_options": {"include_usage": true}
         }'
```

before:

```
data: {"id":"chatcmpl-...","usage":null,"choices":[{"delta":{"content":"Hello"}}]}
data: {"id":"chatcmpl-...","usage":null,"choices":[{"finish_reason":"stop","delta":{}}]}
data: [DONE]
```

and after:

```
data: {"id":"chatcmpl-...","usage":null,"choices":[{"delta":{"content":"Hello"}}]}
data: {"id":"chatcmpl-...","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2},"choices":[{"finish_reason":"stop","delta":{}}]}
data: [DONE]
```