### PR TITLE
link checker - fails PR if links are broken - be consistent with llmd-scheduler

### DIFF
--- a/.github/.lychee.toml
+++ b/.github/.lychee.toml
@@ -1,0 +1,13 @@
+# Ignore transient failures on gnu.org (it sometimes refuses connections)
+exclude = [
+  "^https://www.gnu.org/software/make/?$"
+]
+
+# Timeout in seconds
+timeout = 20
+
+# Retry failed links (helpful for flaky sites)
+retry_count = 3
+
+# Accept non-200 status codes (429: rate limits)
+accept = [200, 429]

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -1,0 +1,25 @@
+name: Markdown Link Checker
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  lychee:
+    name: Check Markdown Links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install lychee v0.18.1
+        run: |
+          curl -Ls https://github.com/lycheeverse/lychee/releases/download/lychee-v0.18.1/lychee-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          sudo mv lychee /usr/local/bin
+      - name: Run lychee on Markdown files with config
+        run: |
+          find . -name "*.md" -print0 | xargs -0 lychee --config .lychee.toml --verbose --no-progress


### PR DESCRIPTION
add check for broken links in  *.md files