### PR TITLE
feat: add support for X-Request-Id header in responses and logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,12 +21,7 @@ require (
 	golang.org/x/sync v0.12.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog/v2 v2.130.1
-)
-
-require (
-	github.com/dgraph-io/ristretto/v2 v2.3.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
+	sigs.k8s.io/controller-runtime v0.21.0
 )
 
 require (
@@ -35,7 +30,9 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/daulet/tokenizers v1.22.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgraph-io/ristretto/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -68,6 +65,7 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
@@ -83,7 +81,6 @@ require (
 	k8s.io/client-go v0.33.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
-	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -223,6 +223,9 @@ type Configuration struct {
 
 	// EnableSleepMode enables sleep mode
 	EnableSleepMode bool `yaml:"enable-sleep-mode" json:"enable-sleep-mode"`
+
+	// EnableRequestIDHeaders enables including X-Request-Id header in responses
+	EnableRequestIDHeaders bool `yaml:"enable-request-id-headers" json:"enable-request-id-headers"`
 }
 
 type Metrics struct {
@@ -749,6 +752,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.BoolVar(&config.DatasetInMemory, "dataset-in-memory", config.DatasetInMemory, "Load the entire dataset into memory for faster access")
 
 	f.BoolVar(&config.EnableSleepMode, "enable-sleep-mode", config.EnableSleepMode, "Enable sleep mode")
+	f.BoolVar(&config.EnableRequestIDHeaders, "enable-request-id-headers", config.EnableRequestIDHeaders, "Enable including X-Request-Id header in responses")
 
 	f.IntVar(&config.FailureInjectionRate, "failure-injection-rate", config.FailureInjectionRate, "Probability (0-100) of injecting failures")
 	failureTypes := getParamValueFromArgs("failure-types")

--- a/pkg/llm-d-inference-sim/test_utils.go
+++ b/pkg/llm-d-inference-sim/test_utils.go
@@ -541,3 +541,7 @@ func checkSimSleeping(client *http.Client, expectedToSleep bool) {
 	expect := fmt.Sprintf("{\"is_sleeping\":%t}", expectedToSleep)
 	gomega.Expect(string(body)).To(gomega.Equal(expect))
 }
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/openai-server-api/response.go
+++ b/pkg/openai-server-api/response.go
@@ -26,7 +26,9 @@ import (
 )
 
 // CompletionResponse interface representing both completion response types (text and chat)
-type CompletionResponse interface{}
+type CompletionResponse interface {
+	GetRequestID() string
+}
 
 // baseCompletionResponse contains base completion response related information
 type baseCompletionResponse struct {
@@ -42,6 +44,8 @@ type baseCompletionResponse struct {
 	Object string `json:"object"`
 	// KVParams kv transfer related fields
 	KVParams *KVTransferParams `json:"kv_transfer_params"`
+	// RequestID is the unique request ID for tracking
+	RequestID string `json:"-"`
 }
 
 // Usage contains token Usage statistics
@@ -303,8 +307,13 @@ func CreateTextRespChoice(base baseResponseChoice, text string) TextRespChoice {
 	return TextRespChoice{baseResponseChoice: base, Text: text, Logprobs: nil}
 }
 
-func CreateBaseCompletionResponse(id string, created int64, model string, usage *Usage) baseCompletionResponse {
-	return baseCompletionResponse{ID: id, Created: created, Model: model, Usage: usage}
+func CreateBaseCompletionResponse(id string, created int64, model string, usage *Usage, requestID string) baseCompletionResponse {
+	return baseCompletionResponse{ID: id, Created: created, Model: model, Usage: usage, RequestID: requestID}
+}
+
+// GetRequestID returns the request ID from the response
+func (b baseCompletionResponse) GetRequestID() string {
+	return b.RequestID
 }
 
 func CreateChatCompletionResponse(base baseCompletionResponse, choices []ChatRespChoice) *ChatCompletionResponse {


### PR DESCRIPTION
This PR adds support for the `X-Request-Id` header, enabling request tracing across the LLM inference simulation server, aligning with extra HTTP headers of vLLM's [OpenAI-compatible server feature](https://docs.vllm.ai/en/latest/serving/openai_compatible_server/#extra-http-headers). The update also provides the `--enable-request-id-headers` flag that vLLM offers.

**Related vLLM PRs:**

- vllm-project/vllm#9594
- vllm-project/vllm#10968

Currently, only `X-Request-Id` is supported since `ctx.Request.Header.Peek` from fasthttp is case-sensitive.