### PR TITLE
🌱 Add typos config, Dependabot, and pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# Dependabot configuration for llm-d-inference-sim
+# Based on canonical config from llm-d/llm-d-infra
+
+version: 2
+updates:
+
+  # Go module updates
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps(go)"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    ignore:
+      - dependency-name: "go"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "sigs.k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      go-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    commit-message:
+      prefix: "deps(actions)"
+
+  # Docker base image updates
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(docker)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,60 @@
+# Canonical pre-commit configuration for llm-d repos
+# Based on template from llm-d/llm-d-infra
+#
+# Install: pip install pre-commit && pre-commit install
+# Run all: pre-commit run --all-files
+
+repos:
+  # General file hygiene hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--unsafe]  # allows custom YAML tags used in k8s
+      - id: check-json
+      - id: check-added-large-files
+        args: [--maxkb=1000]
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+      - id: check-case-conflict
+
+  # Shell script linting (requires shellcheck installed)
+  - repo: local
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+        language: system
+        entry: shellcheck
+        args: [-x, --severity=warning]
+        types: [shell]
+
+  # Dockerfile linting (requires hadolint installed)
+  - repo: local
+    hooks:
+      - id: hadolint-docker
+        name: hadolint
+        language: system
+        entry: hadolint
+        args: [--failure-threshold, error]
+        files: Dockerfile(\..*)?$
+        types: [file]
+
+  # Markdown linting
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.47.0
+    hooks:
+      - id: markdownlint
+        args: [--fix]
+
+  # YAML linting
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        args:
+          - -d
+          - >-
+            {extends: default, rules: {line-length: {max: 250},
+            document-start: disable, truthy: {check-keys: false}}}

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,33 @@
+# Typos configuration for llm-d-inference-sim
+# https://github.com/crate-ci/typos
+
+[default.extend-words]
+# Pre-existing typos in codebase (to be fixed separately)
+tranfer = "tranfer"
+dfined = "dfined"
+emmits = "emmits"
+weghts = "weghts"
+multuple = "multuple"
+allways = "allways"
+Aready = "Aready"
+availbale = "availbale"
+boudaries = "boudaries"
+boudary = "boudary"
+Boudary = "Boudary"
+bounary = "bounary"
+bucker = "bucker"
+choise = "choise"
+Clent = "Clent"
+configuraiton = "configuraiton"
+Convertion = "Convertion"
+currenlty = "currenlty"
+defin = "defin"
+detailes = "detailes"
+ignor = "ignor"
+intput = "intput"
+listents = "listents"
+passsed = "passsed"
+referense = "referense"
+Reponses = "Reponses"
+suppored = "suppored"
+Wating = "Wating"


### PR DESCRIPTION
## Summary
- Add `_typos.toml` to suppress pre-existing typos so the org-wide typos check passes cleanly
- Add Dependabot config for Go modules, GitHub Actions, and Docker base images
- Add canonical `.pre-commit-config.yaml` from [llm-d/llm-d-infra](https://github.com/llm-d/llm-d-infra)

Part of the org-wide effort to standardize CI tooling across all llm-d repos.

## Test plan
- [ ] Verify typos check passes in CI
- [ ] Verify Dependabot creates dependency update PRs on schedule
- [ ] Verify pre-commit hooks work locally: `pip install pre-commit && pre-commit run --all-files`

cc @diegocastanibm @maugustosilva