### PR TITLE
fix: Use "cmpl-" prefix for /completions response IDs (#270)

### DIFF
--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -43,8 +43,6 @@ import (
 )
 
 const (
-	chatComplIDPrefix         = "chatcmpl-"
-	textComplIDPrefix         = "cmpl-"
 	textCompletionObject      = "text_completion"
 	chatCompletionObject      = "chat.completion"
 	chatCompletionChunkObject = "chat.completion.chunk"
@@ -584,13 +582,7 @@ func (s *VllmSimulator) responseSentCallback(model string, isChatCompletion bool
 // from --served-model-name (for a base-model request) or the LoRA adapter name (for a LoRA request).
 func (s *VllmSimulator) createCompletionResponse(logprobs *int, isChatCompletion bool, respTokens []string, toolCalls []openaiserverapi.ToolCall,
 	finishReason *string, usageData *openaiserverapi.Usage, modelName string, doRemoteDecode bool, requestID string) openaiserverapi.CompletionResponse {
-	var idPrefix string
-	if isChatCompletion {
-		idPrefix = chatComplIDPrefix
-	} else {
-		idPrefix = textComplIDPrefix
-	}
-	baseResp := openaiserverapi.CreateBaseCompletionResponse(idPrefix+requestID,
+	baseResp := openaiserverapi.CreateBaseCompletionResponse(
 		time.Now().Unix(), modelName, usageData, requestID)
 
 	if doRemoteDecode {

--- a/pkg/llm-d-inference-sim/streaming.go
+++ b/pkg/llm-d-inference-sim/streaming.go
@@ -179,13 +179,7 @@ func (s *VllmSimulator) sendTokenChunks(context *streamingContext, w *bufio.Writ
 // createUsageChunk creates and returns a CompletionRespChunk with usage data, a single chunk of streamed completion API response,
 // supports both modes (text and chat)
 func (s *VllmSimulator) createUsageChunk(context *streamingContext, usageData *openaiserverapi.Usage) openaiserverapi.CompletionRespChunk {
-	var idPrefix string
-	if context.isChatCompletion {
-		idPrefix = chatComplIDPrefix
-	} else {
-		idPrefix = textComplIDPrefix
-	}
-	baseChunk := openaiserverapi.CreateBaseCompletionResponse(idPrefix+context.requestID,
+	baseChunk := openaiserverapi.CreateBaseCompletionResponse(
 		context.creationTime, context.model, usageData, context.requestID)
 
 	if context.isChatCompletion {
@@ -200,7 +194,7 @@ func (s *VllmSimulator) createUsageChunk(context *streamingContext, usageData *o
 // createTextCompletionChunk creates and returns a CompletionRespChunk, a single chunk of streamed completion API response,
 // for text completion.
 func (s *VllmSimulator) createTextCompletionChunk(context *streamingContext, token string, finishReason *string) openaiserverapi.CompletionRespChunk {
-	baseChunk := openaiserverapi.CreateBaseCompletionResponse(textComplIDPrefix+context.requestID,
+	baseChunk := openaiserverapi.CreateBaseCompletionResponse(
 		context.creationTime, context.model, nil, context.requestID)
 	baseChunk.Object = textCompletionObject
 
@@ -223,7 +217,7 @@ func (s *VllmSimulator) createTextCompletionChunk(context *streamingContext, tok
 // API response, for chat completion. It sets either role, or token, or tool call info in the message.
 func (s *VllmSimulator) createChatCompletionChunk(context *streamingContext, token string, tool *openaiserverapi.ToolCall,
 	role string, finishReason *string) openaiserverapi.CompletionRespChunk {
-	baseChunk := openaiserverapi.CreateBaseCompletionResponse(chatComplIDPrefix+context.requestID,
+	baseChunk := openaiserverapi.CreateBaseCompletionResponse(
 		context.creationTime, context.model, nil, context.requestID)
 	baseChunk.Object = chatCompletionChunkObject
 	chunk := openaiserverapi.CreateChatCompletionRespChunk(baseChunk,

--- a/pkg/openai-server-api/response.go
+++ b/pkg/openai-server-api/response.go
@@ -25,6 +25,11 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+const (
+	chatComplIDPrefix = "chatcmpl-"
+	textComplIDPrefix = "cmpl-"
+)
+
 // CompletionResponse interface representing both completion response types (text and chat)
 type CompletionResponse interface {
 	GetRequestID() string
@@ -307,8 +312,8 @@ func CreateTextRespChoice(base baseResponseChoice, text string) TextRespChoice {
 	return TextRespChoice{baseResponseChoice: base, Text: text, Logprobs: nil}
 }
 
-func CreateBaseCompletionResponse(id string, created int64, model string, usage *Usage, requestID string) baseCompletionResponse {
-	return baseCompletionResponse{ID: id, Created: created, Model: model, Usage: usage, RequestID: requestID}
+func CreateBaseCompletionResponse(created int64, model string, usage *Usage, requestID string) baseCompletionResponse {
+	return baseCompletionResponse{Created: created, Model: model, Usage: usage, RequestID: requestID}
 }
 
 // GetRequestID returns the request ID from the response
@@ -317,13 +322,16 @@ func (b baseCompletionResponse) GetRequestID() string {
 }
 
 func CreateChatCompletionResponse(base baseCompletionResponse, choices []ChatRespChoice) *ChatCompletionResponse {
+	base.ID = chatComplIDPrefix + base.RequestID
 	return &ChatCompletionResponse{baseCompletionResponse: base, Choices: choices}
 }
 
 func CreateTextCompletionResponse(base baseCompletionResponse, choices []TextRespChoice) *TextCompletionResponse {
+	base.ID = textComplIDPrefix + base.RequestID
 	return &TextCompletionResponse{baseCompletionResponse: base, Choices: choices}
 }
 
 func CreateChatCompletionRespChunk(base baseCompletionResponse, choices []ChatRespChunkChoice) *ChatCompletionRespChunk {
+	base.ID = chatComplIDPrefix + base.RequestID
 	return &ChatCompletionRespChunk{baseCompletionResponse: base, Choices: choices}
 }


### PR DESCRIPTION
This PR adds a 'textComplIDPrefix' constant for text completion responses, updates 'createCompletionResponse()' and 'createUsageChunk()'  to select the appropriate prefix based on endpoint type.

Fixes #270