### PR TITLE
feat: change all latency configuration to Duration format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin
 lib
 vendor
 .vscode
+.idea
 .devcontainer
 # MacOSX
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -183,18 +183,18 @@ For more details see the <a href="https://docs.vllm.ai/en/stable/getting_started
     - `echo`: returns the same text that was sent in the request
     - `random`: returns a sentence chosen at random from a set of pre-defined sentences
 ---
-- `time-to-first-token`: the time to the first token (in milliseconds), optional, by default zero
-- `time-to-first-token-std-dev`: standard deviation for time before the first token will be returned, in milliseconds, optional, default is 0, can't be more than 30% of `time-to-first-token`, will not cause the actual time to first token to differ by more than 70% from `time-to-first-token`
-- `inter-token-latency`: the time to 'generate' each additional token (in milliseconds), optional, by default zero
-- `inter-token-latency-std-dev`: standard deviation for time between generated tokens, in milliseconds, optional, default is 0, can't be more than 30% of `inter-token-latency`, will not cause the actual inter token latency to differ by more than 70% from `inter-token-latency`
-- `kv-cache-transfer-latency`: time for KV-cache transfer from a remote vLLM (in milliseconds), by default zero. Usually much shorter than `time-to-first-token`
-- `kv-cache-transfer-latency-std-dev`: standard deviation for time to "transfer" kv-cache from another vLLM instance in case P/D is activated, in milliseconds, optional, default is 0, can't be more than 30% of `kv-cache-transfer-latency`, will not cause the actual latency to differ by more than 70% from `kv-cache-transfer-latency`
+- `time-to-first-token`: the time to the first token (e.g. 100ms. Integer format is deprecated), optional, by default zero
+- `time-to-first-token-std-dev`: standard deviation for time before the first token will be returned, e.g., 100ms. in milliseconds if unit is missing, optional, default is 0, can't be more than 30% of `time-to-first-token`, will not cause the actual time to first token to differ by more than 70% from `time-to-first-token`
+- `inter-token-latency`: the time to 'generate' each additional token (e.g. 100ms. Integer format is deprecated), optional, by default zero
+- `inter-token-latency-std-dev`: standard deviation for time between generated tokens, e.g., 100ms. in milliseconds if unit is missing, optional, default is 0, can't be more than 30% of `inter-token-latency`, will not cause the actual inter token latency to differ by more than 70% from `inter-token-latency`
+- `kv-cache-transfer-latency`: time for KV-cache transfer from a remote vLLM (e.g. 100ms. Integer format is deprecated), by default zero. Usually much shorter than `time-to-first-token`
+- `kv-cache-transfer-latency-std-dev`: standard deviation for time to "transfer" kv-cache from another vLLM instance in case P/D is activated, e.g., 100ms. in milliseconds if unit is missing, optional, default is 0, can't be more than 30% of `kv-cache-transfer-latency`, will not cause the actual latency to differ by more than 70% from `kv-cache-transfer-latency`
 ---
-- `prefill-overhead`: constant overhead time for prefill (in milliseconds), optional, by default zero, used in calculating time to first token, this will be ignored if `time-to-first-token` is not `0`
-- `prefill-time-per-token`: time taken to generate each token during prefill (in milliseconds), optional, by default zero, this will be ignored if `time-to-first-token` is not `0`
+- `prefill-overhead`: constant overhead time for prefill (e.g. 100ms. Integer format is deprecated), optional, by default zero, used in calculating time to first token, this will be ignored if `time-to-first-token` is not `0`
+- `prefill-time-per-token`: time taken to generate each token during prefill (e.g. 100ms. Integer format is deprecated), optional, by default zero, this will be ignored if `time-to-first-token` is not `0`
 - `prefill-time-std-dev`: similar to `time-to-first-token-std-dev`, but is applied on the final prefill time, which is calculated by `prefill-overhead`, `prefill-time-per-token`, and number of prompt tokens, this will be ignored if `time-to-first-token` is not `0`
-- `kv-cache-transfer-time-per-token`: time taken to transfer cache for each token in case P/D is enabled (in milliseconds), optional, by default zero, this will be ignored if `kv-cache-transfer-latency` is not `0`
-- `kv-cache-transfer-time-std-dev`: similar to `time-to-first-token-std-dev`, but is applied on the final kv cache transfer time in case P/D is enabled (in milliseconds), which is calculated by `kv-cache-transfer-time-per-token` and number of prompt tokens, this will be ignored if `kv-cache-transfer-latency` is not `0`
+- `kv-cache-transfer-time-per-token`: time taken to transfer cache for each token in case P/D is enabled (e.g. 100ms. Integer format is deprecated), optional, by default zero, this will be ignored if `kv-cache-transfer-latency` is not `0`
+- `kv-cache-transfer-time-std-dev`: similar to `time-to-first-token-std-dev`, but is applied on the final kv cache transfer time in case P/D is enabled (e.g. 100ms. Integer format is deprecated), which is calculated by `kv-cache-transfer-time-per-token` and number of prompt tokens, this will be ignored if `kv-cache-transfer-latency` is not `0`
 ---
 - `time-factor-under-load`: a multiplicative factor that affects the overall time taken for requests when parallelrequests are being processed. The value of this factor must be >= 1.0, with a default of 1.0. If this factor is 1.0, no extra time is added.  When the factor is x (where x > 1.0) and there are `max-num-seqs` requests, the total time will be multiplied by x. The extra time then decreases multiplicatively to 1.0 when the number of requests is less than MaxNumSeqs.
 - `seed`: random seed for operations (if not set, current Unix time in nanoseconds is used)

--- a/manifests/config_with_duration_latency.yaml
+++ b/manifests/config_with_duration_latency.yaml
@@ -1,0 +1,16 @@
+port: 8001
+model: "Qwen/Qwen2-0.5B"
+served-model-name: 
+- "model1"
+- "model2"
+max-loras: 2
+max-cpu-loras: 5
+max-num-seqs: 5
+lora-modules:
+- '{"name":"lora1","path":"/path/to/lora1"}'
+- '{"name":"lora2","path":"/path/to/lora2"}'
+mode: "random"
+time-to-first-token: "4s"
+inter-token-latency: "2s"
+kv-cache-transfer-latency: "1s"
+seed: 100100100

