### PR TITLE
feat: 🚀 Reduce the mirror image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ COPY . .
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin/llm-d-inference-sim cmd/cmd.go
 
-# Use ubi9 as a minimal base image to package the manager binary
-# Refer to https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5 for more details
-FROM gcr.io/distroless/static:nonroot
+# Use ubi9 as a micro base image to package the manager binary
+# Refer to https://catalog.redhat.com/software/containers/ubi9/ubi-micro/615bdf943f6014fa45ae1b58 for more details
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 WORKDIR /
 COPY --from=builder /workspace/bin/llm-d-inference-sim /app/llm-d-inference-sim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,9 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bi
 
 # Use ubi9 as a minimal base image to package the manager binary
 # Refer to https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5 for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/bin/llm-d-inference-sim /app/llm-d-inference-sim
 USER 65532:65532
 
 ENTRYPOINT ["/app/llm-d-inference-sim"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,5 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bi
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/bin/llm-d-inference-sim /app/llm-d-inference-sim
-USER 65532:65532
 
 ENTRYPOINT ["/app/llm-d-inference-sim"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,6 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bi
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 WORKDIR /
 COPY --from=builder /workspace/bin/llm-d-inference-sim /app/llm-d-inference-sim
+USER 65532:65532
 
 ENTRYPOINT ["/app/llm-d-inference-sim"]

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/gomega v1.37.0
 	github.com/openai/openai-go v0.1.0-beta.10
 	github.com/prometheus/client_golang v1.21.1
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/pflag v1.0.6
 	github.com/valyala/fasthttp v1.59.0
 	k8s.io/klog/v2 v2.130.1
@@ -31,7 +32,6 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect


### PR DESCRIPTION
Reduce the mirror image size **(118MB -> 36.8MB)** by using `gcr.io/distroless/static:nonroot`.

Before:
```
ghcr.io/llm-d/llm-d-inference-sim       latest          232d52460440   12 days ago      118MB
```

After:
```
ghcr.io/llm-d/llm-d-inference-sim      small-image         49ac536af322   5 seconds ago   36.8MB
```