### PR TITLE
Fix display model name behavior

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -81,6 +81,9 @@ type Configuration struct {
 	Port int `yaml:"port" json:"port"`
 	// Model defines the current base model name
 	Model string `yaml:"model" json:"model"`
+	// DisplayModelName defines the model name that will be shown in API responses
+	// If ServedModelNames are not set, it defaults to the value of Model
+	DisplayModelName string
 	// ServedModelNames is one or many model names exposed by the API
 	ServedModelNames []string `yaml:"served-model-name" json:"served-model-name"`
 	// MaxLoras defines maximum number of loaded LoRAs
@@ -359,6 +362,9 @@ func (c *Configuration) validate() error {
 	if len(c.ServedModelNames) == 0 {
 		c.ServedModelNames = []string{c.Model}
 	}
+
+	// set display model name
+	c.DisplayModelName = c.ServedModelNames[0]
 
 	if c.Mode != ModeEcho && c.Mode != ModeRandom {
 		return fmt.Errorf("invalid mode '%s', valid values are 'random' and 'echo'", c.Mode)

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -34,11 +34,24 @@ func createSimConfig(args []string) (*Configuration, error) {
 	return ParseCommandParamsAndLoadConfig()
 }
 
-func createDefaultConfig(model string) *Configuration {
+func createConfigWithModel(model string, servedModelNames []string) *Configuration {
 	c := newConfig()
 
 	c.Model = model
-	c.ServedModelNames = []string{c.Model}
+	if len(servedModelNames) > 0 {
+		c.ServedModelNames = servedModelNames
+	} else {
+		c.ServedModelNames = []string{c.Model}
+	}
+
+	c.DisplayModelName = c.ServedModelNames[0]
+
+	return c
+}
+
+func createDefaultConfig(model string, servedModelNames []string) *Configuration {
+	c := createConfigWithModel(model, servedModelNames)
+
 	c.MaxNumSeqs = 5
 	c.MaxLoras = 2
 	c.MaxCPULoras = 5
@@ -62,9 +75,7 @@ var _ = Describe("Simulator configuration", func() {
 	tests := make([]testCase, 0)
 
 	// Simple config with a few parameters
-	c := newConfig()
-	c.Model = TestModelName
-	c.ServedModelNames = []string{c.Model}
+	c := createConfigWithModel(TestModelName, nil)
 	c.MaxCPULoras = 1
 	c.Seed = 100
 	test := testCase{
@@ -75,9 +86,8 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Config from config.yaml file
-	c = createDefaultConfig(QwenModelName)
+	c = createDefaultConfig(QwenModelName, []string{"model1", "model2"})
 	c.Port = 8001
-	c.ServedModelNames = []string{"model1", "model2"}
 	c.LoraModules = []LoraModule{{Name: "lora1", Path: "/path/to/lora1"}, {Name: "lora2", Path: "/path/to/lora2"}}
 	test = testCase{
 		name:           "config file",
@@ -91,9 +101,8 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Config from config.yaml file plus command line args
-	c = createDefaultConfig(TestModelName)
+	c = createDefaultConfig(TestModelName, []string{"alias1", "alias2"})
 	c.Port = 8002
-	c.ServedModelNames = []string{"alias1", "alias2"}
 	c.Seed = 100
 	c.LoraModules = []LoraModule{{Name: "lora3", Path: "/path/to/lora3"}, {Name: "lora4", Path: "/path/to/lora4"}}
 	c.LoraModulesString = []string{
@@ -113,7 +122,7 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Config from config.yaml file plus command line args with different format
-	c = createDefaultConfig(TestModelName)
+	c = createDefaultConfig(TestModelName, nil)
 	c.Port = 8002
 	c.LoraModules = []LoraModule{{Name: "lora3", Path: "/path/to/lora3"}}
 	c.LoraModulesString = []string{
@@ -130,7 +139,7 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Config from config.yaml file plus command line args with empty string
-	c = createDefaultConfig(TestModelName)
+	c = createDefaultConfig(TestModelName, nil)
 	c.Port = 8002
 	c.LoraModules = []LoraModule{{Name: "lora3", Path: "/path/to/lora3"}}
 	c.LoraModulesString = []string{
@@ -147,9 +156,8 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Config from config.yaml file plus command line args with empty string for loras
-	c = createDefaultConfig(QwenModelName)
+	c = createDefaultConfig(QwenModelName, []string{"model1", "model2"})
 	c.Port = 8001
-	c.ServedModelNames = []string{"model1", "model2"}
 	c.LoraModulesString = []string{}
 	test = testCase{
 		name:           "config file with command line args with empty string for loras",
@@ -159,9 +167,8 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Config from config.yaml file plus command line args with empty parameter for loras
-	c = createDefaultConfig(QwenModelName)
+	c = createDefaultConfig(QwenModelName, []string{"model1", "model2"})
 	c.Port = 8001
-	c.ServedModelNames = []string{"model1", "model2"}
 	c.LoraModulesString = []string{}
 	test = testCase{
 		name:           "config file with command line args with empty parameter for loras",
@@ -171,9 +178,8 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Config from config_with_duration_latency.yaml file plus command line args with empty parameter for loras
-	c = createDefaultConfig(QwenModelName)
+	c = createDefaultConfig(QwenModelName, []string{"model1", "model2"})
 	c.Port = 8001
-	c.ServedModelNames = []string{"model1", "model2"}
 	c.LoraModulesString = []string{}
 	c.TimeToFirstToken = Duration(4 * time.Second)
 	c.InterTokenLatency = Duration(2 * time.Second)
@@ -186,7 +192,7 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Config from basic-config.yaml file plus command line args with time to copy cache
-	c = createDefaultConfig(QwenModelName)
+	c = createDefaultConfig(QwenModelName, nil)
 	c.Port = 8001
 	// basic config file does not contain properties related to lora
 	c.MaxLoras = 1
@@ -200,7 +206,7 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Config from config_with_fake.yaml file
-	c = createDefaultConfig(QwenModelName)
+	c = createDefaultConfig(QwenModelName, nil)
 	c.FakeMetrics = &FakeMetrics{
 		RunningRequests: FakeMetricWithFunction{FixedValue: 16},
 		WaitingRequests: FakeMetricWithFunction{
@@ -244,9 +250,7 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Fake metrics from command line
-	c = newConfig()
-	c.Model = TestModelName
-	c.ServedModelNames = []string{c.Model}
+	c = createConfigWithModel(TestModelName, nil)
 	c.MaxCPULoras = 1
 	c.Seed = 100
 	c.FakeMetrics = &FakeMetrics{
@@ -279,7 +283,7 @@ var _ = Describe("Simulator configuration", func() {
 	tests = append(tests, test)
 
 	// Fake metrics from both the config file and command line
-	c = createDefaultConfig(QwenModelName)
+	c = createDefaultConfig(QwenModelName, nil)
 	c.FakeMetrics = &FakeMetrics{
 		RunningRequests:        FakeMetricWithFunction{FixedValue: 10},
 		WaitingRequests:        FakeMetricWithFunction{FixedValue: 30},

--- a/pkg/llm-d-inference-sim/chat_completion.go
+++ b/pkg/llm-d-inference-sim/chat_completion.go
@@ -53,7 +53,7 @@ func (c *ChatCompletionRequest) validate(toolsValidator *toolsValidator) (string
 
 func (c *ChatCompletionRequest) buildRequestContext(simCtx *SimContext, channel common.Channel[*ResponseInfo]) requestContext {
 	reqCtx := &chatCompletionReqCtx{
-		baseRequestContext: newBaseRequestContext(simCtx, channel, c.GetModel()),
+		baseRequestContext: newBaseRequestContext(simCtx, channel),
 		req:                c,
 	}
 	// wire chatCompletionReqCtx into embedded requestContext interface

--- a/pkg/llm-d-inference-sim/fake_metrics.go
+++ b/pkg/llm-d-inference-sim/fake_metrics.go
@@ -159,7 +159,6 @@ func (s *SimContext) initFakeHistogram(hist *prometheus.HistogramVec, bucketsBou
 	var valueToObserve float64
 	var total int64
 	numOfBoundaries := len(bucketsBoundaries)
-	modelName := s.getDisplayedModelName(s.Config.Model)
 
 	if len(bucketsSamplesCount) == 0 || len(bucketsBoundaries) == 0 {
 		return nil
@@ -178,7 +177,7 @@ func (s *SimContext) initFakeHistogram(hist *prometheus.HistogramVec, bucketsBou
 
 		for range bucketSamplesCount {
 			// create required number of observations for the calculated sample
-			hist.WithLabelValues(modelName).Observe(valueToObserve)
+			hist.WithLabelValues(s.Config.DisplayModelName).Observe(valueToObserve)
 		}
 
 		total += int64(bucketSamplesCount) * int64(valueToObserve)
@@ -201,22 +200,20 @@ func (s *SimContext) initFakeHistogram(hist *prometheus.HistogramVec, bucketsBou
 // all configured keys and an empty oldFakeMetrics) and at runtime via the POST
 // /fake_metrics HTTP endpoint (with only the keys the caller supplied).
 func (s *SimContext) UpdateFakeMetrics(fakeMetricsMap map[string]any, oldFakeMetrics *common.FakeMetrics) error {
-	modelName := s.getDisplayedModelName(s.Config.Model)
-
 	var generatedFakeMetricsWasEmpty bool
 	if len(s.metrics.generatedFakeMetrics) == 0 {
 		generatedFakeMetricsWasEmpty = true
 	}
 	if _, ok := fakeMetricsMap["running-requests"]; ok {
-		s.setFakeMetricWithFunction(modelName, &s.Config.FakeMetrics.RunningRequests, s.metrics.runningRequests,
+		s.setFakeMetricWithFunction(s.Config.DisplayModelName, &s.Config.FakeMetrics.RunningRequests, s.metrics.runningRequests,
 			s.metrics.runReqChan, true)
 	}
 	if _, ok := fakeMetricsMap["waiting-requests"]; ok {
-		s.setFakeMetricWithFunction(modelName, &s.Config.FakeMetrics.WaitingRequests, s.metrics.waitingRequests,
+		s.setFakeMetricWithFunction(s.Config.DisplayModelName, &s.Config.FakeMetrics.WaitingRequests, s.metrics.waitingRequests,
 			s.metrics.waitingReqChan, true)
 	}
 	if _, ok := fakeMetricsMap["kv-cache-usage"]; ok {
-		s.setFakeMetricWithFunction(modelName, &s.Config.FakeMetrics.KVCacheUsagePercentage, s.metrics.kvCacheUsagePercentage,
+		s.setFakeMetricWithFunction(s.Config.DisplayModelName, &s.Config.FakeMetrics.KVCacheUsagePercentage, s.metrics.kvCacheUsagePercentage,
 			s.metrics.kvCacheUsageChan, false)
 	}
 
@@ -315,7 +312,7 @@ func (s *SimContext) UpdateFakeMetrics(fakeMetricsMap map[string]any, oldFakeMet
 	}
 
 	if err := s.updateTokenMetrics(
-		modelName, buckets, fakeMetricsMap,
+		s.Config.DisplayModelName, buckets, fakeMetricsMap,
 		"request-prompt-tokens", "total-prompt-tokens",
 		s.Config.FakeMetrics.RequestPromptTokens, oldFakeMetrics.RequestPromptTokens,
 		s.Config.FakeMetrics.TotalPromptTokens, oldFakeMetrics.TotalPromptTokens,
@@ -327,7 +324,7 @@ func (s *SimContext) UpdateFakeMetrics(fakeMetricsMap map[string]any, oldFakeMet
 	}
 
 	if err := s.updateTokenMetrics(
-		modelName, buckets, fakeMetricsMap,
+		s.Config.DisplayModelName, buckets, fakeMetricsMap,
 		"request-generation-tokens", "total-generation-tokens",
 		s.Config.FakeMetrics.RequestGenerationTokens, oldFakeMetrics.RequestGenerationTokens,
 		s.Config.FakeMetrics.TotalGenerationTokens, oldFakeMetrics.TotalGenerationTokens,
@@ -346,7 +343,7 @@ func (s *SimContext) UpdateFakeMetrics(fakeMetricsMap map[string]any, oldFakeMet
 			}
 		}
 		if s.Config.FakeMetrics.PrefixCacheQueries != nil {
-			s.metrics.prefixCacheQueries.WithLabelValues(modelName).Add(float64(*s.Config.FakeMetrics.PrefixCacheQueries))
+			s.metrics.prefixCacheQueries.WithLabelValues(s.Config.DisplayModelName).Add(float64(*s.Config.FakeMetrics.PrefixCacheQueries))
 		}
 	}
 
@@ -358,7 +355,7 @@ func (s *SimContext) UpdateFakeMetrics(fakeMetricsMap map[string]any, oldFakeMet
 			}
 		}
 		if s.Config.FakeMetrics.PrefixCacheHits != nil {
-			s.metrics.prefixCacheHits.WithLabelValues(modelName).Add(float64(*s.Config.FakeMetrics.PrefixCacheHits))
+			s.metrics.prefixCacheHits.WithLabelValues(s.Config.DisplayModelName).Add(float64(*s.Config.FakeMetrics.PrefixCacheHits))
 		}
 	}
 
@@ -370,7 +367,7 @@ func (s *SimContext) UpdateFakeMetrics(fakeMetricsMap map[string]any, oldFakeMet
 			}
 		}
 		for reason, requestSuccessTotal := range s.Config.FakeMetrics.RequestSuccessTotal {
-			s.metrics.requestSuccessTotal.WithLabelValues(modelName, reason).Add(float64(requestSuccessTotal))
+			s.metrics.requestSuccessTotal.WithLabelValues(s.Config.DisplayModelName, reason).Add(float64(requestSuccessTotal))
 		}
 	}
 

--- a/pkg/llm-d-inference-sim/generation.go
+++ b/pkg/llm-d-inference-sim/generation.go
@@ -37,7 +37,7 @@ func (g *GenerationRequest) validate(toolsValidator *toolsValidator) (string, in
 
 func (g *GenerationRequest) buildRequestContext(simCtx *SimContext, channel common.Channel[*ResponseInfo]) requestContext {
 	reqCtx := &generationReqCtx{
-		baseRequestContext: newBaseRequestContext(simCtx, channel, g.GetModel()),
+		baseRequestContext: newBaseRequestContext(simCtx, channel),
 		req:                g,
 	}
 	// wire generationReqCtx into embedded requestContext interface

--- a/pkg/llm-d-inference-sim/metrics.go
+++ b/pkg/llm-d-inference-sim/metrics.go
@@ -383,11 +383,9 @@ func (s *SimContext) setInitialPrometheusMetrics(cacheConfig *prometheus.GaugeVe
 		return s.setInitialFakeMetrics()
 	}
 
-	modelName := s.getDisplayedModelName(s.Config.Model)
-
-	s.metrics.runningRequests.WithLabelValues(modelName).Set(0)
-	s.metrics.waitingRequests.WithLabelValues(modelName).Set(0)
-	s.metrics.kvCacheUsagePercentage.WithLabelValues(modelName).Set(0)
+	s.metrics.runningRequests.WithLabelValues(s.Config.DisplayModelName).Set(0)
+	s.metrics.waitingRequests.WithLabelValues(s.Config.DisplayModelName).Set(0)
+	s.metrics.kvCacheUsagePercentage.WithLabelValues(s.Config.DisplayModelName).Set(0)
 
 	s.metrics.loraInfo.WithLabelValues(
 		strconv.Itoa(s.Config.MaxLoras),
@@ -432,7 +430,7 @@ func (s *SimContext) reportLoras() {
 func (s *SimContext) reportRunningRequests() {
 	if s.metrics.runningRequests != nil {
 		s.metrics.runningRequests.WithLabelValues(
-			s.getDisplayedModelName(s.Config.Model)).Set(float64(s.metrics.nRunningReqs))
+			s.Config.DisplayModelName).Set(float64(s.metrics.nRunningReqs))
 	}
 }
 
@@ -440,7 +438,7 @@ func (s *SimContext) reportRunningRequests() {
 func (s *SimContext) reportWaitingRequests() {
 	if s.metrics.waitingRequests != nil {
 		s.metrics.waitingRequests.WithLabelValues(
-			s.getDisplayedModelName(s.Config.Model)).Set(float64(s.metrics.nWaitingReqs))
+			s.Config.DisplayModelName).Set(float64(s.metrics.nWaitingReqs))
 	}
 }
 
@@ -450,16 +448,14 @@ func (s *SimContext) reportHistogramValue(hist *prometheus.HistogramVec, val flo
 		return
 	}
 	if hist != nil {
-		hist.WithLabelValues(
-			s.getDisplayedModelName(s.Config.Model)).Observe(val)
+		hist.WithLabelValues(s.Config.DisplayModelName).Observe(val)
 	}
 }
 
 // reportKVCacheUsage sets information about kv cache usage
 func (s *SimContext) reportKVCacheUsage(value float64) {
 	if s.metrics.kvCacheUsagePercentage != nil {
-		s.metrics.kvCacheUsagePercentage.WithLabelValues(
-			s.getDisplayedModelName(s.Config.Model)).Set(value)
+		s.metrics.kvCacheUsagePercentage.WithLabelValues(s.Config.DisplayModelName).Set(value)
 	}
 }
 
@@ -540,12 +536,12 @@ func (s *SimContext) reportPrefixCacheStats(stats kvcache.PrefixCacheStats) {
 	if s.Config.FakeMetrics != nil {
 		return
 	}
-	modelName := s.getDisplayedModelName(s.Config.Model)
+
 	if s.metrics.prefixCacheQueries != nil {
-		s.metrics.prefixCacheQueries.WithLabelValues(modelName).Add(float64(stats.QueriedTokens))
+		s.metrics.prefixCacheQueries.WithLabelValues(s.Config.DisplayModelName).Add(float64(stats.QueriedTokens))
 	}
 	if s.metrics.prefixCacheHits != nil {
-		s.metrics.prefixCacheHits.WithLabelValues(modelName).Add(float64(stats.CachedTokens))
+		s.metrics.prefixCacheHits.WithLabelValues(s.Config.DisplayModelName).Add(float64(stats.CachedTokens))
 	}
 }
 
@@ -716,17 +712,17 @@ type requestSuccessEvent struct {
 // recordRequestMetricsOnSuccess records metrics for a successfully completed request
 func (s *SimContext) recordRequestMetricsOnSuccess(promptTokens,
 	generationTokens int, genTokensPerChoice []int, maxTokens *int64, finishReason string) {
-	modelName := s.getDisplayedModelName(s.Config.Model)
-	s.metrics.requestPromptTokens.WithLabelValues(modelName).Observe(float64(promptTokens))
-	s.metrics.requestGenerationTokens.WithLabelValues(modelName).Observe(float64(generationTokens))
-	s.metrics.promptTokensTotal.WithLabelValues(modelName).Add(float64(promptTokens))
-	s.metrics.generationTokensTotal.WithLabelValues(modelName).Add(float64(generationTokens))
+
+	s.metrics.requestPromptTokens.WithLabelValues(s.Config.DisplayModelName).Observe(float64(promptTokens))
+	s.metrics.requestGenerationTokens.WithLabelValues(s.Config.DisplayModelName).Observe(float64(generationTokens))
+	s.metrics.promptTokensTotal.WithLabelValues(s.Config.DisplayModelName).Add(float64(promptTokens))
+	s.metrics.generationTokensTotal.WithLabelValues(s.Config.DisplayModelName).Add(float64(generationTokens))
 	if maxTokens != nil {
-		s.metrics.requestParamsMaxTokens.WithLabelValues(modelName).Observe(float64(*maxTokens))
+		s.metrics.requestParamsMaxTokens.WithLabelValues(s.Config.DisplayModelName).Observe(float64(*maxTokens))
 	}
-	s.metrics.requestSuccessTotal.WithLabelValues(modelName, finishReason).Inc()
+	s.metrics.requestSuccessTotal.WithLabelValues(s.Config.DisplayModelName, finishReason).Inc()
 	if maxGenTokens, err := common.MaxIntSlice(genTokensPerChoice); err == nil {
-		s.metrics.maxNumGenerationTokens.WithLabelValues(modelName).Observe(float64(maxGenTokens))
+		s.metrics.maxNumGenerationTokens.WithLabelValues(s.Config.DisplayModelName).Observe(float64(maxGenTokens))
 	}
 }
 

--- a/pkg/llm-d-inference-sim/request.go
+++ b/pkg/llm-d-inference-sim/request.go
@@ -51,7 +51,6 @@ type requestContext interface {
 	responseChannel() common.Channel[*ResponseInfo]
 	tokenizedPromptForEcho() (*openaiserverapi.Tokenized, error)
 	encode() ([]uint32, []string, *tokenization.MultiModalFeatures, error)
-	displayModelName() string
 }
 
 type baseRequestContext struct {
@@ -59,20 +58,14 @@ type baseRequestContext struct {
 	sim             *SimContext
 	startProcessing time.Time
 	respChannel     common.Channel[*ResponseInfo]
-	displayModel    string
 }
 
-func newBaseRequestContext(simCtx *SimContext, channel common.Channel[*ResponseInfo], model string) baseRequestContext {
+func newBaseRequestContext(simCtx *SimContext, channel common.Channel[*ResponseInfo]) baseRequestContext {
 	return baseRequestContext{
 		sim:             simCtx,
 		startProcessing: time.Now(),
 		respChannel:     channel,
-		displayModel:    simCtx.getDisplayedModelName(model),
 	}
-}
-
-func (b *baseRequestContext) displayModelName() string {
-	return b.displayModel
 }
 
 func (b *baseRequestContext) responseChannel() common.Channel[*ResponseInfo] {
@@ -135,7 +128,7 @@ func (b *baseRequestContext) validateContextWindow() (string, int) {
 
 func (reqCtx *baseRequestContext) handleRequest() (ResponseContext, *openaiserverapi.Error) {
 	req := reqCtx.request()
-	model := req.GetModel()
+	model := reqCtx.sim.getDisplayedModelName(req.GetModel())
 
 	// increment running requests count
 	common.WriteToChannel(reqCtx.sim.metrics.runReqChan, common.MetricInfo{Value: 1}, reqCtx.sim.logger)
@@ -175,7 +168,7 @@ func (reqCtx *baseRequestContext) handleRequest() (ResponseContext, *openaiserve
 			logprobs = req.GetLogprobs()
 		}
 		sendUsageData := !req.IsStream() || req.IncludeUsage()
-		respCtx := req.createResponseContext(reqCtx, reqCtx.displayModelName(), &openaiserverapi.Tokenized{},
+		respCtx := req.createResponseContext(reqCtx, model, &openaiserverapi.Tokenized{},
 			&finishReason, &usageData, sendUsageData, logprobs, nil)
 		return respCtx, nil
 	}
@@ -216,7 +209,7 @@ func (reqCtx *baseRequestContext) handleRequest() (ResponseContext, *openaiserve
 		finishReason = common.RemoteDecodeFinishReason
 	}
 
-	respCtx := req.createResponseContext(reqCtx, reqCtx.sim.getDisplayedModelName(model), responseTokens, &finishReason,
+	respCtx := req.createResponseContext(reqCtx, model, responseTokens, &finishReason,
 		&usageData, sendUsageData, logprobs, toolCalls)
 
 	return respCtx, nil

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -411,7 +411,7 @@ func (s *VllmSimulator) ResponseSentCallback(reqCtx requestContext) {
 	// decrement running requests count
 	common.WriteToChannel(s.Context.metrics.runReqChan, common.MetricInfo{Value: -1}, s.Context.logger)
 
-	model := reqCtx.displayModelName()
+	model := reqCtx.request().GetModel()
 	if s.Context.isLora(model) {
 		// update loraInfo metrics to reflect that the request processing has been finished
 		common.WriteToChannel(s.Context.metrics.lorasChan, loraUsage{model, doneUsageState},

--- a/pkg/llm-d-inference-sim/text_completion.go
+++ b/pkg/llm-d-inference-sim/text_completion.go
@@ -40,7 +40,7 @@ func (t *TextCompletionRequest) validate(toolsValidator *toolsValidator) (string
 
 func (t *TextCompletionRequest) buildRequestContext(simCtx *SimContext, channel common.Channel[*ResponseInfo]) requestContext {
 	reqCtx := &textCompletionReqCtx{
-		baseRequestContext: newBaseRequestContext(simCtx, channel, t.GetModel()),
+		baseRequestContext: newBaseRequestContext(simCtx, channel),
 		req:                t,
 	}
 	// wire textCompletionReqCtx into embedded requestContext interface


### PR DESCRIPTION
**Summary**
- Introduces `DisplayModelName` as a dedicated field in Configuration, set during validation to ServedModelNames[0]
- Removes the per-request displayModel field and displayModelName() method from baseRequestContext - the display name is now resolved once at config load time via `Config.DisplayModelName`, rather than re-derived on every request
- Updates `ResponseSentCallback` to use the raw request model (for LoRA lookup) rather than the display model name
- Updates tests to use a unified `createConfigWithModel` / `createDefaultConfig` helper that correctly sets `DisplayModelName` alongside `ServedModelNames`

**Test plan**
-  Existing config tests pass with updated helpers
- Prometheus metrics labels use ServedModelNames[0] when served model names are configured
- LoRA detection in ResponseSentCallback correctly matches against the original request model name
