### PR TITLE
fix: graceful shutdown when browser holds open connections

### DIFF
--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
@@ -58,6 +59,14 @@ func (c *Communication) start(ctx context.Context) error {
 	}
 
 	m := cmux.New(listener)
+
+	// Timeout idle connections during protocol matching to avoid blocking shutdown.
+	m.SetReadTimeout(5 * time.Second)
+
+	go func() {
+		<-ctx.Done()
+		listener.Close() //nolint:errcheck
+	}()
 
 	if !c.simulator.Context.Config.MMEncoderOnly {
 		// gRPC uses HTTP/2

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -109,13 +110,24 @@ func (c *Communication) StartHTTPServer(ctx context.Context, listener net.Listen
 	case <-ctx.Done():
 		c.logger.V(logging.INFO).Info("Shutdown signal received, shutting down HTTP server gracefully")
 
-		// Gracefully shutdown the server
-		if err := server.Shutdown(); err != nil {
-			c.logger.Error(err, "error during server shutdown")
-			return err
+		const shutdownTimeout = 5 * time.Second
+		done := make(chan error, 1)
+		go func() {
+			done <- server.Shutdown()
+		}()
+
+		select {
+		case err := <-done:
+			// Ignore closed-listener errors from cmux shutting down first.
+			if err != nil && !errors.Is(err, net.ErrClosed) {
+				c.logger.Error(err, "error during server shutdown")
+				return err
+			}
+		case <-time.After(shutdownTimeout):
+			c.logger.V(logging.INFO).Info("Shutdown timed out, forcing close")
 		}
 
-		c.logger.V(logging.INFO).Info("Server stopped")
+		c.logger.V(logging.INFO).Info("HTTP server stopped")
 		return nil
 
 	case err := <-serverErr:


### PR DESCRIPTION
## Bug

When running the simulator locally and a browser has an open connection (e.g. browsing `http://localhost:8080/metrics`), pressing Ctrl+C hangs indefinitely. The server logs "Shutdown signal received, shutting down HTTP server gracefully" but never reaches "Server stopped". A second Ctrl+C force-kills the process via `os.Exit(1)`.

## How to reproduce

1. `make build`
2. `./bin/llm-d-inference-sim --model random --port 8080`
3. Open `http://localhost:8080/metrics` in a browser (Chrome/Edge)
4. Press Ctrl+C in the terminal
5. Observe: server logs shutdown message but hangs, never exits
6. Press Ctrl+C again: force exit

## Root cause

Two issues prevent clean shutdown:

1. **`fasthttp.Server.Shutdown()`** blocks until all active connections close. Browsers keep HTTP/1.1 keep-alive connections open indefinitely, so `Shutdown()` never returns.

2. **`cmux.Serve()`** waits for all in-flight protocol-matching goroutines to finish before returning. Browsers open speculative TCP connections that send no data, so cmux's protocol-matching read blocks forever, and `Serve()` never completes its internal `wg.Wait()`.

## Changes

**`pkg/communication/communication.go`**
- Set `m.SetReadTimeout(5s)` on cmux so idle connections during protocol matching time out instead of blocking shutdown.
- Close the root listener on context cancellation so `m.Serve()` unblocks.

**`pkg/communication/http.go`**
- Wrap `server.Shutdown()` in a goroutine with a 5-second timeout so it does not block forever on keep-alive connections.
- Ignore `net.ErrClosed` from `Shutdown()` since cmux may close the shared listener first — this is expected during coordinated shutdown.
- Rename log message to "HTTP server stopped" for consistency with gRPC.

## Testing

Manually verified on WSL2 (Ubuntu) with Chrome/Edge on Windows:
1. Built and ran the simulator (`./bin/llm-d-inference-sim --model random --port 8080`)
2. Opened `http://localhost:8080/metrics` in browser
3. Pressed Ctrl+C — server shuts down cleanly and the process exits, no hang
4. Existing unit tests pass (`make test` — the only failure is the pre-existing `dataset` suite which requires Docker/testcontainers)

Fixes #405