### PR TITLE
Remvoe unnecessary deferal of server close

### DIFF
--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -183,12 +183,6 @@ func (s *VllmSimulator) startServer(ctx context.Context, listener net.Listener) 
 		Logger:       s,
 	}
 
-	defer func() {
-		if err := listener.Close(); err != nil {
-			s.logger.Error(err, "server listener close failed")
-		}
-	}()
-
 	// Start server in a goroutine
 	serverErr := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
The last line is produced by the unnecessary code
```I0824 07:06:34.167190   85035 simulator.go:160] "Server starting" port=8000
I0824 07:06:34.181777   85035 simulator.go:201] "HTTP server starting"
I0824 07:06:40.699245   85035 simulator.go:396] "reqProcessingWorker stopped:" worker id=2
I0824 07:06:40.699368   85035 simulator.go:208] "Shutdown signal received, shutting down HTTP server gracefully"
I0824 07:06:40.701089   85035 simulator.go:396] "reqProcessingWorker stopped:" worker id=5
I0824 07:06:40.699663   85035 simulator.go:396] "reqProcessingWorker stopped:" worker id=3
I0824 07:06:40.699605   85035 simulator.go:396] "reqProcessingWorker stopped:" worker id=1
I0824 07:06:40.699596   85035 simulator.go:396] "reqProcessingWorker stopped:" worker id=4
I0824 07:06:40.705896   85035 simulator.go:216] "HTTP server stopped"
E0824 07:06:40.708202   85035 simulator.go:194] "server listener close failed" err="close tcp4 0.0.0.0:8000: use of closed network connection"