### PR TITLE
chore: Make the image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,9 @@ WORKDIR /
 USER root
 RUN microdnf install -y dnf && \
     dnf install -y 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm' && \
-    dnf install -y zeromq
+    dnf install -y zeromq && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf /var/lib/dnf
 
 COPY --from=builder /workspace/bin/llm-d-inference-sim /app/llm-d-inference-sim
 


### PR DESCRIPTION
This PR makes the llm-d-inferece-sim image smaller by deleting the dnf cache created in the build.

This saves some 60MB in the size of the image.

Copied from a PR made to the llm-d-inference-scheduler.