### PR TITLE
fix: crash when omitted stream_options

### DIFF
--- a/pkg/llm-d-inference-sim/streaming.go
+++ b/pkg/llm-d-inference-sim/streaming.go
@@ -60,7 +60,7 @@ func (s *VllmSimulator) sendStreamingResponse(context *streamingContext, respons
 					s.sendTokenChunks(context, w, tc.Function.tokenizedArguments, &tc, finishReason)
 				}
 			} else {
-				s.logger.Info("Going to send text", "number of tokens", usageData.CompletionTokens)
+				s.logger.Info("Going to send text", "number of tokens", len(responseTokens))
 				s.sendTokenChunks(context, w, responseTokens, nil, finishReason)
 			}
 		}


### PR DESCRIPTION
Fixed a small crash when `stream_options` omitted from a streamed completion request.

Previously, if `stream_options` omitted:

```bash
curl -H 'Content-Type: application/json' \
     -X POST http://localhost:8000/v1/chat/completions \
     -d '{
           "model": "Qwen/Qwen2.5-1.5B-Instruct",
           "messages": [{"role": "user", "content": "Test"}],
           "max_tokens": 50,
           "stream": true
         }'

"chat completion request received"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x1050b0124]

goroutine 7 [running]:
github.com/llm-d/llm-d-inference-sim/pkg/llm-d-inference-sim.(*VllmSimulator).sendStreamingResponse.func1(0x1400045e280)
	/Users/jmadigan/Work/llm-d-inference-sim/pkg/llm-d-inference-sim/streaming.go:63 +0x184
github.com/valyala/fasthttp.NewStreamReader.func1()
	/Users/jmadigan/go/pkg/mod/github.com/valyala/fasthttp@v1.59.0/stream.go:44 +0x40
created by github.com/valyala/fasthttp.NewStreamReader in goroutine 44
	/Users/jmadigan/go/pkg/mod/github.com/valyala/fasthttp@v1.59.0/stream.go:43 +0x284
```

This worked, and continues to work:

```bash
curl -H 'Content-Type: application/json' \
     -X POST http://localhost:8000/v1/chat/completions \
     -d '{
           "model": "Qwen/Qwen2.5-1.5B-Instruct",
           "messages": [{"role": "user", "content": "Test"}],
           "max_tokens": 50,
           "stream": true,
            "stream_options": {"include_usage": true}
         }'

data: {"id":"chatcmpl-888e64d3-97d9-421f-9e6f-3b5586cf471e","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant","content":""}}]}

data: {"id":"chatcmpl-55e9a039-cde3-4219-bdf2-2d35a53f0821","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":null,"delta":{"content":"Testing"}}]}

data: {"id":"chatcmpl-a237f94a-9418-4105-a93b-fb1915856a70","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":null,"delta":{"content":", "}}]}

data: {"id":"chatcmpl-f74a327f-ddd7-4232-9ccd-b00f64ca65b9","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":null,"delta":{"content":"testing "}}]}

data: {"id":"chatcmpl-27c4780e-4c41-4634-8726-5222c4d1202f","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":null,"delta":{"content":"1"}}]}

data: {"id":"chatcmpl-d60c72b2-91b2-448b-a323-645447e5466f","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}]}

data: {"id":"chatcmpl-5bb22852-a68a-4674-a01b-89e694c76fd5","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":null,"delta":{"content":"2"}}]}

data: {"id":"chatcmpl-8e33540c-3588-4f03-a76f-c899569185ec","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":null,"delta":{"content":","}}]}

data: {"id":"chatcmpl-c1c2ae7b-e092-4c52-a383-eea807be53f2","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":null,"delta":{"content":"3"}}]}

data: {"id":"chatcmpl-4ee43956-1bcd-4697-bbe4-5ec320097b89","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":null,"delta":{"content":"."}}]}

data: {"id":"chatcmpl-fe6a2755-6a80-4a69-bb18-7a77143f2f75","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":null,"object":"chat.completion.chunk","choices":[{"index":0,"finish_reason":"stop","delta":{"content":""}}]}

data: {"id":"chatcmpl-a048b15a-00b1-457c-b74c-7a7daece57e8","created":1752572695,"model":"Qwen/Qwen2.5-1.5B-Instruct","usage":{"prompt_tokens":1,"completion_tokens":9,"total_tokens":10},"object":"chat.completion.chunk","choices":[]}

data: [DONE]
```

