### PR TITLE
feat: Add  new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,8 @@
+---
+name: Blank Issue
+about: Create a new issue from scratch
+title: ''
+labels: needs-triage
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Report a bug you encountered
+title: ''
+labels: kind/bug, needs-triage
+assignees: ''
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Kubernetes version (use `kubectl version`):
+- llm-d-inference-sim version (use `git describe --tags --dirty --always` if you built from source, or specify the tag if you used a tagged version or image):
+- Cloud provider or hardware configuration:
+- Install tools:
+- Others:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: needs-triage
+assignees: ''
+
+---
+
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -1,0 +1,140 @@
+---
+name: New Release
+about: Propose a new release
+title: Release v0.x.0
+labels: ''
+assignees: ''
+
+---
+
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Release Process](#release-process)
+- [Announce the Release](#announce-the-release)
+- [Final Steps](#final-steps)
+
+## Introduction
+
+This document defines the process for releasing llm-d-inference-sim.
+
+## Prerequisites
+
+1. Permissions to push to the llm-d-inference-sim repository.
+
+2. Set the required environment variables based on the expected release number:
+
+   ```shell
+   export MAJOR=0
+   export MINOR=1
+   export PATCH=0
+   export REMOTE=origin
+   ```
+
+3. If creating a release candidate, set the release candidate number.
+
+   ```shell
+   export RC=1
+   ```
+
+## Release Process
+
+1. If needed, clone the llm-d-inference-sim [repo].
+
+   ```shell
+   git clone -o ${REMOTE} git@github.com:llm-d/llm-d-inference-sim.git
+   ```
+
+2. If you already have the repo cloned, ensure it’s up-to-date and your local branch is clean.
+
+3. Release Branch Handling:
+   - For a Release Candidate:
+     Create a new release branch from the `main` branch. The branch should be named `release-${MAJOR}.${MINOR}`, for example, `release-0.1`:
+
+     ```shell
+     git checkout -b release-${MAJOR}.${MINOR}
+     ```
+
+   - For a Major, Minor or Patch Release:
+     A release branch should already exist. In this case, check out the existing branch:
+
+     ```shell
+     git checkout -b release-${MAJOR}.${MINOR} ${REMOTE}/release-${MAJOR}.${MINOR}
+     ```
+
+4. Update release-specific content, generate release artifacts, and stage the changes.
+
+5. Sign, commit, and push the changes to the `llm-d-inference-sim` repo.
+
+   For a release candidate:
+
+    ```shell
+    git commit -s -m "Updates artifacts for v${MAJOR}.${MINOR}.${PATCH}-rc.${RC} release"
+    ```
+
+   For a major, minor or patch release:
+
+    ```shell
+    git commit -s -m "Updates artifacts for v${MAJOR}.${MINOR}.${PATCH} release"
+    ```
+
+6. Push your release branch to the llm-d-inference-sim remote.
+
+    ```shell
+    git push ${REMOTE} release-${MAJOR}.${MINOR}
+    ```
+
+7. Tag the head of your release branch with the number.
+
+   For a release candidate:
+
+    ```shell
+    git tag -s -a v${MAJOR}.${MINOR}.${PATCH}-rc.${RC} -m 'llm-d-inference-sim v${MAJOR}.${MINOR}.${PATCH}-rc.${RC} Release Candidate'
+    ```
+
+   For a major, minor or patch release:
+
+    ```shell
+    git tag -s -a v${MAJOR}.${MINOR}.${PATCH} -m 'llm-d-inference-sim v${MAJOR}.${MINOR}.${PATCH} Release'
+    ```
+
+8. Push the tag to the llm-d-inference-sim repo.
+
+   For a release candidate:
+
+    ```shell
+    git push ${REMOTE} v${MAJOR}.${MINOR}.${PATCH}-rc.${RC}
+    ```
+
+   For a major, minor or patch release:
+
+    ```shell
+    git push ${REMOTE} v${MAJOR}.${MINOR}.${PATCH}
+    ```
+
+9. Pushing the tag triggers CI action to build and publish the container image to the [ghcr registry].
+10. Test the steps in the tagged quickstart guide after the PR merges. TODO add e2e tests! <!-- link to an e2e tests once we have such one -->
+11. Create a [new release]:
+    1. Choose the tag that you created for the release.
+    2. Use the tag as the release title, i.e. `v0.1.0` refer to previous release for the content of the release body.
+    3. Click "Generate release notes" and preview the release body.
+    4. If this is a release candidate, select the "This is a pre-release" checkbox.
+12. If you find any bugs in this process, create an [issue].
+
+## Announce the Release
+
+Use the following steps to announce the release.
+
+1. Send an announcement email to `llm-d-contributors@googlegroups.com` with the subject:
+
+   ```shell
+   [ANNOUNCE] llm-d-inference-sim v${MAJOR}.${MINOR}.${PATCH} is released
+   ```
+
+2. Add a link to the final release in this issue.
+
+3. Close this issue.
+
+[repo]: https://github.com/llm-d/llm-d-inference-sim
+[ghcr registry]: https://github.com/llm-d/llm-d-inference-sim/pkgs/container/llm-d-inference-sim
+[new release]: https://github.com/llm-d/llm-d-inference-sim/releases/new
+[issue]: https://github.com/llm-d/llm-d-inference-sim/issues/new/choose


### PR DESCRIPTION
This PR adds new issue templates that are similar to those in llm-d-inference-scheduler in an attempt at conformity with llm-d.

fix: #113 