### PR TITLE
Add a 'script' to set the PYTHONPATH env var

### DIFF
--- a/env-setup.sh
+++ b/env-setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export PYTHONPATH=${PYTHONPATH}:$(go env GOPATH)/pkg/mod/github.com/llm-d/llm-d-kv-cache-manager@$(go list -m -f '{{.Version}}' github.com/llm-d/llm-d-kv-cache-manager)/pkg/preprocessing/chat_completions
+


### PR DESCRIPTION
This PR adds a script (`env-setup.sh` that can be used to set the PYTHONPATH environment variable needed to run the llm-d-inference-sim locally due to the tokenization code used.

To use this in the terminal shell that you want to run the llm-d-inference-sim, simply:
```bash
. env-setup.sh
```
and then run the simulator as usuall