### PR TITLE
Graceful shutdown: drain in-flight requests before shutting down

### DIFF
--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -29,11 +30,15 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/communication/grpc/pb"
 	vllmsim "github.com/llm-d/llm-d-inference-sim/pkg/llm-d-inference-sim"
 	"github.com/soheilhy/cmux"
+	"google.golang.org/grpc"
 )
 
 type Communication struct {
 	logger    logr.Logger
 	simulator *vllmsim.VllmSimulator
+
+	// set to 1 during graceful shutdown; new requests are rejected while draining
+	stopping atomic.Bool
 
 	// a mutex for sleep-wake up
 	sleepMutex sync.RWMutex
@@ -63,50 +68,114 @@ func (c *Communication) start(ctx context.Context) error {
 	// Timeout idle connections during protocol matching to avoid blocking shutdown.
 	m.SetReadTimeout(5 * time.Second)
 
-	go func() {
-		<-ctx.Done()
-		listener.Close() //nolint:errcheck
-	}()
-
+	var grpcServer *grpc.Server
+	var grpcErrCh <-chan error
 	if !c.simulator.Context.Config.MMEncoderOnly {
 		// gRPC uses HTTP/2
 		grpcL := m.Match(cmux.HTTP2())
-
-		// start the gRPC server
-		errCh := make(chan error, 1)
-		go func() {
-			errCh <- c.startGRPC(ctx, grpcL)
-		}()
-
+		grpcServer, grpcErrCh = c.startGRPC(grpcL)
+		// Check for an immediate startup error.
 		select {
-		case err := <-errCh:
+		case err := <-grpcErrCh:
 			if err != nil {
 				return err
 			}
 		default:
 		}
 	}
+
 	httpL := m.Match(cmux.Any())
-
-	// start the http server with context support
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- c.StartHTTPServer(ctx, httpL)
-	}()
-
+	httpServer, httpErrCh, err := c.startHTTPServer(httpL)
+	if err != nil {
+		return err
+	}
+	// Check for an immediate startup error.
 	select {
-	case err := <-errCh:
+	case err := <-httpErrCh:
 		if err != nil {
 			return err
 		}
 	default:
 	}
 
-	err = m.Serve()
-	if !errors.Is(err, net.ErrClosed) {
-		return fmt.Errorf("cmux failed: %w", err)
+	// Run cmux in a goroutine so the select below can coordinate shutdown.
+	cmuxErrCh := make(chan error, 1)
+	go func() {
+		if err := m.Serve(); !errors.Is(err, net.ErrClosed) {
+			cmuxErrCh <- err
+		} else {
+			cmuxErrCh <- nil
+		}
+	}()
+
+	// Centralized wait: all shutdown is handled here, not inside individual servers.
+	select {
+	case <-ctx.Done():
+		c.logger.V(logging.INFO).Info("Shutdown signal received, shutting down servers gracefully")
+
+		c.stopping.Store(true)
+
+		// Wait for all in-flight requests to finish before tearing down the servers.
+		const drainTimeout = 30 * time.Second
+		drainDeadline := time.Now().Add(drainTimeout)
+		c.logger.V(logging.INFO).Info("Waiting for all in-flight requests to finish")
+		for c.simulator.OpenRequests() > 0 {
+			if time.Now().After(drainDeadline) {
+				c.logger.V(logging.INFO).Info("Drain timed out, proceeding with shutdown",
+					"open_requests", c.simulator.OpenRequests())
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		c.simulator.Stop()
+
+		// Shut down HTTP first: grpcServer.Stop() closes grpcL which causes cmux to stop
+		// routing to httpL, making the HTTP server's Serve() return and set s.ln = nil.
+		// If gRPC is stopped before HTTP, fasthttp finds s.ln == nil and returns immediately
+		// without waiting for active connections.
+		const shutdownTimeout = 5 * time.Second
+		done := make(chan error, 1)
+		go func() {
+			done <- httpServer.Shutdown()
+		}()
+		select {
+		case err := <-done:
+			// Ignore closed-listener errors from cmux shutting down first.
+			if err != nil && !errors.Is(err, net.ErrClosed) {
+				c.logger.Error(err, "error during HTTP server shutdown")
+			}
+		case <-time.After(shutdownTimeout):
+			c.logger.V(logging.INFO).Info("HTTP shutdown timed out, forcing close")
+		}
+		c.logger.V(logging.INFO).Info("HTTP server stopped")
+
+		if grpcServer != nil {
+			c.logger.V(logging.INFO).Info("Shutting down gRPC server")
+			grpcServer.Stop()
+			c.logger.V(logging.INFO).Info("gRPC server stopped")
+		}
+
+		listener.Close() //nolint:errcheck
+		return nil
+
+	case err := <-grpcErrCh: // nil channel if gRPC disabled — never fires
+		if err != nil {
+			c.logger.Error(err, "gRPC server failed")
+		}
+		return err
+
+	case err := <-httpErrCh:
+		if err != nil {
+			c.logger.Error(err, "HTTP server failed")
+		}
+		return err
+
+	case err := <-cmuxErrCh:
+		if err != nil {
+			return fmt.Errorf("cmux failed: %w", err)
+		}
+		return nil
 	}
-	return nil
 }
 
 // Print prints to a log, implementation of fasthttp.Logger

--- a/pkg/communication/grpc.go
+++ b/pkg/communication/grpc.go
@@ -34,6 +34,10 @@ import (
 
 // Submit a generation request (supports streaming)
 func (c *Communication) Generate(in *pb.GenerateRequest, out grpc.ServerStreamingServer[pb.GenerateResponse]) error {
+	if c.stopping.Load() {
+		return status.Error(codes.Unavailable, "server is shutting down")
+	}
+
 	req := c.pbRequestToRequest(in)
 	respBuilder := &generationGRPCRespBuilder{}
 	_, channel, err, _ := c.simulator.HandleRequest(req)
@@ -116,29 +120,18 @@ func (c *Communication) GetServerInfo(ctx context.Context, in *pb.GetServerInfoR
 	return nil, nil
 }
 
-func (c *Communication) startGRPC(ctx context.Context, listener net.Listener) error {
+// startGRPC starts the gRPC server and returns the server instance and an error channel.
+// It does not handle shutdown — callers are responsible for calling server.Stop().
+func (c *Communication) startGRPC(listener net.Listener) (*grpc.Server, <-chan error) {
 	server := grpc.NewServer()
 	pb.RegisterVllmEngineServer(server, c)
 	reflection.Register(server)
-	serverErr := make(chan error, 1)
+	errCh := make(chan error, 1)
 	go func() {
 		c.logger.V(logging.INFO).Info("Server starting", "protocol", "gRPC", "port", c.simulator.Context.Config.Port)
-		serverErr <- server.Serve(listener)
+		errCh <- server.Serve(listener)
 	}()
-
-	select {
-	case <-ctx.Done():
-		c.logger.V(logging.INFO).Info("Shutdown signal received, shutting down gRPC server")
-		server.Stop()
-		c.logger.V(logging.INFO).Info("gRPC server stopped")
-		return nil
-
-	case err := <-serverErr:
-		if err != nil {
-			c.logger.Error(err, "gRPC server failed")
-		}
-		return err
-	}
+	return server, errCh
 }
 
 func (c *Communication) pbRequestToRequest(in *pb.GenerateRequest) *vllmsim.GenerationRequest {

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -18,9 +18,7 @@ package communication
 
 import (
 	"bufio"
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -57,8 +55,9 @@ func (c *Communication) newListener() (net.Listener, error) {
 	return listener, nil
 }
 
-// startServer starts http/https server on port defined in command line
-func (c *Communication) StartHTTPServer(ctx context.Context, listener net.Listener) error {
+// startHTTPServer builds and starts the HTTP server, returning the server instance and an error channel.
+// It does not handle shutdown — callers are responsible for calling server.Shutdown().
+func (c *Communication) startHTTPServer(listener net.Listener) (*fasthttp.Server, <-chan error, error) {
 	r := fasthttprouter.New()
 
 	// support completion APIs
@@ -90,52 +89,31 @@ func (c *Communication) StartHTTPServer(ctx context.Context, listener net.Listen
 	}
 
 	if err := c.configureSSL(server); err != nil {
-		return err
+		return nil, nil, err
 	}
 
-	// Start server in a goroutine
-	serverErr := make(chan error, 1)
+	errCh := make(chan error, 1)
 	go func() {
 		if c.simulator.Context.Config.SSLEnabled() {
 			c.logger.V(logging.INFO).Info("Server starting", "protocol", "HTTPS", "port", c.simulator.Context.Config.Port)
-			serverErr <- server.ServeTLS(listener, "", "")
+			errCh <- server.ServeTLS(listener, "", "")
 		} else {
 			c.logger.V(logging.INFO).Info("Server starting", "protocol", "HTTP", "port", c.simulator.Context.Config.Port)
-			serverErr <- server.Serve(listener)
+			errCh <- server.Serve(listener)
 		}
 	}()
 
-	// Wait for either context cancellation or server error
-	select {
-	case <-ctx.Done():
-		c.logger.V(logging.INFO).Info("Shutdown signal received, shutting down HTTP server gracefully")
+	return server, errCh, nil
+}
 
-		const shutdownTimeout = 5 * time.Second
-		done := make(chan error, 1)
-		go func() {
-			done <- server.Shutdown()
-		}()
-
-		select {
-		case err := <-done:
-			// Ignore closed-listener errors from cmux shutting down first.
-			if err != nil && !errors.Is(err, net.ErrClosed) {
-				c.logger.Error(err, "error during server shutdown")
-				return err
-			}
-		case <-time.After(shutdownTimeout):
-			c.logger.V(logging.INFO).Info("Shutdown timed out, forcing close")
-		}
-
-		c.logger.V(logging.INFO).Info("HTTP server stopped")
-		return nil
-
-	case err := <-serverErr:
-		if err != nil {
-			c.logger.Error(err, "server failed")
-		}
+// StartHTTPServer starts the HTTP server on the given listener and blocks until it exits.
+// Intended for use in tests with a custom listener. Shutdown is driven by closing the listener.
+func (c *Communication) StartHTTPServer(listener net.Listener) error {
+	_, errCh, err := c.startHTTPServer(listener)
+	if err != nil {
 		return err
 	}
+	return <-errCh
 }
 
 // getRequestID retrieves the request ID from the X-Request-Id header or generates a new one if not present
@@ -174,6 +152,11 @@ func (c *Communication) addResponseHeaders(ctx *fasthttp.RequestCtx, requestID s
 }
 
 func (c *Communication) handleHTTP(req vllmsim.Request, respBuilder responseBuilder, ctx *fasthttp.RequestCtx) {
+	if c.stopping.Load() {
+		ctx.SetStatusCode(fasthttp.StatusServiceUnavailable)
+		return
+	}
+
 	requestID := c.getRequestID(ctx)
 	req.SetRequestID(requestID)
 

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -106,16 +106,6 @@ func (c *Communication) startHTTPServer(listener net.Listener) (*fasthttp.Server
 	return server, errCh, nil
 }
 
-// StartHTTPServer starts the HTTP server on the given listener and blocks until it exits.
-// Intended for use in tests with a custom listener. Shutdown is driven by closing the listener.
-func (c *Communication) StartHTTPServer(listener net.Listener) error {
-	_, errCh, err := c.startHTTPServer(listener)
-	if err != nil {
-		return err
-	}
-	return <-errCh
-}
-
 // getRequestID retrieves the request ID from the X-Request-Id header or generates a new one if not present
 func (c *Communication) getRequestID(ctx *fasthttp.RequestCtx) string {
 	if c.simulator.Context.Config.EnableRequestIDHeaders {

--- a/pkg/communication/test_utils.go
+++ b/pkg/communication/test_utils.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package communication
+
+import "net"
+
+// StartHTTPServer starts the HTTP server on the given listener and blocks until it exits.
+// Intended for use in tests with a custom listener. Shutdown is driven by closing the listener.
+func (c *Communication) StartHTTPServer(listener net.Listener) error {
+	_, errCh, err := c.startHTTPServer(listener)
+	if err != nil {
+		return err
+	}
+	return <-errCh
+}

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -65,6 +66,12 @@ type VllmSimulator struct {
 	queueCapacity int
 	// a channel for incoming requests
 	newRequests common.Channel[requestContext]
+	// openRequests is the count of requests currently in the system
+	// (queued + being processed); incremented on accept, decremented on completion
+	openRequests atomic.Int64
+	// drainCancel cancels the internal drain context once all open requests finish,
+	// allowing internal goroutines (workers, metrics, kvcache) to stop cleanly
+	drainCancel context.CancelFunc
 }
 
 // New creates a new VllmSimulator instance with the given logger
@@ -96,7 +103,11 @@ func Start(ctx context.Context, config *common.Configuration, logger logr.Logger
 		logger.Error(err, "failed to initialize dataset")
 		return nil, err
 	}
-	tokenizer, err := tokenizer.New(ctx, config, logger)
+	// Use context.Background() so the tokenizer's gRPC connection to the UDS
+	// sidecar is not tied to the parent context. Workers run on drainCtx (cancelled
+	// only after all requests drain) and must be able to call the tokenizer until
+	// the very end, after the parent context has already been cancelled.
+	tokenizer, err := tokenizer.New(context.Background(), config, logger)
 	if err != nil {
 		logger.Error(err, "failed to initialize tokenizer")
 		return nil, err
@@ -149,7 +160,13 @@ func Start(ctx context.Context, config *common.Configuration, logger logr.Logger
 }
 
 func (s *VllmSimulator) InitializeSim(ctx context.Context) error {
-	if err := s.Context.initialize(ctx); err != nil {
+	// drainCtx lives until all open requests finish after ctx is cancelled.
+	// It is passed to all internal goroutines so they keep running through drain.
+	drainCtx, drainCancel := context.WithCancel(context.Background())
+	s.drainCancel = drainCancel
+
+	if err := s.Context.initialize(drainCtx); err != nil {
+		drainCancel()
 		return err
 	}
 
@@ -167,7 +184,7 @@ func (s *VllmSimulator) InitializeSim(ctx context.Context) error {
 	for i := 1; i <= s.Context.Config.MaxNumSeqs; i++ {
 		worker := &worker{
 			id:           i,
-			ctx:          ctx,
+			ctx:          drainCtx,
 			logger:       s.Context.logger,
 			finishedChan: s.workerFinished,
 			reqChan: common.Channel[requestContext]{
@@ -180,8 +197,15 @@ func (s *VllmSimulator) InitializeSim(ctx context.Context) error {
 		s.freeWorkers <- worker
 	}
 
-	go s.processing(ctx)
+	go s.processing(drainCtx)
 	return nil
+}
+
+// Stop cancels the internal drain context, causing all internal goroutines
+// (workers, metrics, kvcache) to stop cleanly. It must be called by the
+// communication layer after all open requests have been drained.
+func (s *VllmSimulator) Stop() {
+	s.drainCancel()
 }
 
 func (s *VllmSimulator) processing(ctx context.Context) {
@@ -269,6 +293,7 @@ func (s *VllmSimulator) findRequestAndSendToProcess(worker *worker) bool {
 func (s *VllmSimulator) addRequestToQueue(reqCtx requestContext) {
 	if err := s.enqueue(reqCtx); err != nil {
 		s.Context.logger.Error(err, "failed to enqueue request")
+		s.openRequests.Add(-1)
 		err := openaiserverapi.NewError("Failed to enqueue request, "+err.Error(),
 			fasthttp.StatusTooManyRequests, nil)
 		common.WriteToChannel(reqCtx.responseChannel(), &ResponseInfo{Err: &err},
@@ -308,6 +333,7 @@ func (s *VllmSimulator) HandleRequest(req Request) (bool, *common.Channel[*Respo
 		Name:    "responseInfo",
 	}
 	reqCtx := req.buildRequestContext(&s.Context, channel)
+	s.openRequests.Add(1)
 	common.WriteToChannel(s.newRequests, reqCtx, s.Context.logger)
 	return req.IsStream(), &channel, nil, false
 }
@@ -408,6 +434,7 @@ func (s *VllmSimulator) sendResponse(reqCtx requestContext, respCtx ResponseCont
 
 // request processing finished
 func (s *VllmSimulator) ResponseSentCallback(reqCtx requestContext) {
+	s.openRequests.Add(-1)
 	// decrement running requests count
 	common.WriteToChannel(s.Context.metrics.runReqChan, common.MetricInfo{Value: -1}, s.Context.logger)
 
@@ -419,6 +446,12 @@ func (s *VllmSimulator) ResponseSentCallback(reqCtx requestContext) {
 	}
 
 	reqCtx.kvCacheOnRequestEnd()
+}
+
+// OpenRequests returns the number of requests currently in the system
+// (waiting in queue + being processed by workers).
+func (s *VllmSimulator) OpenRequests() int64 {
+	return s.openRequests.Load()
 }
 
 func (s *VllmSimulator) DiscardKVCache() {

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -66,9 +65,6 @@ type VllmSimulator struct {
 	queueCapacity int
 	// a channel for incoming requests
 	newRequests common.Channel[requestContext]
-	// openRequests is the count of requests currently in the system
-	// (queued + being processed); incremented on accept, decremented on completion
-	openRequests atomic.Int64
 	// drainCancel cancels the internal drain context once all open requests finish,
 	// allowing internal goroutines (workers, metrics, kvcache) to stop cleanly
 	drainCancel context.CancelFunc
@@ -293,7 +289,6 @@ func (s *VllmSimulator) findRequestAndSendToProcess(worker *worker) bool {
 func (s *VllmSimulator) addRequestToQueue(reqCtx requestContext) {
 	if err := s.enqueue(reqCtx); err != nil {
 		s.Context.logger.Error(err, "failed to enqueue request")
-		s.openRequests.Add(-1)
 		err := openaiserverapi.NewError("Failed to enqueue request, "+err.Error(),
 			fasthttp.StatusTooManyRequests, nil)
 		common.WriteToChannel(reqCtx.responseChannel(), &ResponseInfo{Err: &err},
@@ -333,7 +328,6 @@ func (s *VllmSimulator) HandleRequest(req Request) (bool, *common.Channel[*Respo
 		Name:    "responseInfo",
 	}
 	reqCtx := req.buildRequestContext(&s.Context, channel)
-	s.openRequests.Add(1)
 	common.WriteToChannel(s.newRequests, reqCtx, s.Context.logger)
 	return req.IsStream(), &channel, nil, false
 }
@@ -434,7 +428,6 @@ func (s *VllmSimulator) sendResponse(reqCtx requestContext, respCtx ResponseCont
 
 // request processing finished
 func (s *VllmSimulator) ResponseSentCallback(reqCtx requestContext) {
-	s.openRequests.Add(-1)
 	// decrement running requests count
 	common.WriteToChannel(s.Context.metrics.runReqChan, common.MetricInfo{Value: -1}, s.Context.logger)
 
@@ -451,7 +444,11 @@ func (s *VllmSimulator) ResponseSentCallback(reqCtx requestContext) {
 // OpenRequests returns the number of requests currently in the system
 // (waiting in queue + being processed by workers).
 func (s *VllmSimulator) OpenRequests() int64 {
-	return s.openRequests.Load()
+	s.queueLock.Lock()
+	waiting := s.waitingQueue.Len()
+	s.queueLock.Unlock()
+	running := cap(s.freeWorkers) - len(s.freeWorkers)
+	return int64(waiting + running)
 }
 
 func (s *VllmSimulator) DiscardKVCache() {

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
@@ -1305,6 +1306,43 @@ var _ = Describe("Simulator", func() {
 			Expect(openaiError.StatusCode).To(BeNumerically("==", fasthttp.StatusBadRequest))
 			Expect(openaiError.Type).ToNot(BeEmpty())
 			Expect(openaiError.Message).To(ContainSubstring("Max completion tokens and max tokens should be positive"))
+		})
+	})
+
+	Context("OpenRequests counter", func() {
+		It("Should reflect in-flight requests and return to zero after completion", func() {
+			ctx := context.TODO()
+			// 1 worker, queue capacity 2, 500ms TTFT so requests stay in-flight long enough to inspect
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeEcho,
+				"--time-to-first-token", "500", "--max-num-seqs", "1", "--max-waiting-queue-length", "2"}
+			server, _, client, err := startServerHandle(ctx, common.ModeEcho, args, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Before any request the counter must be zero
+			Expect(server.OpenRequests()).To(Equal(int64(0)))
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			// Send two requests concurrently: one will be processed by the single
+			// worker, the other will sit in the waiting queue.
+			for range 2 {
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					openaiclient, params := getOpenAIClientAndChatParams(client, common.TestModelName, testUserMessage, false)
+					_, err := openaiclient.Chat.Completions.New(ctx, params)
+					Expect(err).NotTo(HaveOccurred())
+				}()
+			}
+
+			// Give the goroutines time to reach the server and enter the worker / queue
+			time.Sleep(200 * time.Millisecond)
+			Expect(server.OpenRequests()).To(Equal(int64(2)))
+
+			// Wait for both requests to finish — counter must return to zero
+			wg.Wait()
+			Expect(server.OpenRequests()).To(Equal(int64(0)))
 		})
 	})
 

--- a/pkg/tests/test_utils_test.go
+++ b/pkg/tests/test_utils_test.go
@@ -160,7 +160,7 @@ func startServerHelper(ctx context.Context, mode string, args []string, envs map
 
 	// start the http server
 	go func() {
-		if err := comm.StartHTTPServer(ctx, listener); err != nil {
+		if err := comm.StartHTTPServer(listener); err != nil {
 			logger.Error(err, "error starting server")
 		}
 	}()


### PR DESCRIPTION

- Stop accepting new requests immediately on shutdown signal (HTTP 503 / gRPC Unavailable)
- Wait up to 30 seconds for all in-flight requests to complete before tearing down the transport
- Internal goroutines (workers, metrics, kvcache, tokenizer) now run on a drainCtx derived from context.Background() so they stay alive through the drain period after the parent context is cancelled
