### PR TITLE
Configure the tool_choice option to use a specific tool

### DIFF
--- a/pkg/llm-d-inference-sim/worker.go
+++ b/pkg/llm-d-inference-sim/worker.go
@@ -88,7 +88,7 @@ func (s *VllmSimulator) processRequest(reqCtx *openaiserverapi.CompletionReqCtx)
 	var toolCalls []openaiserverapi.ToolCall
 	var completionTokens int
 	if reqCtx.IsChatCompletion &&
-		req.GetToolChoice() != common.ToolChoiceNone &&
+		!common.IsToolChoiceNone(req.GetToolChoice()) &&
 		req.GetTools() != nil {
 		toolCalls, completionTokens, err =
 			common.CreateToolCalls(req.GetTools(), req.GetToolChoice(), s.config)

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -46,10 +46,10 @@ type CompletionRequest interface {
 	SetNumberOfCachedPromptTokens(cachedPromptTokens int)
 	// GetPrompt returns the prompt
 	GetPrompt() string
-	// GetTools() returns tools to use (in chat completion)
+	// GetTools returns tools to use (in chat completion)
 	GetTools() []Tool
-	// GetToolChoice() returns tool choice (in chat completion)
-	GetToolChoice() string
+	// GetToolChoice returns tool choice (in chat completion)
+	GetToolChoice() ToolChoice
 	// GetMaxCompletionTokens returns the maximum completion tokens requested
 	GetMaxCompletionTokens() *int64
 	// GetIgnoreEOS returns true if the end-of-sequence tokens will be ignored
@@ -184,11 +184,12 @@ type ChatCompletionRequest struct {
 	// Tools is a list of tools the model may call.
 	Tools []Tool `json:"tools,omitempty"`
 
-	// ToolChoice controls which (if any) tool is called by the model,
-	// possible values: none, auto, required.
-	// Sending an object with a specific tool, is currently not supported.
-	ToolChoice string `json:"tool_choice,omitempty"`
+	// ToolChoice controls which (if any) tool is called by the model.
+	// It can be a string ("none", "auto", "required") or an object specifying the function.
+	ToolChoice ToolChoice `json:"tool_choice,omitzero"`
 }
+
+var _ CompletionRequest = (*ChatCompletionRequest)(nil)
 
 // function defines a tool
 type function struct {
@@ -221,7 +222,7 @@ func (c *ChatCompletionRequest) GetTools() []Tool {
 	return c.Tools
 }
 
-func (c *ChatCompletionRequest) GetToolChoice() string {
+func (c *ChatCompletionRequest) GetToolChoice() ToolChoice {
 	return c.ToolChoice
 }
 
@@ -286,6 +287,8 @@ type TextCompletionRequest struct {
 	MaxTokens *int64 `json:"max_tokens"`
 }
 
+var _ CompletionRequest = (*TextCompletionRequest)(nil)
+
 func (t *TextCompletionRequest) GetPrompt() string {
 	return t.Prompt
 }
@@ -294,8 +297,8 @@ func (c *TextCompletionRequest) GetTools() []Tool {
 	return nil
 }
 
-func (c *TextCompletionRequest) GetToolChoice() string {
-	return ""
+func (c *TextCompletionRequest) GetToolChoice() ToolChoice {
+	return ToolChoice{}
 }
 
 func (c *TextCompletionRequest) GetMaxCompletionTokens() *int64 {

--- a/pkg/openai-server-api/tool_choice.go
+++ b/pkg/openai-server-api/tool_choice.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openaiserverapi
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+)
+
+// ToolChoice is a wrapper around ChatCompletionToolChoiceOptionUnionParam that
+// provides custom JSON unmarshalling logic to correctly handle
+// the union type.
+type ToolChoice struct {
+	openai.ChatCompletionToolChoiceOptionUnionParam
+}
+
+// MarshalJSON forwards the marshalling process to the embedded
+// ChatCompletionToolChoiceOptionUnionParam's MarshalJSON method,
+// which is known to work correctly.
+func (t ToolChoice) MarshalJSON() ([]byte, error) {
+	return t.ChatCompletionToolChoiceOptionUnionParam.MarshalJSON()
+}
+
+// UnmarshalJSON provides custom logic to correctly deserialize the JSON data
+// into the appropriate field of the embedded union type. It inspects the JSON
+// structure to determine if it's a simple string or a complex object with a
+// 'type' discriminator field.
+func (t *ToolChoice) UnmarshalJSON(data []byte) error {
+	// If the input is a simple string (e.g., "auto", "none", "required"),
+	// unmarshal it into the OfAuto field.
+	if data[0] == '"' {
+		var strValue string
+		if err := json.Unmarshal(data, &strValue); err != nil {
+			return err
+		}
+		t.OfAuto = param.NewOpt(strValue)
+		return nil
+	}
+
+	// If the input is a JSON object, we need to determine its type.
+	// We use a temporary struct to detect the 'type' field.
+	var typeDetector struct {
+		Type string `json:"type"`
+	}
+
+	// We only care about the type field, ignore other fields
+	if err := json.Unmarshal(data, &typeDetector); err != nil {
+		return fmt.Errorf("failed to detect type for ToolChoice: %w", err)
+	}
+
+	// Based on the detected type, unmarshal the data into the correct struct.
+	switch typeDetector.Type {
+	case "function":
+		var functionChoice openai.ChatCompletionNamedToolChoiceParam
+		if err := functionChoice.UnmarshalJSON(data); err != nil {
+			return err
+		}
+		t.OfFunctionToolChoice = &functionChoice
+	case "custom":
+		var customChoice openai.ChatCompletionNamedToolChoiceCustomParam
+		if err := customChoice.UnmarshalJSON(data); err != nil {
+			return err
+		}
+		t.OfCustomToolChoice = &customChoice
+	case "allowed_tools":
+		var allowedToolsChoice openai.ChatCompletionAllowedToolChoiceParam
+		if err := allowedToolsChoice.UnmarshalJSON(data); err != nil {
+			return err
+		}
+		t.OfAllowedTools = &allowedToolsChoice
+	default:
+		return fmt.Errorf("unknown ToolChoice type: %s", typeDetector.Type)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request enhances the vLLM inference simulator by implementing full support for the `tool_choice` option, specifically adding the capability to force the model to use a specific tool. This update brings the simulator's functionality into closer alignment with the official OpenAI API, allowing for more precise and sophisticated testing of tool-use scenarios.

Limitations: Currently, this PR does not handle the case where the tool type is `custom`, nor does it address the `allowed_tools` option. Adding custom-type tools will require refactoring more fields. For OpenAI's documentation on these fields, refer to [tool-choice](https://platform.openai.com/docs/guides/function-calling#tool-choice).

Fixes #235