### PR TITLE
Fix linter errors and settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,8 @@ linters:
   - prealloc
   - unparam
   - unused
-  settings:
+
+linters-settings:
     revive:
       rules:
         - name: dot-imports

--- a/pkg/common/test_helpers.go
+++ b/pkg/common/test_helpers.go
@@ -40,7 +40,7 @@ func IsValidText(text string) bool {
 					// during generation sentences are connected by space, skip it
 					// additional space at the end of the string is invalid
 					if text[charsTested] == ' ' && charsTested < len(text)-1 {
-						charsTested += 1
+						charsTested++
 						found = true
 					}
 					break

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -200,11 +200,11 @@ func InitRandom(seed int64) {
 	uuid.SetRand(randomGenerator)
 }
 
-// Returns an integer between min and max (included)
-func RandomInt(min int, max int) int {
+// RandomInt returns an integer between minVal and maxVal (included)
+func RandomInt(minVal int, maxVal int) int {
 	randMutex.Lock()
 	defer randMutex.Unlock()
-	return randomGenerator.Intn(max-min+1) + min
+	return randomGenerator.Intn(maxVal-minVal+1) + minVal
 }
 
 // Returns true or false randomly
@@ -219,11 +219,11 @@ func RandomBool(probability int) bool {
 	return randomGenerator.Float64() < float64(probability)/100
 }
 
-// Returns a random float64 in the range [min, max)
-func RandomFloat(min float64, max float64) float64 {
+// RandomFloat returns a random float64 in the range [minVal, maxVal)
+func RandomFloat(minVal float64, maxVal float64) float64 {
 	randMutex.Lock()
 	defer randMutex.Unlock()
-	return randomGenerator.Float64()*(max-min) + min
+	return randomGenerator.Float64()*(maxVal-minVal) + minVal
 }
 
 // Returns a normally distributed float64

--- a/pkg/kv-cache/kv_cache.go
+++ b/pkg/kv-cache/kv_cache.go
@@ -27,14 +27,14 @@ import (
 	"github.com/llm-d/llm-d-kv-cache-manager/pkg/tokenization"
 )
 
-type KVCacheHelper struct {
+type Helper struct {
 	tokenizer       tokenization.Tokenizer
 	tokensProcessor kvblock.TokenProcessor // turns tokens to kv block keys
 	logger          logr.Logger
 	blockCache      *blockCache
 }
 
-func NewKVCacheHelper(config *common.Configuration, logger logr.Logger) (*KVCacheHelper, error) {
+func NewKVCacheHelper(config *common.Configuration, logger logr.Logger) (*Helper, error) {
 	tokenProcConfig := kvblock.DefaultTokenProcessorConfig()
 	tokenProcConfig.BlockSize = config.TokenBlockSize
 	if config.HashSeed != "" {
@@ -54,7 +54,7 @@ func NewKVCacheHelper(config *common.Configuration, logger logr.Logger) (*KVCach
 	if err != nil {
 		return nil, fmt.Errorf("failed to create block cache: %w", err)
 	}
-	return &KVCacheHelper{
+	return &Helper{
 		tokenizer:       tokenizer,
 		tokensProcessor: tokensProcessor,
 		blockCache:      blockCache,
@@ -63,11 +63,11 @@ func NewKVCacheHelper(config *common.Configuration, logger logr.Logger) (*KVCach
 }
 
 // Run starts the helper.
-func (h *KVCacheHelper) Run(ctx context.Context) {
+func (h *Helper) Run(ctx context.Context) {
 	h.blockCache.start(ctx)
 }
 
-func (h *KVCacheHelper) OnRequestStart(vllmReq openaiserverapi.CompletionRequest) error {
+func (h *Helper) OnRequestStart(vllmReq openaiserverapi.CompletionRequest) error {
 	h.logger.Info("KV cache - process request")
 
 	prompt := vllmReq.GetPrompt()
@@ -93,6 +93,6 @@ func (h *KVCacheHelper) OnRequestStart(vllmReq openaiserverapi.CompletionRequest
 	return h.blockCache.startRequest(requestID, blockHashes)
 }
 
-func (h *KVCacheHelper) OnRequestEnd(vllmReq openaiserverapi.CompletionRequest) error {
+func (h *Helper) OnRequestEnd(vllmReq openaiserverapi.CompletionRequest) error {
 	return h.blockCache.finishRequest(vllmReq.GetRequestID())
 }

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -83,7 +83,7 @@ type VllmSimulator struct {
 	// schema validator for tools parameters
 	toolsValidator *openaiserverapi.Validator
 	// kv cache functionality
-	kvcacheHelper *kvcache.KVCacheHelper
+	kvcacheHelper *kvcache.Helper
 	// namespace where simulator is running
 	namespace string
 	// pod name of simulator
@@ -211,12 +211,12 @@ func (s *VllmSimulator) readRequest(ctx *fasthttp.RequestCtx, isChatCompletion b
 		}
 
 		for _, tool := range req.Tools {
-			toolJson, err := json.Marshal(tool.Function)
+			toolJSON, err := json.Marshal(tool.Function)
 			if err != nil {
 				s.logger.Error(err, "failed to marshal request tools")
 				return nil, err
 			}
-			err = s.toolsValidator.ValidateTool(toolJson)
+			err = s.toolsValidator.ValidateTool(toolJSON)
 			if err != nil {
 				s.logger.Error(err, "tool validation failed")
 				return nil, err
@@ -556,8 +556,8 @@ func (s *VllmSimulator) createCompletionResponse(isChatCompletion bool, respToke
 		baseResp.DoRemoteDecode = true
 		baseResp.DoRemotePrefill = false
 		// currently remote prefill information is hard-coded
-		baseResp.RemoteBlockIds = []string{"DUMMY_ID"}
-		baseResp.RemoteEngineId = "DUMMY_ID"
+		baseResp.RemoteBlockIDs = []string{"DUMMY_ID"}
+		baseResp.RemoteEngineID = "DUMMY_ID"
 		baseResp.RemoteHost = "DUMMY"
 		baseResp.RemotePort = 1234
 	}

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -73,10 +73,10 @@ type baseCompletionRequest struct {
 	DoRemoteDecode bool `json:"do_remote_decode"`
 	// DoRemotePrefill boolean value, true when request's prefill was done on remote pod
 	DoRemotePrefill bool `json:"do_remote_prefill"`
-	// RemoteBlockIds is a list of block identifiers to process remotely for distributed decoding
-	RemoteBlockIds []string `json:"remote_block_ids"`
-	// RemoteEngineId is an identifier of the remote inference engine or backend to use for processing requests
-	RemoteEngineId string `json:"remote_engine_id"`
+	// RemoteBlockIDs is a list of block identifiers to process remotely for distributed decoding
+	RemoteBlockIDs []string `json:"remote_block_ids"`
+	// RemoteEngineID is an identifier of the remote inference engine or backend to use for processing requests
+	RemoteEngineID string `json:"remote_engine_id"`
 	// RemoteHost is a hostname or IP address of the remote server handling prefill
 	RemoteHost string `json:"remote_host"`
 	// RemotePort is a port of the remote server handling prefill
@@ -197,10 +197,10 @@ func (c *ChatCompletionRequest) GetMaxCompletionTokens() *int64 {
 
 // getLastUserMsg returns last message from this request's messages with user role,
 // if does not exist - returns an empty string
-func (req *ChatCompletionRequest) getLastUserMsg() string {
-	for i := len(req.Messages) - 1; i >= 0; i-- {
-		if req.Messages[i].Role == RoleUser {
-			return req.Messages[i].Content.PlainText()
+func (c *ChatCompletionRequest) getLastUserMsg() string {
+	for i := len(c.Messages) - 1; i >= 0; i-- {
+		if c.Messages[i].Role == RoleUser {
+			return c.Messages[i].Content.PlainText()
 		}
 	}
 
@@ -210,15 +210,15 @@ func (req *ChatCompletionRequest) getLastUserMsg() string {
 // CreateResponseText creates and returns response payload based on this request,
 // i.e., an array of generated tokens, the finish reason, and the number of created
 // tokens
-func (req ChatCompletionRequest) CreateResponseText(mode string) ([]string, string, int, error) {
-	maxTokens, err := common.GetMaxTokens(req.MaxCompletionTokens, req.MaxTokens)
+func (c ChatCompletionRequest) CreateResponseText(mode string) ([]string, string, int, error) {
+	maxTokens, err := common.GetMaxTokens(c.MaxCompletionTokens, c.MaxTokens)
 	if err != nil {
 		return nil, "", 0, err
 	}
 
 	var text, finishReason string
 	if mode == common.ModeEcho {
-		text, finishReason = common.GetResponseText(maxTokens, req.getLastUserMsg())
+		text, finishReason = common.GetResponseText(maxTokens, c.getLastUserMsg())
 	} else {
 		text, finishReason = common.GetRandomResponseText(maxTokens)
 	}
@@ -250,30 +250,30 @@ func (t *TextCompletionRequest) GetNumberOfPromptTokens() int {
 	return len(common.Tokenize(t.GetPrompt()))
 }
 
-func (c *TextCompletionRequest) GetTools() []Tool {
+func (t *TextCompletionRequest) GetTools() []Tool {
 	return nil
 }
 
-func (c *TextCompletionRequest) GetToolChoice() string {
+func (t *TextCompletionRequest) GetToolChoice() string {
 	return ""
 }
 
-func (c *TextCompletionRequest) GetMaxCompletionTokens() *int64 {
-	return c.MaxTokens
+func (t *TextCompletionRequest) GetMaxCompletionTokens() *int64 {
+	return t.MaxTokens
 }
 
 // CreateResponseText creates and returns response payload based on this request,
 // i.e., an array of generated tokens, the finish reason, and the number of created
 // tokens
-func (req TextCompletionRequest) CreateResponseText(mode string) ([]string, string, int, error) {
-	maxTokens, err := common.GetMaxTokens(nil, req.MaxTokens)
+func (t TextCompletionRequest) CreateResponseText(mode string) ([]string, string, int, error) {
+	maxTokens, err := common.GetMaxTokens(nil, t.MaxTokens)
 	if err != nil {
 		return nil, "", 0, err
 	}
 
 	var text, finishReason string
 	if mode == common.ModeEcho {
-		text, finishReason = common.GetResponseText(maxTokens, req.Prompt)
+		text, finishReason = common.GetResponseText(maxTokens, t.Prompt)
 	} else {
 		text, finishReason = common.GetRandomResponseText(maxTokens)
 	}

--- a/pkg/openai-server-api/response.go
+++ b/pkg/openai-server-api/response.go
@@ -42,10 +42,10 @@ type BaseCompletionResponse struct {
 	DoRemoteDecode bool `json:"do_remote_decode"`
 	// DoRemotePrefill boolean value, true when request's prefill was done on remote pod
 	DoRemotePrefill bool `json:"do_remote_prefill"`
-	// RemoteBlockIds is a list of block identifiers to process remotely for distributed decoding
-	RemoteBlockIds []string `json:"remote_block_ids"`
-	// RemoteEngineId is an identifier of the remote inference engine or backend to use for processing requests
-	RemoteEngineId string `json:"remote_engine_id"`
+	// RemoteBlockIDs is a list of block identifiers to process remotely for distributed decoding
+	RemoteBlockIDs []string `json:"remote_block_ids"`
+	// RemoteEngineID is an identifier of the remote inference engine or backend to use for processing requests
+	RemoteEngineID string `json:"remote_engine_id"`
 	// RemoteHost is a hostname or IP address of the remote server handling prefill
 	RemoteHost string `json:"remote_host"`
 	// RemotePort is a port of the remote server handling prefill
@@ -100,7 +100,7 @@ type ContentBlock struct {
 }
 
 type ImageBlock struct {
-	Url string `json:"url,omitempty"`
+	URL string `json:"url,omitempty"`
 }
 
 // UnmarshalJSON allow use both format

--- a/pkg/openai-server-api/tools_utils.go
+++ b/pkg/openai-server-api/tools_utils.go
@@ -60,11 +60,11 @@ func CreateToolCalls(tools []Tool, toolChoice string, config *common.Configurati
 	// In case of 'required' at least one tool call has to be created, and we randomly choose
 	// the number of calls starting from one. Otherwise, we start from 0, and in case we randomly
 	// choose the number of calls to be 0, response text will be generated instead of a tool call.
-	min := 0
+	minVal := 0
 	if toolChoice == ToolChoiceRequired {
-		min = 1
+		minVal = 1
 	}
-	numberOfCalls := common.RandomInt(min, len(tools))
+	numberOfCalls := common.RandomInt(minVal, len(tools))
 	if numberOfCalls == 0 {
 		return nil, "", 0, nil
 	}
@@ -77,15 +77,15 @@ func CreateToolCalls(tools []Tool, toolChoice string, config *common.Configurati
 		if err != nil {
 			return nil, "", 0, err
 		}
-		argsJson, err := json.Marshal(args)
+		argsJSON, err := json.Marshal(args)
 		if err != nil {
 			return nil, "", 0, err
 		}
 
 		call := ToolCall{
 			Function: FunctionCall{
-				Arguments:          string(argsJson),
-				TokenizedArguments: common.Tokenize(string(argsJson)),
+				Arguments:          string(argsJSON),
+				TokenizedArguments: common.Tokenize(string(argsJSON)),
 				Name:               &tools[index].Function.Name,
 			},
 			ID:    "chatcmpl-tool-" + common.RandomNumericString(10),


### PR DESCRIPTION
Let me know if there are any changes we want to revent/rules we want to disable

On main:
```
llm-d-inference-sim on  main  
❯ make lint
==== Running linting ====
golangci-lint run
pkg/common/test_helpers.go:43:7: increment-decrement: should replace charsTested += 1 with charsTested++ (revive)
                                                charsTested += 1
                                                ^
pkg/common/utils.go:204:16: redefines-builtin-id: redefinition of the built-in function min (revive)
func RandomInt(min int, max int) int {
               ^
pkg/common/utils.go:223:18: redefines-builtin-id: redefinition of the built-in function min (revive)
func RandomFloat(min float64, max float64) float64 {
                 ^
pkg/common/utils_test.go:23:2: dot-imports: should not use dot imports (revive)
        . "github.com/onsi/ginkgo/v2"
        ^
pkg/common/utils_test.go:24:2: dot-imports: should not use dot imports (revive)
        . "github.com/onsi/gomega"
        ^
pkg/common/common_suite_test.go:6:2: dot-imports: should not use dot imports (revive)
        . "github.com/onsi/ginkgo/v2"
        ^
pkg/kv-cache/block_cache.go:75:1: receiver-naming: receiver name bc should be consistent with previous receiver name b for blockCache (revive)
func (bc *blockCache) startRequest(requestID string, blocks []uint64) error {
        bc.mu.Lock()
        defer bc.mu.Unlock()

        if _, exists := bc.requestToBlocks[requestID]; exists {
                // request with the same id already exists
                return fmt.Errorf("request already exists for id %s", requestID)
        }

        // divide list of blocks to three lists:
        // blockAreadyInUse - blocks, which are already used by currently running request
        // blockToMoveToUsed - blocks, which were used in past
        // blocksToAdd - new blocks
        blocksToAdd := make([]uint64, 0)
        blockToMoveToUsed := make([]uint64, 0)
        blockAreadyInUse := make([]uint64, 0)

        // first step - ensure that there is enough space for all blocks
        // count number of new blocks + number of blocks that are in the unused blocks
        // don't update the data until we are sure that it's ok
        for _, blockHash := range blocks {
                if _, exists := bc.unusedBlocks[blockHash]; exists {
                        blockToMoveToUsed = append(blockToMoveToUsed, blockHash)
                } else if _, exists := bc.usedBlocks[blockHash]; !exists {
                        blocksToAdd = append(blocksToAdd, blockHash)
                } else {
                        blockAreadyInUse = append(blockAreadyInUse, blockHash)
                }
        }

        if len(bc.usedBlocks)+len(blocksToAdd)+len(blockToMoveToUsed) > bc.maxBlocks {
                return errors.New(capacityError)
        }

        // for blocks that are already in use - update the reference
        for _, block := range blockAreadyInUse {
                bc.usedBlocks[block] += 1
        }

        // for block used in the past - move them to the used blocks collection
        for _, block := range blockToMoveToUsed {
                bc.usedBlocks[block] = 1
                delete(bc.unusedBlocks, block)
        }

        // for new block - add them, if there is no empty slots - evict the oldest block
        for _, block := range blocksToAdd {
                if len(bc.usedBlocks)+len(bc.unusedBlocks) == bc.maxBlocks {
                        // cache is full but contains unused blocks - evict the oldest
                        var oldestUnusedHash uint64
                        oldestUnusedTime := time.Now()

                        for hash, t := range bc.unusedBlocks {
                                if t.Before(oldestUnusedTime) {
                                        oldestUnusedHash = hash
                                        oldestUnusedTime = t
                                }
                        }

                        delete(bc.unusedBlocks, oldestUnusedHash)
                        bc.eventChan <- EventData{action: eventActionRemove, hashValues: []uint64{oldestUnusedHash}}
                }

                // Add the new block
                bc.usedBlocks[block] = 1
                bc.eventChan <- EventData{action: eventActionStore, hashValues: []uint64{block}}
        }

        // store the request mapping
        bc.requestToBlocks[requestID] = make([]uint64, len(blocks))
        copy(bc.requestToBlocks[requestID], blocks)

        return nil
}
pkg/kv-cache/block_cache.go:151:1: receiver-naming: receiver name bc should be consistent with previous receiver name b for blockCache (revive)
func (bc *blockCache) finishRequest(requestID string) error {
        bc.mu.Lock()
        defer bc.mu.Unlock()

        // Get blocks associated with this request
        blockHashes, exists := bc.requestToBlocks[requestID]
        if !exists {
                return errors.New("request not found")
        }

        now := time.Now()

        // Decrease reference count for each block
        errBlocks := make([]uint64, 0)
        for _, blockHash := range blockHashes {
                if refCount, exists := bc.usedBlocks[blockHash]; exists {
                        if refCount > 1 {
                                // this block is in use by another request, just update reference count
                                bc.usedBlocks[blockHash] = refCount - 1
                        } else {
                                // this was the last block usage - move this block to unused
                                bc.unusedBlocks[blockHash] = now
                                delete(bc.usedBlocks, blockHash)
                        }
                } else {
                        errBlocks = append(errBlocks, blockHash)
                }
        }

        // Remove the request mapping
        delete(bc.requestToBlocks, requestID)

        if len(errBlocks) > 0 {
                errMsg := "Not existing blocks "
                for _, b := range errBlocks {
                        errMsg += fmt.Sprintf("%d, ", b)
                }
                return fmt.Errorf("%s for request %s", errMsg[:len(errMsg)-2], requestID)
        }

        return nil
}
pkg/kv-cache/block_cache.go:195:1: receiver-naming: receiver name bc should be consistent with previous receiver name b for blockCache (revive)
func (bc *blockCache) getStats() (int, int, int) {
        bc.mu.RLock()
        defer bc.mu.RUnlock()

        return len(bc.requestToBlocks), len(bc.usedBlocks) + len(bc.unusedBlocks), len(bc.unusedBlocks)
}
pkg/kv-cache/kv_cache.go:30:6: exported: type name will be used as kvcache.KVCacheHelper by other packages, and that stutters; consider calling this Helper (revive)
type KVCacheHelper struct {
     ^
pkg/kv-cache/block_cache.go:111:3: increment-decrement: should replace bc.usedBlocks[block] += 1 with bc.usedBlocks[block]++ (revive)
                bc.usedBlocks[block] += 1
                ^
pkg/llm-d-inference-sim/tools_test.go:820:25: unused-parameter: parameter 'numberOfParams' seems to be unused, consider removing or renaming it as _ (revive)
                func(probability int, numberOfParams int) string {
                                      ^
pkg/llm-d-inference-sim/tools_test.go:877:25: unused-parameter: parameter 'numberOfParams' seems to be unused, consider removing or renaming it as _ (revive)
                func(probability int, numberOfParams int, min int, max int) string {
                                      ^
pkg/llm-d-inference-sim/tools_test.go:520:51: redefines-builtin-id: redefinition of the built-in function min (revive)
                func(mode string, minLength int, maxLength int, min float64, max float64) {
                                                                ^
pkg/llm-d-inference-sim/simulator.go:214:4: var-naming: var toolJson should be toolJSON (revive)
                        toolJson, err := json.Marshal(tool.Function)
                        ^
pkg/openai-server-api/tools_utils.go:80:3: var-naming: var argsJson should be argsJSON (revive)
                argsJson, err := json.Marshal(args)
                ^
pkg/openai-server-api/response.go:46:2: var-naming: struct field RemoteBlockIds should be RemoteBlockIDs (revive)
        RemoteBlockIds []string `json:"remote_block_ids"`
        ^
pkg/openai-server-api/response.go:48:2: var-naming: struct field RemoteEngineId should be RemoteEngineID (revive)
        RemoteEngineId string `json:"remote_engine_id"`
        ^
pkg/openai-server-api/response.go:103:2: var-naming: struct field Url should be URL (revive)
        Url string `json:"url,omitempty"`
        ^
pkg/openai-server-api/request.go:200:1: receiver-naming: receiver name req should be consistent with previous receiver name c for ChatCompletionRequest (revive)
func (req *ChatCompletionRequest) getLastUserMsg() string {
        for i := len(req.Messages) - 1; i >= 0; i-- {
                if req.Messages[i].Role == RoleUser {
                        return req.Messages[i].Content.PlainText()
                }
        }

        return ""
}
pkg/openai-server-api/request.go:213:1: receiver-naming: receiver name req should be consistent with previous receiver name c for ChatCompletionRequest (revive)
func (req ChatCompletionRequest) CreateResponseText(mode string) ([]string, string, int, error) {
        maxTokens, err := common.GetMaxTokens(req.MaxCompletionTokens, req.MaxTokens)
        if err != nil {
                return nil, "", 0, err
        }

        var text, finishReason string
        if mode == common.ModeEcho {
                text, finishReason = common.GetResponseText(maxTokens, req.getLastUserMsg())
        } else {
                text, finishReason = common.GetRandomResponseText(maxTokens)
        }

        tokens := common.Tokenize(text)
        return tokens, finishReason, len(tokens), nil
}
pkg/openai-server-api/request.go:253:1: receiver-naming: receiver name c should be consistent with previous receiver name t for TextCompletionRequest (revive)
func (c *TextCompletionRequest) GetTools() []Tool {
        return nil
}
pkg/openai-server-api/request.go:257:1: receiver-naming: receiver name c should be consistent with previous receiver name t for TextCompletionRequest (revive)
func (c *TextCompletionRequest) GetToolChoice() string {
        return ""
}
pkg/openai-server-api/request.go:261:1: receiver-naming: receiver name c should be consistent with previous receiver name t for TextCompletionRequest (revive)
func (c *TextCompletionRequest) GetMaxCompletionTokens() *int64 {
        return c.MaxTokens
}
pkg/openai-server-api/request.go:268:1: receiver-naming: receiver name req should be consistent with previous receiver name t for TextCompletionRequest (revive)
func (req TextCompletionRequest) CreateResponseText(mode string) ([]string, string, int, error) {
        maxTokens, err := common.GetMaxTokens(nil, req.MaxTokens)
        if err != nil {
                return nil, "", 0, err
        }

        var text, finishReason string
        if mode == common.ModeEcho {
                text, finishReason = common.GetResponseText(maxTokens, req.Prompt)
        } else {
                text, finishReason = common.GetRandomResponseText(maxTokens)
        }

        tokens := common.Tokenize(text)
        return tokens, finishReason, len(tokens), nil
}
pkg/openai-server-api/request.go:77:2: var-naming: struct field RemoteBlockIds should be RemoteBlockIDs (revive)
        RemoteBlockIds []string `json:"remote_block_ids"`
        ^
pkg/openai-server-api/request.go:79:2: var-naming: struct field RemoteEngineId should be RemoteEngineID (revive)
        RemoteEngineId string `json:"remote_engine_id"`
        ^
make: *** [Makefile:90: lint] Error 1
```

Now:
```
❯ make lint
==== Running linting ====
golangci-lint run

```