### PR TITLE
docs(example): Fix indentation for POD_IP valueFrom field

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -37,9 +37,9 @@ spec:
                 apiVersion: v1
                 fieldPath: metadata.namespace
           - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         ports:
         - containerPort: 8000
           name: http


### PR DESCRIPTION
fix example
- manifests/deployment.yaml

which is erroring with:
```
kubectl apply -f https://raw.githubusercontent.com/llm-d/llm-d-inference-sim/main/manifests/deployment.yaml
error: error parsing https://raw.githubusercontent.com/llm-d/llm-d-inference-sim/main/manifests/deployment.yaml: error converting YAML to JSON: yaml: line 39: did not find expected '-' indicator
```