### PR TITLE
Rand generator is not set in a test suite which result in accessing nil pointer during runtime if run the only test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,11 @@ format: ## Format Go source files
 .PHONY: test
 test: check-ginkgo download-tokenizer download-zmq ## Run tests
 	@printf "\033[33;1m==== Running tests ====\033[0m\n"
+ifdef GINKGO_FOCUS
+	CGO_ENABLED=1 ginkgo -ldflags="$(GO_LDFLAGS)" -v -r --focus="$(GINKGO_FOCUS)"
+else
 	CGO_ENABLED=1 ginkgo -ldflags="$(GO_LDFLAGS)" -v -r
+endif
 
 .PHONY: post-deploy-test
 post-deploy-test: ## Run post deployment tests

--- a/pkg/llm-d-inference-sim/simulator_test.go
+++ b/pkg/llm-d-inference-sim/simulator_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	. "github.com/onsi/ginkgo/v2"
@@ -754,6 +755,8 @@ var _ = Describe("Simulator", func() {
 				KVCacheTransferLatency:       2048,
 				KVCacheTransferLatencyStdDev: 2048,
 			}
+
+			common.InitRandom(time.Now().UnixNano())
 		})
 
 		DescribeTable("should calculate inter token latency correctly",


### PR DESCRIPTION
Reproduce: `CGO_ENABLED=1 ginkgo -ldflags="-extldflags '-L/workspaces/llm-d-inference-sim/lib'" -v -r -- -ginkgo.focus="Check random latencies"`

<details>
<summary> click to see</summary>

```
Running Suite: VllmSim Suite - /workspaces/llm-d-inference-sim/pkg/llm-d-inference-sim
======================================================================================
Random Seed: 1756093008

Will run 14 of 97 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Simulator Check random latencies should calculate inter token latency correctly interTokenLatency: 1000 stddev: 300
/workspaces/llm-d-inference-sim/pkg/llm-d-inference-sim/simulator_test.go:770
  [PANICKED] in [It] - /usr/lib/golang/src/runtime/panic.go:262 @ 08/25/25 03:36:54.26
• [PANICKED] [0.003 seconds]
Simulator Check random latencies should calculate inter token latency correctly [It] interTokenLatency: 1000 stddev: 300
/workspaces/llm-d-inference-sim/pkg/llm-d-inference-sim/simulator_test.go:770

  [PANICKED] Test Panicked
  In [It] at: /usr/lib/golang/src/runtime/panic.go:262 @ 08/25/25 03:36:54.26

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    math/rand.(*Rand).Int63(...)
    	/usr/lib/golang/src/math/rand/rand.go:96
    math/rand.(*Rand).Uint32(...)
    	/usr/lib/golang/src/math/rand/rand.go:99
    math/rand.(*Rand).NormFloat64(0x0)
    	/usr/lib/golang/src/math/rand/normal.go:39 +0x24
    github.com/llm-d/llm-d-inference-sim/pkg/common.RandomNorm(0x408f400000000000, 0x4072c00000000000)
    	/workspaces/llm-d-inference-sim/pkg/common/utils.go:238 +0xdc
    github.com/llm-d/llm-d-inference-sim/pkg/llm-d-inference-sim.(*VllmSimulator).getInterTokenLatency(...)
    	/workspaces/llm-d-inference-sim/pkg/llm-d-inference-sim/simulator.go:669
    github.com/llm-d/llm-d-inference-sim/pkg/llm-d-inference-sim.init.func3.18.2(0x0?, 0x0?)
    	/workspaces/llm-d-inference-sim/pkg/llm-d-inference-sim/simulator_test.go:763 +0x6c
    reflect.Value.call({0x1baf160?, 0x400051de40?, 0x13?}, {0x1e50f16, 0x4}, {0x4000848b10, 0x2, 0x2?})
    	/usr/lib/golang/src/reflect/value.go:584 +0x978
    reflect.Value.Call({0x1baf160?, 0x400051de40?, 0x2167d40?}, {0x4000848b10?, 0x0?, 0x0?})
    	/usr/lib/golang/src/reflect/value.go:368 +0x94
------------------------------
S [SKIPPED] [0.000 seconds]Running Suite: VllmSim Suite - /workspaces/llm-d-inference-sim/pkg/llm-d-inference-sim
======================================================================================
Random Seed: 1756093008

Will run 14 of 97 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Simulator Check random latencies should calculate inter token latency correctly interTokenLatency: 1000 stddev: 300
/workspaces/llm-d-inference-sim/pkg/llm-d-inference-sim/simulator_test.go:770
  [PANICKED] in [It] - /usr/lib/golang/src/runtime/panic.go:262 @ 08/25/25 03:36:54.26
• [PANICKED] [0.003 seconds]
Simulator Check random latencies should calculate inter token latency correctly [It] interTokenLatency: 1000 stddev: 300
/workspaces/llm-d-inference-sim/pkg/llm-d-inference-sim/simulator_test.go:770

  [PANICKED] Test Panicked
  In [It] at: /usr/lib/golang/src/runtime/panic.go:262 @ 08/25/25 03:36:54.26

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    math/rand.(*Rand).Int63(...)
    	/usr/lib/golang/src/math/rand/rand.go:96
    math/rand.(*Rand).Uint32(...)
    	/usr/lib/golang/src/math/rand/rand.go:99
    math/rand.(*Rand).NormFloat64(0x0)
    	/usr/lib/golang/src/math/rand/normal.go:39 +0x24
    github.com/llm-d/llm-d-inference-sim/pkg/common.RandomNorm(0x408f400000000000, 0x4072c00000000000)
    	/workspaces/llm-d-inference-sim/pkg/common/utils.go:238 +0xdc
    github.com/llm-d/llm-d-inference-sim/pkg/llm-d-inference-sim.(*VllmSimulator).getInterTokenLatency(...)
    	/workspaces/llm-d-inference-sim/pkg/llm-d-inference-sim/simulator.go:669
    github.com/llm-d/llm-d-inference-sim/pkg/llm-d-inference-sim.init.func3.18.2(0x0?, 0x0?)
    	/workspaces/llm-d-inference-sim/pkg/llm-d-inference-sim/simulator_test.go:763 +0x6c
    reflect.Value.call({0x1baf160?, 0x400051de40?, 0x13?}, {0x1e50f16, 0x4}, {0x4000848b10, 0x2, 0x2?})
    	/usr/lib/golang/src/reflect/value.go:584 +0x978
    reflect.Value.Call({0x1baf160?, 0x400051de40?, 0x2167d40?}, {0x4000848b10?, 0x0?, 0x0?})
    	/usr/lib/golang/src/reflect/value.go:368 +0x94
------------------------------
S [SKIPPED] [0.000 seconds]
```
</details>

Added make flat to run filtered cases: ` make test GINKGO_FOCUS="Check random latencies"`
