### PR TITLE
Changed random from static to a field in the simulator

### DIFF
--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -17,17 +17,11 @@ limitations under the License.
 package common
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Utils", Ordered, func() {
-	BeforeAll(func() {
-		InitRandom(time.Now().UnixNano())
-	})
-
 	Context("validateContextWindow", func() {
 		It("should pass when total tokens are within limit", func() {
 			promptTokens := 100

--- a/pkg/dataset/custom_dataset_test.go
+++ b/pkg/dataset/custom_dataset_test.go
@@ -46,10 +46,11 @@ var _ = Describe("CustomDataset", Ordered, func() {
 		pathToInvalidTableDB  string
 		pathToInvalidColumnDB string
 		pathToInvalidTypeDB   string
+		random                *common.Random
 	)
 
 	BeforeAll(func() {
-		common.InitRandom(time.Now().UnixNano())
+		random = common.NewRandom(time.Now().UnixNano())
 	})
 
 	BeforeEach(func() {
@@ -182,7 +183,7 @@ var _ = Describe("CustomDataset", Ordered, func() {
 		req := &openaiserverapi.TextCompletionRequest{
 			Prompt: testPrompt,
 		}
-		tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom)
+		tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom, random)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(finishReason).To(Equal(StopFinishReason))
 		Expect(tokens).To(Equal([]string{"Hello", " llm-d ", "world", "!"}))
@@ -196,7 +197,7 @@ var _ = Describe("CustomDataset", Ordered, func() {
 			Prompt:    testPrompt,
 			MaxTokens: &n,
 		}
-		tokens, _, err := dataset.GetTokens(req, common.ModeRandom)
+		tokens, _, err := dataset.GetTokens(req, common.ModeRandom, random)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(tokens)).To(BeNumerically("<=", 2))
 	})
@@ -208,7 +209,7 @@ var _ = Describe("CustomDataset", Ordered, func() {
 		req := &openaiserverapi.TextCompletionRequest{
 			Prompt: testPrompt,
 		}
-		tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom)
+		tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom, random)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(finishReason).To(Equal(StopFinishReason))
 		Expect(tokens).To(Equal([]string{"Hello", " llm-d ", "world", "!"}))

--- a/pkg/dataset/dataset_test.go
+++ b/pkg/dataset/dataset_test.go
@@ -30,10 +30,11 @@ import (
 var _ = Describe("Dataset", Ordered, func() {
 	var (
 		dataset *BaseDataset
+		random  *common.Random
 	)
 
 	BeforeAll(func() {
-		common.InitRandom(time.Now().UnixNano())
+		random = common.NewRandom(time.Now().UnixNano())
 	})
 
 	BeforeEach(func() {
@@ -44,7 +45,7 @@ var _ = Describe("Dataset", Ordered, func() {
 
 		It("should return complete text", func() {
 			req := &openaiserverapi.ChatCompletionRequest{}
-			tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom)
+			tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom, random)
 			Expect(err).ShouldNot(HaveOccurred())
 			text := strings.Join(tokens, "")
 			Expect(IsValidText(text)).To(BeTrue())
@@ -56,7 +57,7 @@ var _ = Describe("Dataset", Ordered, func() {
 			req := &openaiserverapi.ChatCompletionRequest{
 				MaxCompletionTokens: &maxCompletionTokens,
 			}
-			tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom)
+			tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom, random)
 			Expect(err).ShouldNot(HaveOccurred())
 			tokensCnt := int64(len(tokens))
 			Expect(tokensCnt).Should(BeNumerically("<=", maxCompletionTokens))
@@ -74,7 +75,7 @@ var _ = Describe("Dataset", Ordered, func() {
 			req := &openaiserverapi.ChatCompletionRequest{
 				MaxTokens: &maxCompletionTokens,
 			}
-			tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom)
+			tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom, random)
 			Expect(err).ShouldNot(HaveOccurred())
 			tokensCnt := int64(len(tokens))
 			Expect(tokensCnt).Should(BeNumerically("<=", maxCompletionTokens))
@@ -95,7 +96,7 @@ var _ = Describe("Dataset", Ordered, func() {
 					MaxTokens: &n,
 				}
 				req.SetIgnoreEOS(true)
-				tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom)
+				tokens, finishReason, err := dataset.GetTokens(req, common.ModeRandom, random)
 				Expect(err).ShouldNot(HaveOccurred())
 				nGenTokens := int64(len(tokens))
 				Expect(nGenTokens).Should(Equal(n))
@@ -140,7 +141,7 @@ var _ = Describe("Dataset", Ordered, func() {
 		for _, len := range lenArr {
 			name := fmt.Sprintf("should return text with %d tokens", len)
 			It(name, func() {
-				tokens := GenPresetRandomTokens(len)
+				tokens := GenPresetRandomTokens(random, len)
 				Expect(tokens).Should(HaveLen(len))
 			})
 		}

--- a/pkg/kv-cache/kv_cache_test.go
+++ b/pkg/kv-cache/kv_cache_test.go
@@ -121,7 +121,7 @@ type threadTestCase struct {
 }
 
 var _ = Describe("KV cache", Ordered, func() {
-	common.InitRandom(time.Now().UnixNano())
+	random := common.NewRandom(time.Now().UnixNano())
 
 	Context("general tests", func() {
 		// check single request processing, ensure cache is valid after request processing started
@@ -434,7 +434,8 @@ var _ = Describe("KV cache", Ordered, func() {
 
 						for j := range testCase.numOperations {
 							reqID := fmt.Sprintf("req_%d_%d", id, j)
-							blocks := createRandomArray(testCase.minBlockLen, testCase.maxBlockLen, testCase.maxHashValue)
+							blocks := createRandomArray(testCase.minBlockLen, testCase.maxBlockLen,
+								testCase.maxHashValue, random)
 
 							_, err := blockCache.startRequest(reqID, blocks)
 							if err != nil {
@@ -443,7 +444,7 @@ var _ = Describe("KV cache", Ordered, func() {
 								continue
 							}
 
-							time.Sleep(time.Duration(common.RandomInt(1, 100)) * time.Microsecond)
+							time.Sleep(time.Duration(random.RandomInt(1, 100)) * time.Microsecond)
 
 							err = blockCache.finishRequest(reqID)
 							Expect(err).NotTo(HaveOccurred())
@@ -465,16 +466,16 @@ var _ = Describe("KV cache", Ordered, func() {
 	})
 })
 
-func createRandomArray(minArrLen, maxArrLen int, maxValue uint64) []uint64 {
+func createRandomArray(minArrLen, maxArrLen int, maxValue uint64, random *common.Random) []uint64 {
 	// Random length between a and b (inclusive)
-	length := common.RandomInt(minArrLen, maxArrLen)
+	length := random.RandomInt(minArrLen, maxArrLen)
 
 	// Create array with random values
 	arr := make([]uint64, 0)
 	seen := make(map[uint64]struct{})
 
 	for len(arr) < length {
-		val := uint64(common.RandomInt(0, int(maxValue)))
+		val := uint64(random.RandomInt(0, int(maxValue)))
 		if _, exists := seen[val]; !exists {
 			seen[val] = struct{}{}
 			arr = append(arr, val)

--- a/pkg/llm-d-inference-sim/failures.go
+++ b/pkg/llm-d-inference-sim/failures.go
@@ -44,16 +44,16 @@ var predefinedFailures = map[string]openaiserverapi.CompletionError{
 }
 
 // shouldInjectFailure determines whether to inject a failure based on configuration
-func shouldInjectFailure(config *common.Configuration) bool {
+func shouldInjectFailure(config *common.Configuration, random *common.Random) bool {
 	if config.FailureInjectionRate == 0 {
 		return false
 	}
 
-	return common.RandomInt(1, 100) <= config.FailureInjectionRate
+	return random.RandomInt(1, 100) <= config.FailureInjectionRate
 }
 
 // getRandomFailure returns a random failure from configured types or all types if none specified
-func getRandomFailure(config *common.Configuration) openaiserverapi.CompletionError {
+func getRandomFailure(config *common.Configuration, random *common.Random) openaiserverapi.CompletionError {
 	var availableFailures []string
 	if len(config.FailureTypes) == 0 {
 		// Use all failure types if none specified
@@ -69,7 +69,7 @@ func getRandomFailure(config *common.Configuration) openaiserverapi.CompletionEr
 		return predefinedFailures[common.FailureTypeServerError]
 	}
 
-	randomIndex := common.RandomInt(0, len(availableFailures)-1)
+	randomIndex := random.RandomInt(0, len(availableFailures)-1)
 	randomType := availableFailures[randomIndex]
 
 	// Customize message with current model name

--- a/pkg/llm-d-inference-sim/failures_test.go
+++ b/pkg/llm-d-inference-sim/failures_test.go
@@ -33,8 +33,9 @@ import (
 
 var _ = Describe("Failures", func() {
 	Describe("getRandomFailure", Ordered, func() {
+		var random *common.Random
 		BeforeAll(func() {
-			common.InitRandom(time.Now().UnixNano())
+			random = common.NewRandom(time.Now().UnixNano())
 		})
 
 		It("should return a failure from all types when none specified", func() {
@@ -42,7 +43,7 @@ var _ = Describe("Failures", func() {
 				Model:        "test-model",
 				FailureTypes: []string{},
 			}
-			failure := getRandomFailure(config)
+			failure := getRandomFailure(config, random)
 			Expect(failure.Code).To(BeNumerically(">=", 400))
 			Expect(failure.Message).ToNot(BeEmpty())
 			Expect(failure.Type).ToNot(BeEmpty())
@@ -53,7 +54,7 @@ var _ = Describe("Failures", func() {
 				Model:        "test-model",
 				FailureTypes: []string{common.FailureTypeRateLimit},
 			}
-			failure := getRandomFailure(config)
+			failure := getRandomFailure(config, random)
 			Expect(failure.Code).To(Equal(429))
 			Expect(failure.Type).To(Equal(openaiserverapi.ErrorCodeToType(429)))
 			Expect(strings.Contains(failure.Message, "test-model")).To(BeTrue())
@@ -63,7 +64,7 @@ var _ = Describe("Failures", func() {
 			config := &common.Configuration{
 				FailureTypes: []string{common.FailureTypeInvalidAPIKey},
 			}
-			failure := getRandomFailure(config)
+			failure := getRandomFailure(config, random)
 			Expect(failure.Code).To(Equal(401))
 			Expect(failure.Type).To(Equal(openaiserverapi.ErrorCodeToType(401)))
 			Expect(failure.Message).To(Equal("Incorrect API key provided."))
@@ -73,7 +74,7 @@ var _ = Describe("Failures", func() {
 			config := &common.Configuration{
 				FailureTypes: []string{common.FailureTypeContextLength},
 			}
-			failure := getRandomFailure(config)
+			failure := getRandomFailure(config, random)
 			Expect(failure.Code).To(Equal(400))
 			Expect(failure.Type).To(Equal(openaiserverapi.ErrorCodeToType(400)))
 			Expect(failure.Param).ToNot(BeNil())
@@ -84,7 +85,7 @@ var _ = Describe("Failures", func() {
 			config := &common.Configuration{
 				FailureTypes: []string{common.FailureTypeServerError},
 			}
-			failure := getRandomFailure(config)
+			failure := getRandomFailure(config, random)
 			Expect(failure.Code).To(Equal(503))
 			Expect(failure.Type).To(Equal(openaiserverapi.ErrorCodeToType(503)))
 		})
@@ -94,7 +95,7 @@ var _ = Describe("Failures", func() {
 				Model:        "test-model",
 				FailureTypes: []string{common.FailureTypeModelNotFound},
 			}
-			failure := getRandomFailure(config)
+			failure := getRandomFailure(config, random)
 			Expect(failure.Code).To(Equal(404))
 			Expect(failure.Type).To(Equal(openaiserverapi.ErrorCodeToType(404)))
 			Expect(strings.Contains(failure.Message, "test-model-nonexistent")).To(BeTrue())
@@ -105,7 +106,7 @@ var _ = Describe("Failures", func() {
 				FailureTypes: []string{},
 			}
 			// This test is probabilistic since it randomly selects, but we can test structure
-			failure := getRandomFailure(config)
+			failure := getRandomFailure(config, random)
 			Expect(failure.Code).To(BeNumerically(">=", 400))
 			Expect(failure.Type).ToNot(BeEmpty())
 		})

--- a/pkg/llm-d-inference-sim/latencies.go
+++ b/pkg/llm-d-inference-sim/latencies.go
@@ -17,8 +17,6 @@ limitations under the License.
 // Package vllmsim implements the vLLM simulator.
 package llmdinferencesim
 
-import "github.com/llm-d/llm-d-inference-sim/pkg/common"
-
 func (s *VllmSimulator) getCurrLoadFactor() float64 {
 	if s.config.MaxNumSeqs <= 1 {
 		return 1.0
@@ -44,22 +42,22 @@ func (s *VllmSimulator) getWaitTimeToFirstToken(nPromptTokens int, nCachedPrompt
 		if s.config.KVCacheTransferLatency == 0 && s.config.KVCacheTransferLatencyStdDev == 0 {
 			// is disaggregated PD and ttft is calculated using number of prompt tokens
 			kvCacheTransT := s.config.KVCacheTransferTimePerToken * nPromptTokens
-			return common.RandomNorm(kvCacheTransT, s.config.KVCacheTransferTimeStdDev)
+			return s.random.RandomNormTruncated(kvCacheTransT, s.config.KVCacheTransferTimeStdDev)
 		}
 		// is disaggregated PD and *not* using number of prompt tokens
-		return common.RandomNorm(s.config.KVCacheTransferLatency, s.config.KVCacheTransferLatencyStdDev)
+		return s.random.RandomNormTruncated(s.config.KVCacheTransferLatency, s.config.KVCacheTransferLatencyStdDev)
 	}
 	if s.config.TimeToFirstToken == 0 && s.config.TimeToFirstTokenStdDev == 0 {
 		// is aggregated PD and ttft is calculated using number of prompt tokens that are not in kv cache
 		prefillTime := s.getPrefillOverhead() + (nPromptTokens-nCachedPromptTokens)*s.getPrefillTimePerToken()
-		return common.RandomNorm(prefillTime, s.config.PrefillTimeStdDev)
+		return s.random.RandomNormTruncated(prefillTime, s.config.PrefillTimeStdDev)
 	}
 	// is aggregated PD and *not* using number of prompt tokens
-	return common.RandomNorm(s.getTimeToFirstToken(), s.config.TimeToFirstTokenStdDev)
+	return s.random.RandomNormTruncated(s.getTimeToFirstToken(), s.config.TimeToFirstTokenStdDev)
 }
 
 // returns inter token latency
 func (s *VllmSimulator) getInterTokenLatency() int {
 	latency := int(float64(s.config.InterTokenLatency) * s.getCurrLoadFactor())
-	return common.RandomNorm(latency, s.config.InterTokenLatencyStdDev)
+	return s.random.RandomNormTruncated(latency, s.config.InterTokenLatencyStdDev)
 }

--- a/pkg/llm-d-inference-sim/latencies_test.go
+++ b/pkg/llm-d-inference-sim/latencies_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Check random latencies", Ordered, func() {
 
 		simulator.metrics.runReqChan = make(chan int64, 100)
 
-		common.InitRandom(time.Now().UnixNano())
+		simulator.random = common.NewRandom(time.Now().UnixNano())
 	})
 
 	DescribeTable("should calculate inter token latency correctly",

--- a/pkg/llm-d-inference-sim/server.go
+++ b/pkg/llm-d-inference-sim/server.go
@@ -107,7 +107,7 @@ func (s *VllmSimulator) startServer(ctx context.Context, listener net.Listener) 
 
 // readRequest reads and parses data from the body of the given request according the type defined by isChatCompletion
 func (s *VllmSimulator) readRequest(ctx *fasthttp.RequestCtx, isChatCompletion bool) (openaiserverapi.CompletionRequest, error) {
-	requestID := common.GenerateUUIDString()
+	requestID := s.random.GenerateUUIDString()
 
 	if isChatCompletion {
 		var req openaiserverapi.ChatCompletionRequest

--- a/pkg/llm-d-inference-sim/streaming.go
+++ b/pkg/llm-d-inference-sim/streaming.go
@@ -171,7 +171,7 @@ func (s *VllmSimulator) sendTokenChunks(context *streamingContext, w *bufio.Writ
 // createUsageChunk creates and returns a CompletionRespChunk with usage data, a single chunk of streamed completion API response,
 // supports both modes (text and chat)
 func (s *VllmSimulator) createUsageChunk(context *streamingContext, usageData *openaiserverapi.Usage) openaiserverapi.CompletionRespChunk {
-	baseChunk := openaiserverapi.CreateBaseCompletionResponse(chatComplIDPrefix+common.GenerateUUIDString(),
+	baseChunk := openaiserverapi.CreateBaseCompletionResponse(chatComplIDPrefix+s.random.GenerateUUIDString(),
 		context.creationTime, context.model, usageData)
 
 	if context.isChatCompletion {
@@ -186,7 +186,7 @@ func (s *VllmSimulator) createUsageChunk(context *streamingContext, usageData *o
 // createTextCompletionChunk creates and returns a CompletionRespChunk, a single chunk of streamed completion API response,
 // for text completion
 func (s *VllmSimulator) createTextCompletionChunk(context *streamingContext, token string, finishReason *string) openaiserverapi.CompletionRespChunk {
-	baseChunk := openaiserverapi.CreateBaseCompletionResponse(chatComplIDPrefix+common.GenerateUUIDString(),
+	baseChunk := openaiserverapi.CreateBaseCompletionResponse(chatComplIDPrefix+s.random.GenerateUUIDString(),
 		context.creationTime, context.model, nil)
 	baseChunk.Object = textCompletionObject
 	return openaiserverapi.CreateTextCompletionResponse(baseChunk,
@@ -198,7 +198,7 @@ func (s *VllmSimulator) createTextCompletionChunk(context *streamingContext, tok
 // API response, for chat completion. It sets either role, or token, or tool call info in the message.
 func (s *VllmSimulator) createChatCompletionChunk(context *streamingContext, token string, tool *openaiserverapi.ToolCall,
 	role string, finishReason *string) openaiserverapi.CompletionRespChunk {
-	baseChunk := openaiserverapi.CreateBaseCompletionResponse(chatComplIDPrefix+common.GenerateUUIDString(),
+	baseChunk := openaiserverapi.CreateBaseCompletionResponse(chatComplIDPrefix+s.random.GenerateUUIDString(),
 		context.creationTime, context.model, nil)
 	baseChunk.Object = chatCompletionChunkObject
 	chunk := openaiserverapi.CreateChatCompletionRespChunk(baseChunk,

--- a/pkg/llm-d-inference-sim/worker.go
+++ b/pkg/llm-d-inference-sim/worker.go
@@ -97,13 +97,13 @@ func (s *VllmSimulator) processRequest(reqCtx *openaiserverapi.CompletionReqCtx)
 		!common.IsToolChoiceNone(req.GetToolChoice()) &&
 		req.GetTools() != nil {
 		toolCalls, completionTokens, err =
-			common.CreateToolCalls(req.GetTools(), req.GetToolChoice(), s.config)
+			common.CreateToolCalls(req.GetTools(), req.GetToolChoice(), s.config, s.random)
 		finishReason = dataset.ToolsFinishReason
 	}
 	if toolCalls == nil && err == nil {
 		// Either no tool calls were defined, or we randomly chose not to create tool calls,
 		// so we generate a response text.
-		responseTokens, finishReason, err = s.dataset.GetTokens(req, s.config.Mode)
+		responseTokens, finishReason, err = s.dataset.GetTokens(req, s.config.Mode, s.random)
 		completionTokens += len(responseTokens)
 	}
 	if err != nil {


### PR DESCRIPTION
Fixes #226 

The test failed because another test used random generator, and this made changed the pseudo random numbers generated for the seed test.

This PR makes rand a field in the simulator, this prevents the above collision. This fix is important not only for the tests, but also for DP, allowing to reproduce the responses of each rank.

This PR also changes the uuid initialization: it now creates its own rand (with the same seed), to prevent the collision with random numbers generation and ensure reproducible results.