### PR TITLE
feat: Added standard vLLM health and readiness endpoints

### DIFF
--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -155,6 +155,9 @@ func (s *VllmSimulator) startServer(listener net.Listener) error {
 	r.POST("/v1/unload_lora_adapter", s.HandleUnloadLora)
 	// supports /metrics prometheus API
 	r.GET("/metrics", fasthttpadaptor.NewFastHTTPHandler(promhttp.Handler()))
+	// supports standard Kubernetes health and readiness checks
+	r.GET("/health", s.HandleHealth)
+	r.GET("/ready", s.HandleReady)
 
 	server := fasthttp.Server{
 		ErrorHandler: s.HandleError,
@@ -507,4 +510,20 @@ func (s *VllmSimulator) createModelsResponse() *vllmapi.ModelsResponse {
 	}
 
 	return &modelsResp
+}
+
+// HandleHealth http handler for /health
+func (s *VllmSimulator) HandleHealth(ctx *fasthttp.RequestCtx) {
+	s.logger.V(4).Info("health request received")
+	ctx.Response.Header.SetContentType("application/json")
+	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
+	ctx.Response.SetBody([]byte("{}"))
+}
+
+// HandleReady http handler for /ready
+func (s *VllmSimulator) HandleReady(ctx *fasthttp.RequestCtx) {
+	s.logger.V(4).Info("readiness request received")
+	ctx.Response.Header.SetContentType("application/json")
+	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
+	ctx.Response.SetBody([]byte("{}"))
 }

--- a/pkg/llm-d-inference-sim/simulator_test.go
+++ b/pkg/llm-d-inference-sim/simulator_test.go
@@ -358,4 +358,24 @@ var _ = Describe("Simulator", func() {
 		Entry(nil, modeRandom, -1),
 		Entry(nil, modeEcho, -1),
 	)
+
+	It("Should respond to /health", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, modeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, err := client.Get("http://localhost/health")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	})
+
+	It("Should respond to /ready", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, modeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, err := client.Get("http://localhost/ready")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	})
 })


### PR DESCRIPTION
This PR adds the standard vLLM health and readiness HTTP endpoints to the simulator.

In particular it adds support for the `/health` and `/ready` HTTP endpoints. In both cases the simulator will always return an HTTP status code of 200 (OK) with a body of an empty JSON object ({}).

fix: #45