### PR TITLE
🌱 Standardize governance workflows via llm-d-infra

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+# Canonical Dependabot configuration for llm-d repos
+# Copy this file to .github/dependabot.yml in your repo
+#
+# Covers: Go modules, GitHub Actions, Docker base images
+# Remove sections that don't apply to your repo
+
+version: 2
+updates:
+
+  # Go module updates
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps(go)"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    ignore:
+      # Ignore major and minor updates to Go toolchain
+      - dependency-name: "go"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore major and minor version updates to k8s packages
+      - dependency-name: "k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "sigs.k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore major updates for all packages
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    commit-message:
+      prefix: "deps(actions)"
+
+  # Docker base image updates
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(docker)"
+
+  # Python dependencies (uncomment if repo uses pip/requirements.txt)
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   labels:
+  #     - "dependencies"
+  #   commit-message:
+  #     prefix: "deps(pip)"

--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -1,0 +1,8 @@
+name: Check Typos
+on:
+  pull_request:
+  push:
+
+jobs:
+  typos:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@2b273d6

--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -1,0 +1,9 @@
+name: Check Signed Commits
+on: pull_request_target
+
+jobs:
+  signed-commits:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@2b273d6
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -1,25 +1,11 @@
-name: Markdown Link Checker
-
+name: Markdown Link Check
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  lychee:
-    name: Check Markdown Links
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install lychee v0.18.1
-        run: |
-          curl -Ls https://github.com/lycheeverse/lychee/releases/download/lychee-v0.18.1/lychee-x86_64-unknown-linux-gnu.tar.gz | tar xz
-          sudo mv lychee /usr/local/bin
-      - name: Run lychee on Markdown files with config
-        run: |
-          find . -name "*.md" -print0 | xargs -0 lychee --config .lychee.toml --verbose --no-progress
+  links:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@2b273d6

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -1,0 +1,8 @@
+name: Non-Main Gatekeeper
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  gatekeeper:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@2b273d6

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -1,37 +1,12 @@
-# Run specified actions or jobs for issue and PR comments
-
-name: "Prow github actions"
+name: Prow Commands
 on:
   issue_comment:
     types: [created]
 
-# Grant additional permissions to the GITHUB_TOKEN
 permissions:
-  # Allow labeling issues
   issues: write
-  # Allow adding a review to a pull request
   pull-requests: write
 
 jobs:
-  prow-execute:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          prow-commands: "/assign
-            /unassign
-            /approve
-            /retitle
-            /area
-            /kind
-            /priority
-            /remove
-            /lgtm
-            /close
-            /reopen
-            /lock
-            /milestone
-            /hold
-            /cc
-            /uncc"
+  prow:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@2b273d6

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -1,18 +1,8 @@
-# This Github workflow will check every 5m for PRs with the lgtm label and will attempt to automatically merge them.
-# If the hold label is present, it will block automatic merging.
-
-name: "Prow merge on lgtm label"
+name: Prow Auto-merge
 on:
   schedule:
-  - cron: "*/5 * * * *" # every 5 minutes
+    - cron: "*/5 * * * *"
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
-        with:
-          jobs: 'lgtm'
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          merge-method: 'squash'
-          
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@2b273d6

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -1,11 +1,6 @@
-name: Run Jobs on PR
+name: Prow Remove LGTM
 on: pull_request
 
 jobs:
-  execute:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
-        with:
-          jobs: lgtm
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+  remove-lgtm:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@2b273d6

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,38 +1,11 @@
-name: 'Mark stale issues'
-
+name: Mark Stale Issues
 on:
   schedule:
     - cron: '0 1 * * *'
 
 jobs:
-  stale-issues:
-    runs-on: ubuntu-latest
+  stale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@2b273d6
     permissions:
       issues: write
-    steps:
-      - name: 'Mark stale issues'
-        uses: actions/stale@v9
-        with:
-          days-before-issue-stale: 90
-          days-before-pr-stale: -1
-          days-before-close: -1
-          stale-issue-label: 'lifecycle/stale'
-          exempt-issue-labels: 'lifecycle/rotten'
-
-      - name: 'Mark rotten issues'
-        uses: actions/stale@v9
-        with:
-          days-before-issue-stale: 30
-          days-before-pr-stale: -1
-          days-before-close: -1
-          stale-issue-label: 'lifecycle/rotten'
-          only-labels: 'lifecycle/stale'
-          labels-to-remove-when-stale: 'lifecycle/stale'
-
-      - name: 'Close rotten issues'
-        uses: actions/stale@v9
-        with:
-          days-before-stale: -1
-          days-before-issue-close: 30
-          days-before-pr-close: -1
-          stale-issue-label: 'lifecycle/rotten'
+      pull-requests: write

--- a/.github/workflows/unstale.yaml
+++ b/.github/workflows/unstale.yaml
@@ -1,27 +1,12 @@
-name: 'Unstale Issue'
-
+name: Unstale Issues
 on:
   issues:
-    types: [ reopened ]
+    types: [reopened]
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 jobs:
-  remove-stale:
-    runs-on: ubuntu-latest
+  unstale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@2b273d6
     permissions:
       issues: write
-    if: >-
-      github.event.issue.state == 'open' &&
-      (contains(github.event.issue.labels.*.name, 'lifecycle/stale') || 
-       contains(github.event.issue.labels.*.name, 'lifecycle/rotten'))
-    steps:
-      - name: 'Checkout repository'
-        uses: actions/checkout@v5
-
-      - name: 'Remove stale labels'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Removing 'stale' label from issue #${{ github.event.issue.number }}"
-          gh issue edit ${{ github.event.issue.number }} --remove-label "lifecycle/stale,lifecycle/rotten"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,60 @@
+# Canonical pre-commit configuration for llm-d repos
+# Copy this file to the root of your repo
+#
+# Install: pip install pre-commit && pre-commit install
+# Run all: pre-commit run --all-files
+
+repos:
+  # General file hygiene hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--unsafe]  # allows custom YAML tags used in k8s
+      - id: check-json
+      - id: check-added-large-files
+        args: [--maxkb=1000]
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+      - id: check-case-conflict
+
+  # Shell script linting (requires shellcheck installed)
+  - repo: local
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+        language: system
+        entry: shellcheck
+        args: [-x, --severity=warning]
+        types: [shell]
+
+  # Dockerfile linting (requires hadolint installed)
+  - repo: local
+    hooks:
+      - id: hadolint-docker
+        name: hadolint
+        language: system
+        entry: hadolint
+        args: [--failure-threshold, error]
+        files: Dockerfile(\..*)?$
+        types: [file]
+
+  # Markdown linting
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.47.0
+    hooks:
+      - id: markdownlint
+        args: [--fix]
+
+  # YAML linting
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        args:
+          - -d
+          - >-
+            {extends: default, rules: {line-length: {max: 250},
+            document-start: disable, truthy: {check-keys: false}}}


### PR DESCRIPTION
## Summary
- Replace local Prow, stale/unstale, and md-link-check workflows with thin callers to `llm-d/llm-d-infra` reusable workflows
- Add new governance workflows: signed-commits, typos, non-main-gatekeeper
- Add standardized pre-commit config (shellcheck, hadolint, markdownlint, yamllint)
- Add Dependabot config for Go modules, GitHub Actions, and Docker

## Test plan
- [ ] Verify Prow commands still work
- [ ] Run `pre-commit run --all-files` locally to check for false positives
- [ ] Confirm new workflows trigger correctly
- [ ] Review Dependabot config

Depends on: https://github.com/llm-d/llm-d-infra/pull/2 (already merged)