--- a/manifests/disaggregation/README.md
+++ b/manifests/disaggregation/README.md
@@ -79,5 +79,5 @@ This example already configures non-zero latency parameters to reflect real-worl
 ```
 
 Parameter meanings:
-- `prefill-time-per-token`: Average time (in milliseconds) to process each prompt token during the prefill phase. Higher values emphasize the cost of large prompts.
+- `prefill-time-per-token`: Average time (e.g., 100ms. in milliseconds if unit is missing) to process each prompt token during the prefill phase. Higher values emphasize the cost of large prompts.
 - `prefill-time-std-dev`: Standard deviation (in ms) of prefill latency, introducing realistic variation across requests.

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -94,42 +94,44 @@ type Configuration struct {
 	// LoraModules is a list of LoRA adapters
 	LoraModules []LoraModule
 
-	// TimeToFirstToken time before the first token will be returned, in milliseconds
-	TimeToFirstToken int `yaml:"time-to-first-token" json:"time-to-first-token"`
-	// TimeToFirstTokenStdDev standard deviation for time before the first token will be returned,
-	// in milliseconds, optional, default is 0, can't be more than 30% of TimeToFirstToken, will not
-	// cause the actual time to first token to differ by more than 70% from TimeToFirstToken
-	TimeToFirstTokenStdDev int `yaml:"time-to-first-token-std-dev" json:"time-to-first-token-std-dev"`
+	// --- Duration Configuration ---
+	// NOTE: For all duration fields listed below, providing a raw integer (milliseconds) is DEPRECATED
+	// and support will be removed in the next version.
+	// Please use duration strings instead (e.g., "100ms", "1.5s").
 
-	// InterTokenLatency time between generated tokens, in milliseconds
-	InterTokenLatency int `yaml:"inter-token-latency" json:"inter-token-latency"`
-	// InterTokenLatencyStdDev standard deviation for time between generated tokens, in milliseconds,
+	// TimeToFirstToken time before the first token will be returned
+	TimeToFirstToken Duration `yaml:"time-to-first-token" json:"time-to-first-token"`
+	// TimeToFirstTokenStdDev standard deviation for time before the first token will be returned
+	// optional, default is 0, can't be more than 30% of TimeToFirstToken, will not
+	// cause the actual time to first token to differ by more than 70% from TimeToFirstToken
+	TimeToFirstTokenStdDev Duration `yaml:"time-to-first-token-std-dev" json:"time-to-first-token-std-dev"`
+
+	// InterTokenLatency time between generated tokens
+	InterTokenLatency Duration `yaml:"inter-token-latency" json:"inter-token-latency"`
+	// InterTokenLatencyStdDev standard deviation for time between generated tokens
 	// optional, default is 0, can't be more than 30% of InterTokenLatency, will not cause the actual
 	// inter token latency to differ by more than 70% from InterTokenLatency
-	InterTokenLatencyStdDev int `yaml:"inter-token-latency-std-dev" json:"inter-token-latency-std-dev"`
+	InterTokenLatencyStdDev Duration `yaml:"inter-token-latency-std-dev" json:"inter-token-latency-std-dev"`
 	// KVCacheTransferLatency time to "transfer" kv-cache from another vLLM instance in case P/D is activated,
-	// in milliseconds
-	KVCacheTransferLatency int `yaml:"kv-cache-transfer-latency" json:"kv-cache-transfer-latency"`
+	KVCacheTransferLatency Duration `yaml:"kv-cache-transfer-latency" json:"kv-cache-transfer-latency"`
 	// KVCacheTransferLatencyStdDev standard deviation for time to "transfer" kv-cache from another
-	// vLLM instance in case P/D is activated, in milliseconds, optional, default is 0, can't be more
-	// than 30% of KVCacheTransferLatency, will not cause the actual latency to differ by more than 70% from
-	// KVCacheTransferLatency
-	KVCacheTransferLatencyStdDev int `yaml:"kv-cache-transfer-latency-std-dev" json:"kv-cache-transfer-latency-std-dev"`
+	// vLLM instance in case P/D is activated, can't be more than 30% of KVCacheTransferLatency, will not
+	// cause the actual latency to differ by more than 70% from KVCacheTransferLatency
+	KVCacheTransferLatencyStdDev Duration `yaml:"kv-cache-transfer-latency-std-dev" json:"kv-cache-transfer-latency-std-dev"`
 
 	// $Total Prefill Time = PrefillOverhead + n * PrefillTimePerToken$
 	// the assumption is that n is less than k, where k is the number of prallelism units of GPU
-	// PrefillOverhead time taken to prefill the context, in milliseconds
-	PrefillOverhead     int `yaml:"prefill-overhead" json:"prefill-overhead"`
-	PrefillTimePerToken int `yaml:"prefill-time-per-token" json:"prefill-time-per-token"`
+	// PrefillOverhead time taken to prefill the context
+	PrefillOverhead     Duration `yaml:"prefill-overhead" json:"prefill-overhead"`
+	PrefillTimePerToken Duration `yaml:"prefill-time-per-token" json:"prefill-time-per-token"`
 	// PrefillOverheadStdDev similar to TimeToFirstTokenStdDev
-	PrefillTimeStdDev int `yaml:"prefill-time-std-dev" json:"prefill-time-std-dev"`
+	PrefillTimeStdDev Duration `yaml:"prefill-time-std-dev" json:"prefill-time-std-dev"`
 	// $Total KV Cache Transfer Time = n * KVCacheTransferTimePerToken$
 	// the assumption is that the cache blocks are all missed at the remote pod
-	// KVCacheTransfer overhead time taken to transfer kv-cache from another vLLM instance in case P/D is activated,
-	// in milliseconds.
-	KVCacheTransferTimePerToken int `yaml:"kv-cache-transfer-time-per-token" json:"kv-cache-transfer-time-per-token"`
+	// KVCacheTransfer overhead time taken to transfer kv-cache from another vLLM instance in case P/D is activated
+	KVCacheTransferTimePerToken Duration `yaml:"kv-cache-transfer-time-per-token" json:"kv-cache-transfer-time-per-token"`
 	// KVCacheTransferOverheadStdDev similar to TimeToFirstTokenStdDev
-	KVCacheTransferTimeStdDev int `yaml:"kv-cache-transfer-time-std-dev" json:"kv-cache-transfer-time-std-dev"`
+	KVCacheTransferTimeStdDev Duration `yaml:"kv-cache-transfer-time-std-dev" json:"kv-cache-transfer-time-std-dev"`
 
 	// TimeFactorUnderLoad is a multiplicative factor that affects the overall time taken for requests when parallel
 	// requests are being processed.
@@ -737,19 +739,19 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.IntVar(&config.MaxModelLen, "max-model-len", config.MaxModelLen, "Model's context window, maximum number of tokens in a single request including input and output")
 
 	f.StringVar(&config.Mode, "mode", config.Mode, "Simulator mode: echo - returns the same text that was sent in the request, for chat completion returns the last message; random - returns random sentence from a bank of pre-defined sentences")
-	f.IntVar(&config.InterTokenLatency, "inter-token-latency", config.InterTokenLatency, "Time to generate one token (in milliseconds)")
-	f.IntVar(&config.TimeToFirstToken, "time-to-first-token", config.TimeToFirstToken, "Time to first token (in milliseconds)")
+	f.Var(&config.InterTokenLatency, "inter-token-latency", "Time to generate one token (e.g. 100ms. Integer format is deprecated)")
+	f.Var(&config.TimeToFirstToken, "time-to-first-token", "Time to first token (e.g. 100ms. Integer format is deprecated)")
 
-	f.IntVar(&config.PrefillOverhead, "prefill-overhead", config.PrefillOverhead, "Time to prefill in milliseconds. This argument is ignored if <time-to-first-token> is not 0.")
-	f.IntVar(&config.PrefillTimePerToken, "prefill-time-per-token", config.PrefillTimePerToken, "Time to prefill per token (in milliseconds)")
-	f.IntVar(&config.PrefillTimeStdDev, "prefill-time-std-dev", config.PrefillTimeStdDev, "Standard deviation for time to prefill (in milliseconds)")
-	f.IntVar(&config.KVCacheTransferTimePerToken, "kv-cache-transfer-time-per-token", config.KVCacheTransferTimePerToken, "Time for KV-cache transfer per token from a remote vLLM (in milliseconds)")
-	f.IntVar(&config.KVCacheTransferTimeStdDev, "kv-cache-transfer-time-std-dev", config.KVCacheTransferTimeStdDev, "Standard deviation for time for KV-cache transfer per token from a remote vLLM (in milliseconds)")
+	f.Var(&config.PrefillOverhead, "prefill-overhead", "Time to prefill (e.g. 100ms. Integer format is deprecated). This argument is ignored if <time-to-first-token> is not 0.")
+	f.Var(&config.PrefillTimePerToken, "prefill-time-per-token", "Time to prefill per token (e.g. 100ms. Integer format is deprecated)")
+	f.Var(&config.PrefillTimeStdDev, "prefill-time-std-dev", "Standard deviation for time to prefill (e.g. 100ms. Integer format is deprecated)")
+	f.Var(&config.KVCacheTransferTimePerToken, "kv-cache-transfer-time-per-token", "Time for KV-cache transfer per token from a remote vLLM (e.g. 100ms. Integer format is deprecated)")
+	f.Var(&config.KVCacheTransferTimeStdDev, "kv-cache-transfer-time-std-dev", "Standard deviation for time for KV-cache transfer per token from a remote vLLM (e.g. 100ms. Integer format is deprecated)")
 
-	f.IntVar(&config.KVCacheTransferLatency, "kv-cache-transfer-latency", config.KVCacheTransferLatency, "Time for KV-cache transfer from a remote vLLM (in milliseconds)")
-	f.IntVar(&config.InterTokenLatencyStdDev, "inter-token-latency-std-dev", config.InterTokenLatencyStdDev, "Standard deviation for time between generated tokens (in milliseconds)")
-	f.IntVar(&config.TimeToFirstTokenStdDev, "time-to-first-token-std-dev", config.TimeToFirstTokenStdDev, "Standard deviation for time before the first token will be returned (in milliseconds)")
-	f.IntVar(&config.KVCacheTransferLatencyStdDev, "kv-cache-transfer-latency-std-dev", config.KVCacheTransferLatencyStdDev, "Standard deviation for time for KV-cache transfer from a remote vLLM (in milliseconds)")
+	f.Var(&config.KVCacheTransferLatency, "kv-cache-transfer-latency", "Time for KV-cache transfer from a remote vLLM (e.g. 100ms. Integer format is deprecated)")
+	f.Var(&config.InterTokenLatencyStdDev, "inter-token-latency-std-dev", "Standard deviation for time between generated tokens (e.g. 100ms. Integer format is deprecated)")
+	f.Var(&config.TimeToFirstTokenStdDev, "time-to-first-token-std-dev", "Standard deviation for time before the first token will be returned (e.g. 100ms. Integer format is deprecated)")
+	f.Var(&config.KVCacheTransferLatencyStdDev, "kv-cache-transfer-latency-std-dev", "Standard deviation for time for KV-cache transfer from a remote vLLM (e.g. 100ms. Integer format is deprecated)")
 	f.Int64Var(&config.Seed, "seed", config.Seed, "Random seed for operations (if not set, current Unix time in nanoseconds is used)")
 	f.Float64Var(&config.TimeFactorUnderLoad, "time-factor-under-load", config.TimeFactorUnderLoad, "Time factor under load (must be >= 1.0)")
 

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -46,9 +47,9 @@ func createDefaultConfig(model string) *Configuration {
 	c.MaxNumSeqs = 5
 	c.MaxLoras = 2
 	c.MaxCPULoras = 5
-	c.TimeToFirstToken = 2000
-	c.InterTokenLatency = 1000
-	c.KVCacheTransferLatency = 100
+	c.TimeToFirstToken = Duration(2000 * time.Millisecond)
+	c.InterTokenLatency = Duration(1000 * time.Millisecond)
+	c.KVCacheTransferLatency = Duration(100 * time.Millisecond)
 	c.Seed = 100100100
 	c.LoraModules = []LoraModule{}
 	return c
@@ -176,13 +177,28 @@ var _ = Describe("Simulator configuration", func() {
 	}
 	tests = append(tests, test)
 
+	// Config from config_with_duration_latency.yaml file plus command line args with empty parameter for loras
+	c = createDefaultConfig(qwenModelName)
+	c.Port = 8001
+	c.ServedModelNames = []string{"model1", "model2"}
+	c.LoraModulesString = []string{}
+	c.TimeToFirstToken = Duration(4 * time.Second)
+	c.InterTokenLatency = Duration(2 * time.Second)
+	c.KVCacheTransferLatency = Duration(time.Second)
+	test = testCase{
+		name:           "config file with command line args with empty parameter for loras",
+		args:           []string{"cmd", "--config", "../../manifests/config_with_duration_latency.yaml", "--lora-modules"},
+		expectedConfig: c,
+	}
+	tests = append(tests, test)
+
 	// Config from basic-config.yaml file plus command line args with time to copy cache
 	c = createDefaultConfig(qwenModelName)
 	c.Port = 8001
 	// basic config file does not contain properties related to lora
 	c.MaxLoras = 1
 	c.MaxCPULoras = 1
-	c.KVCacheTransferLatency = 50
+	c.KVCacheTransferLatency = Duration(50 * time.Millisecond)
 	test = testCase{
 		name:           "basic config file with command line args with time to transfer kv-cache",
 		args:           []string{"cmd", "--config", "../../manifests/basic-config.yaml", "--kv-cache-transfer-latency", "50"},

--- a/pkg/llm-d-inference-sim/latencies.go
+++ b/pkg/llm-d-inference-sim/latencies.go
@@ -17,6 +17,10 @@ limitations under the License.
 // Package vllmsim implements the vLLM simulator.
 package llmdinferencesim
 
+import (
+	"time"
+)
+
 func (s *VllmSimulator) getCurrLoadFactor() float64 {
 	if s.config.MaxNumSeqs <= 1 {
 		return 1.0
@@ -24,40 +28,40 @@ func (s *VllmSimulator) getCurrLoadFactor() float64 {
 	return 1 + (s.config.TimeFactorUnderLoad-1)*float64(s.metrics.nRunningReqs-1)/float64(s.config.MaxNumSeqs-1)
 }
 
-func (s *VllmSimulator) getTimeToFirstToken() int {
-	return int(float64(s.config.TimeToFirstToken) * s.getCurrLoadFactor())
+func (s *VllmSimulator) getTimeToFirstToken() time.Duration {
+	return time.Duration(float64(s.config.TimeToFirstToken) * s.getCurrLoadFactor())
 }
 
-func (s *VllmSimulator) getPrefillOverhead() int {
-	return int(float64(s.config.PrefillOverhead) * s.getCurrLoadFactor())
+func (s *VllmSimulator) getPrefillOverhead() time.Duration {
+	return time.Duration(float64(s.config.PrefillOverhead) * s.getCurrLoadFactor())
 }
 
-func (s *VllmSimulator) getPrefillTimePerToken() int {
-	return int(float64(s.config.PrefillTimePerToken) * s.getCurrLoadFactor())
+func (s *VllmSimulator) getPrefillTimePerToken() time.Duration {
+	return time.Duration(float64(s.config.PrefillTimePerToken) * s.getCurrLoadFactor())
 }
 
 // returns time to first token based on the current request's doRemotePrefill
-func (s *VllmSimulator) getWaitTimeToFirstToken(nPromptTokens int, nCachedPromptTokens int, doRemotePrefill bool) int {
+func (s *VllmSimulator) getWaitTimeToFirstToken(nPromptTokens int, nCachedPromptTokens int, doRemotePrefill bool) time.Duration {
 	if doRemotePrefill {
 		if s.config.KVCacheTransferLatency == 0 && s.config.KVCacheTransferLatencyStdDev == 0 {
 			// is disaggregated PD and ttft is calculated using number of prompt tokens
-			kvCacheTransT := s.config.KVCacheTransferTimePerToken * nPromptTokens
-			return s.random.RandomNormTruncated(kvCacheTransT, s.config.KVCacheTransferTimeStdDev)
+			kvCacheTransT := s.config.KVCacheTransferTimePerToken.ToDuration() * time.Duration(nPromptTokens)
+			return s.random.RandomNormDuration(kvCacheTransT, s.config.KVCacheTransferTimeStdDev.ToDuration())
 		}
 		// is disaggregated PD and *not* using number of prompt tokens
-		return s.random.RandomNormTruncated(s.config.KVCacheTransferLatency, s.config.KVCacheTransferLatencyStdDev)
+		return s.random.RandomNormDuration(s.config.KVCacheTransferLatency.ToDuration(), s.config.KVCacheTransferLatencyStdDev.ToDuration())
 	}
 	if s.config.TimeToFirstToken == 0 && s.config.TimeToFirstTokenStdDev == 0 {
 		// is aggregated PD and ttft is calculated using number of prompt tokens that are not in kv cache
-		prefillTime := s.getPrefillOverhead() + (nPromptTokens-nCachedPromptTokens)*s.getPrefillTimePerToken()
-		return s.random.RandomNormTruncated(prefillTime, s.config.PrefillTimeStdDev)
+		prefillTime := s.getPrefillOverhead() + time.Duration(nPromptTokens-nCachedPromptTokens)*s.getPrefillTimePerToken()
+		return s.random.RandomNormDuration(prefillTime, s.config.PrefillTimeStdDev.ToDuration())
 	}
 	// is aggregated PD and *not* using number of prompt tokens
-	return s.random.RandomNormTruncated(s.getTimeToFirstToken(), s.config.TimeToFirstTokenStdDev)
+	return s.random.RandomNormDuration(s.getTimeToFirstToken(), s.config.TimeToFirstTokenStdDev.ToDuration())
 }
 
 // returns inter token latency
-func (s *VllmSimulator) getInterTokenLatency() int {
-	latency := int(float64(s.config.InterTokenLatency) * s.getCurrLoadFactor())
-	return s.random.RandomNormTruncated(latency, s.config.InterTokenLatencyStdDev)
+func (s *VllmSimulator) getInterTokenLatency() time.Duration {
+	latency := time.Duration(float64(s.config.InterTokenLatency) * s.getCurrLoadFactor())
+	return s.random.RandomNormDuration(latency, s.config.InterTokenLatencyStdDev.ToDuration())
 }

--- a/pkg/llm-d-inference-sim/latencies_test.go
+++ b/pkg/llm-d-inference-sim/latencies_test.go
@@ -26,6 +26,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
+func milliseconds(m int) common.Duration {
+	return common.Duration(time.Duration(m) * time.Millisecond)
+}
+
 var _ = Describe("Check random latencies", Ordered, func() {
 	var simulator *VllmSimulator
 
@@ -35,10 +39,10 @@ var _ = Describe("Check random latencies", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		simulator.config = &common.Configuration{
-			TimeToFirstToken:             2048,
-			TimeToFirstTokenStdDev:       2048,
-			KVCacheTransferLatency:       2048,
-			KVCacheTransferLatencyStdDev: 2048,
+			TimeToFirstToken:             milliseconds(2048),
+			TimeToFirstTokenStdDev:       milliseconds(2048),
+			KVCacheTransferLatency:       milliseconds(2048),
+			KVCacheTransferLatencyStdDev: milliseconds(2048),
 		}
 
 		simulator.metrics.runReqChan = make(chan int64, 100)
@@ -47,30 +51,31 @@ var _ = Describe("Check random latencies", Ordered, func() {
 	})
 
 	DescribeTable("should calculate inter token latency correctly",
-		func(interTokenLatency int, stddev int) {
+		func(interTokenLatency common.Duration, stddev common.Duration) {
 			simulator.config.InterTokenLatency = interTokenLatency
 			simulator.config.InterTokenLatencyStdDev = stddev
 			interToken := simulator.getInterTokenLatency()
+
 			Expect(interToken).To(BeNumerically(">=", int(float32(interTokenLatency)*0.3)))
 			Expect(interToken).To(BeNumerically("<=", int(float32(interTokenLatency)*1.7)))
 		},
-		func(interTokenLatency int, stddev int) string {
+		func(interTokenLatency common.Duration, stddev common.Duration) string {
 			return fmt.Sprintf("interTokenLatency: %d stddev: %d", interTokenLatency, stddev)
 		},
-		Entry(nil, 1000, 300),
-		Entry(nil, 1000, 800), // invalid std dev, used for testing purposes
-		Entry(nil, 1000, 900), // invalid std dev, used for testing purposes
-		Entry(nil, 1000, 0),
+		Entry(nil, milliseconds(1000), milliseconds(300)),
+		Entry(nil, milliseconds(1000), milliseconds(800)), // invalid std dev, used for testing purposes
+		Entry(nil, milliseconds(1000), milliseconds(900)), // invalid std dev, used for testing purposes
+		Entry(nil, milliseconds(1000), milliseconds(0)),
 	)
 
 	DescribeTable("should calculate total inter token latency correctly",
-		func(interTokenLatency int, stddev int, numberOfTokens int) {
+		func(interTokenLatency common.Duration, stddev common.Duration, numberOfTokens int) {
 			simulator.config.InterTokenLatency = interTokenLatency
 			simulator.config.InterTokenLatencyStdDev = stddev
 			simulator.config.MaxNumSeqs = 1
 			simulator.config.TimeFactorUnderLoad = 1.0
 
-			latency := 0
+			var latency time.Duration
 			for range numberOfTokens - 1 {
 				latency += simulator.getInterTokenLatency()
 			}
@@ -78,19 +83,19 @@ var _ = Describe("Check random latencies", Ordered, func() {
 			Expect(latency).To(BeNumerically(">=", int(float32(interTokenLatency)*0.3*float32(numberOfTokens-1))))
 			Expect(latency).To(BeNumerically("<=", int(float32(interTokenLatency)*1.7*float32(numberOfTokens-1))))
 		},
-		func(interTokenLatency int, stddev int, numberOfTokens int) string {
+		func(interTokenLatency common.Duration, stddev common.Duration, numberOfTokens int) string {
 			return fmt.Sprintf("interTokenLatency: %d stddev: %d, numberOfTokens: %d", interTokenLatency,
 				stddev, numberOfTokens)
 		},
-		Entry(nil, 1000, 30, 100),
-		Entry(nil, 1000, 800, 20), // invalid std dev, used for testing purposes
-		Entry(nil, 1000, 900, 5),  // invalid std dev, used for testing purposes
-		Entry(nil, 1000, 0, 50),
+		Entry(nil, milliseconds(1000), milliseconds(30), 100),
+		Entry(nil, milliseconds(1000), milliseconds(800), 20), // invalid std dev, used for testing purposes
+		Entry(nil, milliseconds(1000), milliseconds(900), 5),  // invalid std dev, used for testing purposes
+		Entry(nil, milliseconds(1000), milliseconds(0), 50),
 	)
 
 	DescribeTable("should calculate time to first token correctly",
-		func(timeToFirstToken int, timeToFirstTokenStdDev int,
-			kvCacheLatency int, kvCacheLatencyStdDev int, doREmotePrefill bool) {
+		func(timeToFirstToken common.Duration, timeToFirstTokenStdDev common.Duration,
+			kvCacheLatency common.Duration, kvCacheLatencyStdDev common.Duration, doREmotePrefill bool) {
 			simulator.config.TimeToFirstToken = timeToFirstToken
 			simulator.config.TimeToFirstTokenStdDev = timeToFirstTokenStdDev
 			simulator.config.KVCacheTransferLatency = kvCacheLatency
@@ -104,27 +109,28 @@ var _ = Describe("Check random latencies", Ordered, func() {
 				Expect(timeToFirst).To(BeNumerically("<=", int(float32(timeToFirstToken)*1.7)))
 			}
 		},
-		func(timeToFirstToken int, timeToFirstTokenStdDev int,
-			kvCacheLatency int, kvCacheLatencyStdDev int, doREmotePrefill bool) string {
+		func(timeToFirstToken common.Duration, timeToFirstTokenStdDev common.Duration,
+			kvCacheLatency common.Duration, kvCacheLatencyStdDev common.Duration, doREmotePrefill bool) string {
 			return fmt.Sprintf("timeToFirstToken: %d stddev: %d kvCacheLatency: %d stddev: %d doREmotePrefill: %t",
-				timeToFirstToken, timeToFirstTokenStdDev, kvCacheLatency, kvCacheLatencyStdDev, doREmotePrefill)
+				timeToFirstToken, timeToFirstTokenStdDev,
+				kvCacheLatency, kvCacheLatencyStdDev, doREmotePrefill)
 		},
-		Entry(nil, 10000, 300, 1000, 200, true),
-		Entry(nil, 10000, 300, 1000, 200, false),
-		Entry(nil, 10000, 9000, 1000, 800, true),  // invalid std dev, used for testing purposes
-		Entry(nil, 10000, 8000, 1000, 900, false), // invalid std dev, used for testing purposes
-		Entry(nil, 10000, 0, 1000, 0, true),
-		Entry(nil, 10000, 0, 1000, 0, false),
+		Entry(nil, milliseconds(1000), milliseconds(300), milliseconds(1000), milliseconds(200), true),
+		Entry(nil, milliseconds(1000), milliseconds(300), milliseconds(1000), milliseconds(200), false),
+		Entry(nil, milliseconds(1000), milliseconds(9000), milliseconds(1000), milliseconds(800), true),  // invalid std dev, used for testing purposes
+		Entry(nil, milliseconds(1000), milliseconds(8000), milliseconds(1000), milliseconds(900), false), // invalid std dev, used for testing purposes
+		Entry(nil, milliseconds(1000), milliseconds(0), milliseconds(1000), milliseconds(0), true),
+		Entry(nil, milliseconds(1000), milliseconds(0), milliseconds(1000), milliseconds(0), false),
 	)
 
 	It("when <time-to-first-token> is not 0, ignore <prefill-overhead>", func() {
-		timeToFirstToken := 1000
+		timeToFirstToken := milliseconds(1000)
 		simulator.config.TimeToFirstToken = timeToFirstToken
 		simulator.config.TimeToFirstTokenStdDev = 0
 
-		simulator.config.PrefillOverhead = 100
-		simulator.config.PrefillTimePerToken = 200
-		simulator.config.PrefillTimeStdDev = 80
+		simulator.config.PrefillOverhead = milliseconds(100)
+		simulator.config.PrefillTimePerToken = milliseconds(200)
+		simulator.config.PrefillTimeStdDev = milliseconds(80)
 
 		ttft := simulator.getWaitTimeToFirstToken(128, 0, false)
 
@@ -135,16 +141,16 @@ var _ = Describe("Check random latencies", Ordered, func() {
 		simulator.config.TimeToFirstToken = 0
 		simulator.config.TimeToFirstTokenStdDev = 0
 
-		simulator.config.PrefillOverhead = 100
-		simulator.config.PrefillTimePerToken = 200
-		simulator.config.PrefillTimeStdDev = 80
+		simulator.config.PrefillOverhead = milliseconds(100)
+		simulator.config.PrefillTimePerToken = milliseconds(200)
+		simulator.config.PrefillTimeStdDev = milliseconds(80)
 
 		ttft := simulator.getWaitTimeToFirstToken(128, 0, false)
 		Expect(ttft).NotTo(BeNumerically("==", 0))
 	})
 
 	DescribeTable("time to first token is against number of prompt tokens with std",
-		func(prefillOverhead int, prefillTimePerToken int, stdDev int, nTokens int, nCachedTokens int) {
+		func(prefillOverhead common.Duration, prefillTimePerToken common.Duration, stdDev common.Duration, nTokens int, nCachedTokens int) {
 			simulator.config.TimeToFirstToken = 0
 			simulator.config.PrefillOverhead = prefillOverhead
 			simulator.config.PrefillTimePerToken = prefillTimePerToken
@@ -152,54 +158,54 @@ var _ = Describe("Check random latencies", Ordered, func() {
 
 			ttft := simulator.getWaitTimeToFirstToken(nTokens, nCachedTokens, false)
 
-			expectedTTFT := prefillOverhead + prefillTimePerToken*(nTokens-nCachedTokens)
+			expectedTTFT := prefillOverhead + prefillTimePerToken*common.Duration(nTokens-nCachedTokens)
 			Expect(ttft).To(BeNumerically(">=", int(float64(expectedTTFT)*0.3)))
 			Expect(ttft).To(BeNumerically("<=", int(float64(expectedTTFT)*1.7)))
 		},
-		func(prefillOverhead int, prefillTimePerToken, stdDev int, nTokens int, nCachedTokens int) string {
+		func(prefillOverhead common.Duration, prefillTimePerToken, stdDev common.Duration, nTokens int, nCachedTokens int) string {
 			return fmt.Sprintf("prefillOverhead: %d, prefillTimePerToken: %d, stdDev: %d, nTokens: %d nCachedTokens: %d",
 				prefillOverhead, prefillTimePerToken, stdDev, nTokens, nCachedTokens)
 		},
-		Entry("single token", 100, 50, 10, 1, 0),
-		Entry("single token big std", 100, 50, 70, 1, 0),
-		Entry("stddev is 0", 100, 50, 0, 1, 0),
-		Entry("medium overhead, 512 tokens", 200, 1000, 150, 512, 0),
-		Entry("large overhead, 1024 tokens", 2000, 3000, 800, 1024, 0),
-		Entry("very long prompt", 150, 200, 70, 20000, 0),
-		Entry("medium overhead, 512 tokens, 256 cached", 200, 1000, 150, 512, 256),
-		Entry("large overhead, 1024 tokens, 1008 cached", 2000, 3000, 800, 1024, 1008),
-		Entry("very long prompt, 1024 cached", 150, 200, 70, 20000, 1024),
+		Entry("single token", milliseconds(100), milliseconds(50), milliseconds(10), 1, 0),
+		Entry("single token big std", milliseconds(100), milliseconds(50), milliseconds(70), 1, 0),
+		Entry("stddev is 0", milliseconds(100), milliseconds(50), milliseconds(0), 1, 0),
+		Entry("medium overhead, 512 tokens", milliseconds(200), milliseconds(1000), milliseconds(150), 512, 0),
+		Entry("large overhead, 1024 tokens", milliseconds(2000), milliseconds(3000), milliseconds(800), 1024, 0),
+		Entry("very long prompt", milliseconds(150), milliseconds(200), milliseconds(70), 20000, 0),
+		Entry("medium overhead, 512 tokens, 256 cached", milliseconds(200), milliseconds(1000), milliseconds(150), 512, 256),
+		Entry("large overhead, 1024 tokens, 1008 cached", milliseconds(2000), milliseconds(3000), milliseconds(800), 1024, 1008),
+		Entry("very long prompt, 1024 cached", milliseconds(150), milliseconds(200), milliseconds(70), 20000, 1024),
 	)
 
 	DescribeTable("time to first token is against number of prompt tokens",
-		func(prefillOverhead int, prefillTimePerToken int, nTokens int, nCachedTokens int) {
+		func(prefillOverhead common.Duration, prefillTimePerToken common.Duration, nTokens int, nCachedTokens int) {
 			simulator.config.TimeToFirstToken = 0
 			simulator.config.PrefillOverhead = prefillOverhead
 			simulator.config.PrefillTimePerToken = prefillTimePerToken
 			simulator.config.PrefillTimeStdDev = 0
 
 			ttft := simulator.getWaitTimeToFirstToken(nTokens, nCachedTokens, false)
-			expectedTTFT := prefillOverhead + prefillTimePerToken*(nTokens-nCachedTokens)
+			expectedTTFT := prefillOverhead + prefillTimePerToken*common.Duration(nTokens-nCachedTokens)
 			Expect(ttft).To(Equal(expectedTTFT))
 		},
-		func(prefillOverhead int, prefillTimePerToken, nTokens int, nCachedTokens int) string {
+		func(prefillOverhead common.Duration, prefillTimePerToken common.Duration, nTokens int, nCachedTokens int) string {
 			return fmt.Sprintf("prefillOverhead: %d, prefillTimePerToken: %d, nTokens: %d nCachedTokens: %d",
 				prefillOverhead, prefillTimePerToken, nTokens, nCachedTokens)
 		},
-		Entry("single token", 100, 50, 1, 0),
-		Entry("medium overhead, 512 tokens", 200, 1000, 512, 0),
-		Entry("large overhead, 1024 tokens", 2000, 3000, 1024, 0),
-		Entry("very long prompt", 150, 200, 20000, 0),
-		Entry("medium overhead, 512 tokens, 256 cached", 200, 1000, 512, 256),
-		Entry("large overhead, 1024 tokens, 128 cached", 2000, 3000, 1024, 128),
-		Entry("very long prompt, 1024 cached", 150, 200, 20000, 1024),
+		Entry("single token", milliseconds(100), milliseconds(50), 1, 0),
+		Entry("medium overhead, 512 tokens", milliseconds(200), milliseconds(1000), 512, 0),
+		Entry("large overhead, 1024 tokens", milliseconds(2000), milliseconds(3000), 1024, 0),
+		Entry("very long prompt", milliseconds(150), milliseconds(200), 20000, 0),
+		Entry("medium overhead, 512 tokens, 256 cached", milliseconds(200), milliseconds(1000), 512, 256),
+		Entry("large overhead, 1024 tokens, 128 cached", milliseconds(2000), milliseconds(3000), 1024, 128),
+		Entry("very long prompt, 1024 cached", milliseconds(150), milliseconds(200), 20000, 1024),
 	)
 
 	It("when <kv-cache-transfer-latency> not 0, ignore <kv-cache-transfer-overhead>", func() {
-		simulator.config.KVCacheTransferLatency = 200
+		simulator.config.KVCacheTransferLatency = milliseconds(200)
 		simulator.config.KVCacheTransferLatencyStdDev = 0
 
-		simulator.config.KVCacheTransferTimePerToken = 100
+		simulator.config.KVCacheTransferTimePerToken = milliseconds(100)
 		simulator.config.KVCacheTransferTimeStdDev = 0
 
 		ttft := simulator.getWaitTimeToFirstToken(128, 0, true)
@@ -210,7 +216,7 @@ var _ = Describe("Check random latencies", Ordered, func() {
 		simulator.config.KVCacheTransferLatency = 0
 		simulator.config.KVCacheTransferLatencyStdDev = 0
 
-		simulator.config.KVCacheTransferTimePerToken = 100
+		simulator.config.KVCacheTransferTimePerToken = milliseconds(200)
 		simulator.config.KVCacheTransferTimeStdDev = 0
 
 		ttft := simulator.getWaitTimeToFirstToken(128, 0, true)
@@ -218,32 +224,32 @@ var _ = Describe("Check random latencies", Ordered, func() {
 	})
 
 	DescribeTable("kv cache transfer time against number of prompt tokens",
-		func(kvCacheTransTPT int, stddev int, nTokens int) {
+		func(kvCacheTransTPT common.Duration, stddev common.Duration, nTokens int) {
 			simulator.config.TimeToFirstToken = 0
-			simulator.config.PrefillOverhead = 1
+			simulator.config.PrefillOverhead = milliseconds(1)
 			simulator.config.KVCacheTransferTimePerToken = kvCacheTransTPT
 			simulator.config.KVCacheTransferTimeStdDev = stddev
 
 			ttft := simulator.getWaitTimeToFirstToken(nTokens, 0, true)
 
-			expectedTTFT := kvCacheTransTPT * nTokens
+			expectedTTFT := kvCacheTransTPT * common.Duration(nTokens)
 			Expect(ttft).To(BeNumerically(">=", int(float64(expectedTTFT)*0.3)))
 			Expect(ttft).To(BeNumerically("<=", int(float64(expectedTTFT)*1.7)))
 
 		},
-		func(kvCacheTransferTimePerToken int, stddev int, nTokens int) string {
+		func(kvCacheTransferTimePerToken common.Duration, stddev common.Duration, nTokens int) string {
 			return fmt.Sprintf("kvCacheTransferTimePerToken: %d stddev: %d nTokens: %d",
 				kvCacheTransferTimePerToken, stddev, nTokens)
 		},
-		Entry("single token", 100, 70, 1),
-		Entry("stddev is 0", 100, 0, 1),
-		Entry("medium overhead, 512 tokens", 200, 150, 512),
-		Entry("large overhead, 1024 tokens", 2000, 1800, 1024),
-		Entry("very long prompt", 150, 100, 20000),
+		Entry("single token", milliseconds(100), milliseconds(70), 1),
+		Entry("stddev is 0", milliseconds(100), milliseconds(0), 1),
+		Entry("medium overhead, 512 tokens", milliseconds(200), milliseconds(150), 512),
+		Entry("large overhead, 1024 tokens", milliseconds(2000), milliseconds(1800), 1024),
+		Entry("very long prompt", milliseconds(150), milliseconds(100), 20000),
 	)
 
 	It("when time-factor-under-load is 1, the time to first token should be equal to time-to-first-token", func() {
-		simulator.config.TimeToFirstToken = 42
+		simulator.config.TimeToFirstToken = milliseconds(42)
 		simulator.config.TimeToFirstTokenStdDev = 0
 		simulator.config.TimeFactorUnderLoad = 1.0
 
@@ -254,7 +260,7 @@ var _ = Describe("Check random latencies", Ordered, func() {
 	})
 
 	It("when time-factor-under-load is > 1, but max-num-seqs is 1, the factor will not take effect", func() {
-		simulator.config.TimeToFirstToken = 42
+		simulator.config.TimeToFirstToken = milliseconds(42)
 		simulator.config.TimeToFirstTokenStdDev = 0
 		simulator.config.TimeFactorUnderLoad = 100.0
 		simulator.config.MaxNumSeqs = 1
@@ -271,7 +277,7 @@ var _ = Describe("Check random latencies", Ordered, func() {
 
 	DescribeTable("when time-factor-under-load is > 1, and the sim is fully loaded, the time to first token should be time-factor-under-load * time-to-first-token",
 		func(timeFactorUnderLoad float64, maxNumOfReq int) {
-			simulator.config.TimeToFirstToken = 42
+			simulator.config.TimeToFirstToken = milliseconds(42)
 			simulator.config.TimeToFirstTokenStdDev = 0
 			simulator.config.TimeFactorUnderLoad = timeFactorUnderLoad
 			simulator.config.MaxNumSeqs = maxNumOfReq
@@ -294,7 +300,7 @@ var _ = Describe("Check random latencies", Ordered, func() {
 
 	DescribeTable("when time-factor-under-load is > 1, and the sim is partially loaded, the time to first token should be linear interpolation between time-to-first-token and time-factor-under-load * time-to-first-token",
 		func(timeFactorUnderLoad float64, maxNumOfReq int, nCurrNumOfReq int) {
-			simulator.config.TimeToFirstToken = 42
+			simulator.config.TimeToFirstToken = milliseconds(42)
 			simulator.config.TimeToFirstTokenStdDev = 0
 			simulator.config.TimeFactorUnderLoad = timeFactorUnderLoad
 			simulator.config.MaxNumSeqs = maxNumOfReq

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -678,10 +678,10 @@ func (s *VllmSimulator) sendResponse(reqCtx *openaiserverapi.CompletionReqCtx, r
 	nCachedPromptTokens := reqCtx.CompletionReq.GetNumberOfCachedPromptTokens()
 	startPrefill := time.Now()
 	ttft := s.getWaitTimeToFirstToken(usageData.PromptTokens, nCachedPromptTokens, reqCtx.CompletionReq.IsDoRemotePrefill())
-	time.Sleep(time.Duration(ttft) * time.Millisecond)
+	time.Sleep(ttft)
 
 	// report ttft in seconds
-	common.WriteToChannel(s.metrics.ttftChan, (float64(ttft) / 1000), s.logger, "metrics.ttftChan")
+	common.WriteToChannel(s.metrics.ttftChan, ttft.Seconds(), s.logger, "metrics.ttftChan")
 	common.WriteToChannel(s.metrics.reqPrefillTimeChan, time.Since(startPrefill).Seconds(), s.logger, "metrics.reqPrefillTimeChan")
 
 	startDecode := time.Now()
@@ -690,7 +690,7 @@ func (s *VllmSimulator) sendResponse(reqCtx *openaiserverapi.CompletionReqCtx, r
 		time.Sleep(time.Duration(perTokenLatency) * time.Millisecond)
 
 		// report tpot in seconds
-		common.WriteToChannel(s.metrics.tpotChan, (float64(perTokenLatency) / 1000), s.logger, "metrics.tpotChan")
+		common.WriteToChannel(s.metrics.tpotChan, perTokenLatency.Seconds(), s.logger, "metrics.tpotChan")
 	}
 	common.WriteToChannel(s.metrics.reqDecodeTimeChan, time.Since(startDecode).Seconds(), s.logger, "metrics.reqDecodeTimeChan")
 

--- a/pkg/llm-d-inference-sim/streaming.go
+++ b/pkg/llm-d-inference-sim/streaming.go
@@ -113,18 +113,18 @@ func (s *VllmSimulator) sendTokenChunks(context *streamingContext, w *bufio.Writ
 	startPrefill := time.Now()
 	// time to first token delay
 	ttft := s.getWaitTimeToFirstToken(context.nPromptTokens, context.nCachedPromptTokens, context.doRemotePrefill)
-	time.Sleep(time.Duration(ttft) * time.Millisecond)
+	time.Sleep(ttft)
 	// report ttft in seconds
-	common.WriteToChannel(s.metrics.ttftChan, (float64(ttft) / 1000), s.logger, "metrics.ttftChan")
+	common.WriteToChannel(s.metrics.ttftChan, ttft.Seconds(), s.logger, "metrics.ttftChan")
 	common.WriteToChannel(s.metrics.reqPrefillTimeChan, time.Since(startPrefill).Seconds(), s.logger, "metrics.reqPrefillTimeChan")
 
 	startDecode := time.Now()
 	for i, token := range genTokens {
 		if i != 0 {
 			interTokenLat := s.getInterTokenLatency()
-			time.Sleep(time.Duration(interTokenLat) * time.Millisecond)
+			time.Sleep(interTokenLat)
 			// report tpot in seconds
-			common.WriteToChannel(s.metrics.tpotChan, (float64(interTokenLat) / 1000), s.logger, "metrics.tpotChan")
+			common.WriteToChannel(s.metrics.tpotChan, interTokenLat.Seconds(), s.logger, "metrics.tpotChan")
 		}
 
 		var toolChunkInsert *openaiserverapi.ToolCall


### PR DESCRIPTION
Change all latency configuration parameters from miliseconds to custom Duration format.
It supports both an integer (interpreted as milliseconds for backward compatibility) and a duration string (e.g., "100ms", "1s").

ref: https://github.com/llm-d/llm-d-inference-sim/issues/287