### PR TITLE
Calculate usage data once for both text and chat

### DIFF
--- a/pkg/llm-d-inference-sim/request.go
+++ b/pkg/llm-d-inference-sim/request.go
@@ -30,8 +30,9 @@ type completionRequest interface {
 	// and the finish reason
 	createResponseText(mode string) (string, string, error)
 	// createToolCalls creates and returns response payload based on this request
-	// (tool calls or nothing in case we randomly choose not to generate calls), and the finish reason
-	createToolCalls() ([]toolCall, string, error)
+	// (tool calls or nothing in case we randomly choose not to generate calls), the finish reason,
+	// and the number of generated completion tokens
+	createToolCalls() ([]toolCall, string, int, error)
 	// isStream returns boolean that defines is response should be streamed
 	isStream() bool
 	// getModel returns model name as defined in the request

--- a/pkg/llm-d-inference-sim/request.go
+++ b/pkg/llm-d-inference-sim/request.go
@@ -29,10 +29,6 @@ type completionRequest interface {
 	// createResponseText creates and returns response payload based on this request,
 	// and the finish reason
 	createResponseText(mode string) (string, string, error)
-	// createToolCalls creates and returns response payload based on this request
-	// (tool calls or nothing in case we randomly choose not to generate calls), the finish reason,
-	// and the number of generated completion tokens
-	createToolCalls() ([]toolCall, string, int, error)
 	// isStream returns boolean that defines is response should be streamed
 	isStream() bool
 	// getModel returns model name as defined in the request
@@ -158,6 +154,23 @@ func (req *chatCompletionRequest) getLastUserMsg() string {
 	return ""
 }
 
+// createResponseText creates response text for the given chat completion request and mode
+func (req chatCompletionRequest) createResponseText(mode string) (string, string, error) {
+	maxTokens, err := getMaxTokens(req.MaxCompletionTokens, req.MaxTokens)
+	if err != nil {
+		return "", "", err
+	}
+
+	var text, finishReason string
+	if mode == modeEcho {
+		text, finishReason = getResponseText(maxTokens, req.getLastUserMsg())
+	} else {
+		text, finishReason = getRandomResponseText(maxTokens)
+	}
+
+	return text, finishReason, nil
+}
+
 // v1/completion
 // textCompletionRequest defines structure of /completion request
 type textCompletionRequest struct {
@@ -183,4 +196,21 @@ func (c *textCompletionRequest) getTools() []tool {
 
 func (c *textCompletionRequest) getToolChoice() string {
 	return ""
+}
+
+// createResponseText creates response text for the given text completion request and mode
+func (req textCompletionRequest) createResponseText(mode string) (string, string, error) {
+	maxTokens, err := getMaxTokens(nil, req.MaxTokens)
+	if err != nil {
+		return "", "", err
+	}
+
+	var text, finishReason string
+	if mode == modeEcho {
+		text, finishReason = getResponseText(maxTokens, req.Prompt)
+	} else {
+		text, finishReason = getRandomResponseText(maxTokens)
+	}
+
+	return text, finishReason, nil
 }

--- a/pkg/llm-d-inference-sim/response.go
+++ b/pkg/llm-d-inference-sim/response.go
@@ -20,7 +20,6 @@ package llmdinferencesim
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 )
 
@@ -191,106 +190,6 @@ type chatRespChunkChoice struct {
 	baseResponseChoice
 	// Delta is a content of the chunk
 	Delta message `json:"delta"`
-}
-
-// returns the max tokens or error if incorrect
-func getMaxTokens(maxCompletionTokens *int64, maxTokens *int64) (*int64, error) {
-	var typeToken string
-	var tokens *int64
-	// if both arguments are passed,
-	// use maxCompletionTokens
-	// as in the real vllm
-	if maxCompletionTokens != nil {
-		tokens = maxCompletionTokens
-		typeToken = "max_completion_tokens"
-	} else if maxTokens != nil {
-		tokens = maxTokens
-		typeToken = "max_tokens"
-	}
-	if tokens != nil && *tokens < 1 {
-		return nil, fmt.Errorf("%s must be at least 1, got %d", typeToken, *tokens)
-	}
-	return tokens, nil
-}
-
-// createResponseText creates response text for the given chat completion request and mode
-func (req chatCompletionRequest) createResponseText(mode string) (string, string, error) {
-	maxTokens, err := getMaxTokens(req.MaxCompletionTokens, req.MaxTokens)
-	if err != nil {
-		return "", "", err
-	}
-
-	var text, finishReason string
-	if mode == modeEcho {
-		text, finishReason = getResponseText(maxTokens, req.getLastUserMsg())
-	} else {
-		text, finishReason = getRandomResponseText(maxTokens)
-	}
-
-	return text, finishReason, nil
-}
-
-// createResponseText creates response text for the given text completion request and mode
-func (req textCompletionRequest) createResponseText(mode string) (string, string, error) {
-	maxTokens, err := getMaxTokens(nil, req.MaxTokens)
-	if err != nil {
-		return "", "", err
-	}
-
-	var text, finishReason string
-	if mode == modeEcho {
-		text, finishReason = getResponseText(maxTokens, req.Prompt)
-	} else {
-		text, finishReason = getRandomResponseText(maxTokens)
-	}
-
-	return text, finishReason, nil
-}
-
-// createToolCalls creates and returns response payload based on this request
-// (tool calls or nothing in case we randomly choose not to generate calls), the finish reason,
-// and the number of generated completion tokensand the finish reason
-func (req chatCompletionRequest) createToolCalls() ([]toolCall, string, int, error) {
-	// This function is called if tool choice is either 'required' or 'auto'.
-	// In case of 'required' at least one tool call has to be created, and we randomly choose
-	// the number of calls starting from one. Otherwise, we start from 0, and in case we randomly
-	// choose the number of calls to be 0, response text will be generated instead of a tool call.
-	numberOfCalls := randomInt(len(req.Tools), req.ToolChoice == toolChoiceRequired)
-	if numberOfCalls == 0 {
-		return nil, "", 0, nil
-	}
-
-	calls := make([]toolCall, 0)
-	for i := range numberOfCalls {
-		// Randomly choose which tools to call. We may call the same tool more than once.
-		index := randomInt(len(req.Tools)-1, false)
-		args, err := generateToolArguments(req.Tools[index])
-		if err != nil {
-			return nil, "", 0, err
-		}
-		argsJson, err := json.Marshal(args)
-		if err != nil {
-			return nil, "", 0, err
-		}
-
-		call := toolCall{
-			Function: functionCall{
-				Arguments: string(argsJson),
-				Name:      &req.Tools[index].Function.Name,
-			},
-			ID:    "chatcmpl-tool-" + randomNumericString(10),
-			Type:  "function",
-			Index: i,
-		}
-		calls = append(calls, call)
-	}
-
-	return calls, toolsFinishReason, countTokensForToolCalls(calls), nil
-}
-
-// createToolCalls shouldn't be called for text completion
-func (req textCompletionRequest) createToolCalls() ([]toolCall, string, int, error) {
-	return nil, "", 0, errors.New("tool calls are not supported in text completion")
 }
 
 // completionError defines the simulator's response in case of an error

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -397,7 +397,7 @@ func (s *VllmSimulator) reqProcessingWorker(ctx context.Context, id int) {
 			var toolCalls []toolCall
 			var completionTokens int
 			if reqCtx.isChatCompletion && req.getToolChoice() != toolChoiceNone && req.getTools() != nil {
-				toolCalls, finishReason, completionTokens, err = req.createToolCalls()
+				toolCalls, finishReason, completionTokens, err = createToolCalls(req.getTools(), req.getToolChoice())
 			}
 			if toolCalls == nil {
 				// Either no tool calls were defined, or we randomly chose not to create tool calls,

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -395,13 +395,15 @@ func (s *VllmSimulator) reqProcessingWorker(ctx context.Context, id int) {
 			var responseTxt, finishReason string
 			var err error
 			var toolCalls []toolCall
+			var completionTokens int
 			if reqCtx.isChatCompletion && req.getToolChoice() != toolChoiceNone && req.getTools() != nil {
-				toolCalls, finishReason, err = req.createToolCalls()
+				toolCalls, finishReason, completionTokens, err = req.createToolCalls()
 			}
 			if toolCalls == nil {
 				// Either no tool calls were defined, or we randomly chose not to create tool calls,
 				// so we generate a response text.
 				responseTxt, finishReason, err = req.createResponseText(s.mode)
+				completionTokens = len(strings.Fields(responseTxt))
 			}
 			if err != nil {
 				prefix := ""
@@ -413,13 +415,22 @@ func (s *VllmSimulator) reqProcessingWorker(ctx context.Context, id int) {
 				s.logger.Error(err, prefix)
 				reqCtx.httpReqCtx.Error(prefix+err.Error(), fasthttp.StatusBadRequest)
 			} else {
+				usageData := usage{
+					PromptTokens:     req.getNumberOfPromptTokens(),
+					CompletionTokens: completionTokens,
+					TotalTokens:      req.getNumberOfPromptTokens() + completionTokens,
+				}
 				if req.isStream() {
+					var usageDataToSend *usage
+					if req.includeUsage() {
+						usageDataToSend = &usageData
+					}
 					s.sendStreamingResponse(
 						&streamingContext{ctx: reqCtx.httpReqCtx, isChatCompletion: reqCtx.isChatCompletion, model: model},
-						responseTxt, toolCalls, finishReason, req.includeUsage(), req.getNumberOfPromptTokens())
+						responseTxt, toolCalls, finishReason, usageDataToSend)
 				} else {
 					s.sendResponse(reqCtx.isChatCompletion, reqCtx.httpReqCtx, responseTxt, toolCalls, model, finishReason,
-						req.getNumberOfPromptTokens())
+						&usageData)
 				}
 			}
 			reqCtx.wg.Done()
@@ -505,16 +516,12 @@ func (s *VllmSimulator) HandleError(_ *fasthttp.RequestCtx, err error) {
 // model - model name
 // finishReason - a pointer to string that represents finish reason, can be nil or stop or length, ...
 func (s *VllmSimulator) createCompletionResponse(isChatCompletion bool, respText string, toolCalls []toolCall, model string,
-	finishReason *string, promptTokens int, completionTokens int) completionResponse {
+	finishReason *string, usageData *usage) completionResponse {
 	baseResp := baseCompletionResponse{
 		ID:      chatComplIDPrefix + uuid.NewString(),
 		Created: time.Now().Unix(),
 		Model:   model,
-		Usage: &usage{
-			PromptTokens:     promptTokens,
-			CompletionTokens: completionTokens,
-			TotalTokens:      promptTokens + completionTokens,
-		},
+		Usage:   usageData,
 	}
 	baseChoice := baseResponseChoice{Index: 0, FinishReason: finishReason}
 
@@ -544,12 +551,8 @@ func (s *VllmSimulator) createCompletionResponse(isChatCompletion bool, respText
 // respText - content to be sent in the response
 // model - model name
 func (s *VllmSimulator) sendResponse(isChatCompletion bool, ctx *fasthttp.RequestCtx, respText string, toolCalls []toolCall,
-	model string, finishReason string, promptTokens int) {
-	numOfWords := len(strings.Fields(respText))
-	if toolCalls != nil {
-		numOfWords = countTokensForToolCalls(toolCalls)
-	}
-	resp := s.createCompletionResponse(isChatCompletion, respText, toolCalls, model, &finishReason, promptTokens, numOfWords)
+	model string, finishReason string, usageData *usage) {
+	resp := s.createCompletionResponse(isChatCompletion, respText, toolCalls, model, &finishReason, usageData)
 
 	data, err := json.Marshal(resp)
 	if err != nil {
@@ -558,6 +561,7 @@ func (s *VllmSimulator) sendResponse(isChatCompletion bool, ctx *fasthttp.Reques
 	}
 
 	// calculate how long to wait before returning the response, time is based on number of tokens (use words number)
+	numOfWords := usageData.PromptTokens
 	totalMillisToWait := s.timeToFirstToken + (numOfWords-1)*s.interTokenLatency
 	time.Sleep(time.Duration(totalMillisToWait) * time.Millisecond)
 

--- a/pkg/llm-d-inference-sim/utils.go
+++ b/pkg/llm-d-inference-sim/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package llmdinferencesim
 
 import (
+	"fmt"
 	"math/rand"
 	"strings"
 	"time"
@@ -34,6 +35,26 @@ var chatCompletionFakeResponses = []string{
 	`Alas, poor Yorick! I knew him, Horatio: A fellow of infinite jest`,
 	`The rest is silence. `,
 	`Give a man a fish and you feed him for a day; teach a man to fish and you feed him for a lifetime`,
+}
+
+// returns the max tokens or error if incorrect
+func getMaxTokens(maxCompletionTokens *int64, maxTokens *int64) (*int64, error) {
+	var typeToken string
+	var tokens *int64
+	// if both arguments are passed,
+	// use maxCompletionTokens
+	// as in the real vllm
+	if maxCompletionTokens != nil {
+		tokens = maxCompletionTokens
+		typeToken = "max_completion_tokens"
+	} else if maxTokens != nil {
+		tokens = maxTokens
+		typeToken = "max_tokens"
+	}
+	if tokens != nil && *tokens < 1 {
+		return nil, fmt.Errorf("%s must be at least 1, got %d", typeToken, *tokens)
+	}
+	return tokens, nil
 }
 
 // getRandomResponseText returns random response text from the pre-defined list of responses


### PR DESCRIPTION
We now calculate usage data in one place for both text and chat completion, and pass it to the relevant functions.

This is the second part of #56 (fixes #56)



