### PR TITLE
Test fix: number of running requests can be one request less when scheduling requests

### DIFF
--- a/pkg/llm-d-inference-sim/worker_test.go
+++ b/pkg/llm-d-inference-sim/worker_test.go
@@ -411,12 +411,14 @@ var _ = Describe("Simulator requests scheduling", Ordered, func() {
 
 			// We sent 2500 requests, after about 2.5 seconds
 			// number of running requests should be 1000
-			// and the number of waiting requests should be less than 1000
+			// and the number of waiting requests should be less than 1000.
+			// Since we are in the middle of requests scheduling,
+			// the number of running requests can be 999.
 			runningStr = findMetric(metrics, runningMetric)
 			Expect(runningStr).NotTo(Equal(""))
 			running, err = strconv.Atoi(runningStr)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(running).To(Equal(1000))
+			Expect(running).To(Or(Equal(1000), Equal(999)))
 			waitingStr = findMetric(metrics, waitingMetric)
 			waiting, err = strconv.Atoi(waitingStr)
 			Expect(err).NotTo(HaveOccurred())
@@ -431,13 +433,15 @@ var _ = Describe("Simulator requests scheduling", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			metrics = strings.Split(string(data), "\n")
 
-			// number of running requests should be 1000
-			// and the number of waiting requests should be less than 1000
+			// The number of running requests should be 1000
+			// and the number of waiting requests should be less than 1000.
+			// Since we are in the middle of requests scheduling,
+			// the number of running requests can be 999.
 			runningStr = findMetric(metrics, runningMetric)
 			Expect(runningStr).NotTo(Equal(""))
 			running, err = strconv.Atoi(runningStr)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(running).To(Equal(1000))
+			Expect(running).To(Or(Equal(1000), Equal(999)))
 			waitingStr = findMetric(metrics, waitingMetric)
 			waiting, err = strconv.Atoi(waitingStr)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The test sends a large number of requests simultaneously, max-num-seqs is 1000, time-to-first-token is 2000, std-dev 600.
The test checks number of running requests metric three times: 
1. Short time after the requests were sent, in this case we expect the number of running requests to be exactly 1000, since all the requests should be still running.
2. 2.5 seconds later, most of the first 1000 requests should be finished, but there can be some still finishing and being replaced by new requests. Therefore, the number of running requests can be either 1000 and 999, with one request finished but still not replaced.
3. After one more second, we can also expect 1000 or 999 running requests as in the second case.

Closes #228 