### PR TITLE
Support space separated arguments, use correct format in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ For more details see the <a href="https://docs.vllm.ai/en/stable/getting_started
 - `config`: the path to a yaml configuration file 
 - `port`: the port the simulator listents on, default is 8000
 - `model`: the currently 'loaded' model, mandatory
-- `served-model-name`: model names exposed by the API (comma-separated)
-- `lora-modules`: LoRA module configurations in JSON format: [{"name": "name", "path": "lora_path", "base_model_name": "id"}], optional, empty by default
+- `served-model-name`: model names exposed by the API (a list of space-separated strings)
+- `lora-modules`: a list of LoRA adapters (a list of space-separated JSON strings): '{"name": "name", "path": "lora_path", "base_model_name": "id"}', optional, empty by default
 - `max-loras`: maximum number of LoRAs in a single batch, optional, default is one
 - `max-cpu-loras`: maximum number of LoRAs to store in CPU memory, optional, must be >= than max-loras, default is max-loras
 - `max-num-seqs`: maximum number of sequences per iteration (maximum number of inference requests that could be processed at the same time), default is 5
@@ -118,7 +118,7 @@ In addition, as we are using klog, the following parameters are available:
 
 ## Migrating from releases prior to v0.2.0
 - `max-running-requests` was replaced by `max-num-seqs`
-- `lora` was replaced by `lora-modules`, which is now an array in JSON format, e.g, [{"name": "name", "path": "lora_path", "base_model_name": "id"}]
+- `lora` was replaced by `lora-modules`, which is now a list of JSON strings, e.g, '{"name": "name", "path": "lora_path", "base_model_name": "id"}'
 
 ## Working with docker image
 

--- a/manifests/config.yaml
+++ b/manifests/config.yaml
@@ -1,11 +1,14 @@
 port: 8001
 model: "Qwen/Qwen2-0.5B"
-served-model-name: ["model1", "model2"]
+served-model-name: 
+- "model1"
+- "model2"
 max-loras: 2
 max-cpu-loras: 5
 max-num-seqs: 5
-lora-modules: [{"name":"lora1","path":"/path/to/lora1"},{"name":"lora2","path":"/path/to/lora2"}]
-
+lora-modules:
+- '{"name":"lora1","path":"/path/to/lora1"}'
+- '{"name":"lora2","path":"/path/to/lora2"}'
 mode: "random"
 time-to-first-token: 2
 inter-token-latency: 1

--- a/pkg/llm-d-inference-sim/config_test.go
+++ b/pkg/llm-d-inference-sim/config_test.go
@@ -78,6 +78,10 @@ var _ = Describe("Simulator configuration", func() {
 		args:           []string{"cmd", "--config", "../../manifests/config.yaml"},
 		expectedConfig: c,
 	}
+	c.LoraModulesString = []string{
+		"{\"name\":\"lora1\",\"path\":\"/path/to/lora1\"}",
+		"{\"name\":\"lora2\",\"path\":\"/path/to/lora2\"}",
+	}
 	tests = append(tests, test)
 
 	// Config from config.yaml file plus command line args
@@ -90,11 +94,65 @@ var _ = Describe("Simulator configuration", func() {
 	c.MaxNumSeqs = 5
 	c.TimeToFirstToken = 2
 	c.InterTokenLatency = 1
-	c.LoraModules = []loraModule{{Name: "lora1", Path: "/path/to/lora1"}, {Name: "lora2", Path: "/path/to/lora2"}}
+	c.LoraModules = []loraModule{{Name: "lora3", Path: "/path/to/lora3"}, {Name: "lora4", Path: "/path/to/lora4"}}
+	c.LoraModulesString = []string{
+		"{\"name\":\"lora3\",\"path\":\"/path/to/lora3\"}",
+		"{\"name\":\"lora4\",\"path\":\"/path/to/lora4\"}",
+	}
 	test = testCase{
 		name: "config file with command line args",
 		args: []string{"cmd", "--model", model, "--config", "../../manifests/config.yaml", "--port", "8002",
-			"--served-model-name", "alias1,alias2"},
+			"--served-model-name", "alias1", "alias2",
+			"--lora-modules", "{\"name\":\"lora3\",\"path\":\"/path/to/lora3\"}", "{\"name\":\"lora4\",\"path\":\"/path/to/lora4\"}",
+		},
+		expectedConfig: c,
+	}
+	tests = append(tests, test)
+
+	// Config from config.yaml file plus command line args with different format
+	c = newConfig()
+	c.Port = 8002
+	c.Model = model
+	c.ServedModelNames = []string{c.Model}
+	c.MaxLoras = 2
+	c.MaxCPULoras = 5
+	c.MaxNumSeqs = 5
+	c.TimeToFirstToken = 2
+	c.InterTokenLatency = 1
+	c.LoraModules = []loraModule{{Name: "lora3", Path: "/path/to/lora3"}}
+	c.LoraModulesString = []string{
+		"{\"name\":\"lora3\",\"path\":\"/path/to/lora3\"}",
+	}
+	test = testCase{
+		name: "config file with command line args",
+		args: []string{"cmd", "--model", model, "--config", "../../manifests/config.yaml", "--port", "8002",
+			"--served-model-name",
+			"--lora-modules={\"name\":\"lora3\",\"path\":\"/path/to/lora3\"}",
+		},
+		expectedConfig: c,
+	}
+	tests = append(tests, test)
+
+	// Config from config.yaml file plus command line args with empty string
+	c = newConfig()
+	c.Port = 8002
+	c.Model = model
+	c.ServedModelNames = []string{c.Model}
+	c.MaxLoras = 2
+	c.MaxCPULoras = 5
+	c.MaxNumSeqs = 5
+	c.TimeToFirstToken = 2
+	c.InterTokenLatency = 1
+	c.LoraModules = []loraModule{{Name: "lora3", Path: "/path/to/lora3"}}
+	c.LoraModulesString = []string{
+		"{\"name\":\"lora3\",\"path\":\"/path/to/lora3\"}",
+	}
+	test = testCase{
+		name: "config file with command line args",
+		args: []string{"cmd", "--model", model, "--config", "../../manifests/config.yaml", "--port", "8002",
+			"--served-model-name", "",
+			"--lora-modules", "{\"name\":\"lora3\",\"path\":\"/path/to/lora3\"}",
+		},
 		expectedConfig: c,
 	}
 	tests = append(tests, test)
@@ -140,6 +198,8 @@ var _ = Describe("Simulator configuration", func() {
 		Entry(tests[0].name, tests[0].args, tests[0].expectedConfig),
 		Entry(tests[1].name, tests[1].args, tests[1].expectedConfig),
 		Entry(tests[2].name, tests[2].args, tests[2].expectedConfig),
+		Entry(tests[3].name, tests[3].args, tests[3].expectedConfig),
+		Entry(tests[4].name, tests[4].args, tests[4].expectedConfig),
 	)
 
 	DescribeTable("invalid configurations",
@@ -147,10 +207,10 @@ var _ = Describe("Simulator configuration", func() {
 			_, err := createSimConfig(args)
 			Expect(err).To(HaveOccurred())
 		},
-		Entry(tests[3].name, tests[3].args),
-		Entry(tests[4].name, tests[4].args),
 		Entry(tests[5].name, tests[5].args),
 		Entry(tests[6].name, tests[6].args),
 		Entry(tests[7].name, tests[7].args),
+		Entry(tests[8].name, tests[8].args),
+		Entry(tests[9].name, tests[9].args),
 	)
 })


### PR DESCRIPTION
This PR allows space separated command line arguments (served-model-name and lora-modules), and fixes the example config file format