### PR TITLE
Extend kv-cache to manage prefixes per lora and support additional kv-event fields

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,7 +129,7 @@ The following command line parameters are ignored by the simulator:
 - `mm-processor-kwargs` - arguments to be forwarded to the model's processor for multi-modal data, ignored
 - `ec-transfer-config` - configuration for distributed EC cache transfer, ignored
 - `enforce-eager`, `no-enforce-eager` - controls whether PyTorch eager mode is always enforced, ignored
-- `enable-prefix-caching`, `no-enable-prefix-caching` - enable or disable prefix caching, ignored
+- `enable-prefix-caching`, `no-enable-prefix-caching` - enable or disable prefix caching, ignored, behaves as enable-prefix-caching=true
 
 ## Klog
 In addition, as we are using klog, the following parameters are available:

--- a/pkg/kv-cache/block_cache.go
+++ b/pkg/kv-cache/block_cache.go
@@ -39,7 +39,7 @@ const (
 // contains sub-set of openai server api request fields that are relevant for the block cache
 type Request interface {
 	GetRequestID() string
-	GetModel() string
+	GetDisplayedModel() string
 	GetLoraName() *string
 	GetLoraID() *int
 }
@@ -180,7 +180,7 @@ func (bc *blockCache) startRequest(req Request, blockHashes []uint64, blockToken
 	// count number of new blocks + number of blocks that are in the unused blocks
 	// don't update the data until we are sure that it's ok
 	for i, blockHash := range blockHashes {
-		bKey := blockKey{hash: blockHash, modelName: req.GetModel()}
+		bKey := blockKey{hash: blockHash, modelName: req.GetDisplayedModel()}
 		if _, exists := bc.unusedBlocks[bKey]; exists {
 			blockToMoveToUsed = append(blockToMoveToUsed, bKey)
 		} else if _, exists := bc.usedBlocks[bKey]; !exists {
@@ -250,7 +250,7 @@ func (bc *blockCache) startRequest(req Request, blockHashes []uint64, blockToken
 	// store blockKeys and not only plain uint64
 	bc.requestToBlocks[req.GetRequestID()] = make([]blockKey, len(blockHashes))
 	for i, blockHash := range blockHashes {
-		bKey := blockKey{hash: blockHash, modelName: req.GetModel()}
+		bKey := blockKey{hash: blockHash, modelName: req.GetDisplayedModel()}
 		bc.requestToBlocks[req.GetRequestID()][i] = bKey
 	}
 

--- a/pkg/kv-cache/block_cache.go
+++ b/pkg/kv-cache/block_cache.go
@@ -124,7 +124,7 @@ func (bc *blockCache) activate() {
 
 // startRequest adds a request with its associated block hashes to the cache
 // and returns the number of blocks that were already in the cache
-func (bc *blockCache) startRequest(requestID string, blockHashes []uint64, blockTokens [][]uint32) (int, error) {
+func (bc *blockCache) startRequest(requestID string, loraName *string, blockHashes []uint64, blockTokens [][]uint32) (int, error) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
@@ -217,7 +217,13 @@ func (bc *blockCache) startRequest(requestID string, blockHashes []uint64, block
 	}
 
 	if len(hashes) > 0 {
-		common.WriteToChannel(bc.eventChan, EventData{action: eventActionStore, hashes: hashes, tokens: tokens}, bc.logger)
+		common.WriteToChannel(bc.eventChan,
+			EventData{
+				action:   eventActionStore,
+				hashes:   hashes,
+				tokens:   tokens,
+				loraName: loraName,
+			}, bc.logger)
 	}
 
 	// store the request mapping

--- a/pkg/kv-cache/block_cache.go
+++ b/pkg/kv-cache/block_cache.go
@@ -35,7 +35,7 @@ const (
 	topicNameSeparator = "@"
 )
 
-// define the interface for requests that can be stored in the block cache
+// Request defines the interface for requests that can be stored in the block cache
 // contains sub-set of openai server api request fields that are relevant for the block cache
 type Request interface {
 	GetRequestID() string
@@ -56,7 +56,7 @@ type blockCache struct {
 	usedBlocks      map[blockKey]int                   // block hash -> reference count
 	unusedBlocks    map[blockKey]time.Time             // block hash -> last usage timestamp
 	blockToTokens   map[blockKey][]uint32              // block hash -> block tokens
-	loadedModels    map[string]bool                    // models currently loaded (base model + loaded loras)
+	loadedModels    map[string]struct{}                // models currently loaded (base model + loaded loras)
 	maxBlocks       int                                // maximum number of blocks in the cache
 	eventSender     *KVEventSender                     // emmits kv events
 	eventChan       common.Channel[EventData]          // channel for asynchronous event processing
@@ -73,7 +73,7 @@ func newBlockCache(ctx context.Context, config *common.Configuration, logger log
 	}
 
 	eChan := common.Channel[EventData]{
-		Channel: make(chan EventData, config.KVCacheSize),
+		Channel: make(chan EventData, 10*config.KVCacheSize),
 		Name:    "block cache eventChan",
 	}
 
@@ -87,20 +87,29 @@ func newBlockCache(ctx context.Context, config *common.Configuration, logger log
 	}
 
 	eventSender := NewKVEventSender(publisher, CreateKVEventsTopic(config.IP, config.Model),
-		eChan, config.EventBatchSize, delay, logger)
+		eChan, config.EventBatchSize, config.TokenBlockSize, delay, logger)
 
-	return &blockCache{
+	bCache := blockCache{
 		requestToBlocks: make(map[string][]blockKey),
 		usedBlocks:      make(map[blockKey]int),
 		unusedBlocks:    make(map[blockKey]time.Time),
 		blockToTokens:   make(map[blockKey][]uint32),
-		loadedModels:    make(map[string]bool),
+		loadedModels:    make(map[string]struct{}),
 		maxBlocks:       config.KVCacheSize,
 		eventChan:       eChan,
 		usageChan:       usageChan,
 		eventSender:     eventSender,
 		logger:          logger,
-	}, nil
+	}
+
+	// mark the base model and all it aliases as always loaded,
+	// so its blocks will be evicted with lower priority than blocks of unloaded loras
+	bCache.setModelLoaded(config.Model)
+	for _, modelName := range config.ServedModelNames {
+		bCache.setModelLoaded(modelName)
+	}
+
+	return &bCache, nil
 }
 
 func (bc *blockCache) start(ctx context.Context) {
@@ -141,7 +150,7 @@ func (bc *blockCache) activate() {
 // startRequest adds a request with its associated block hashes to the cache
 // and returns the number of blocks that were already in the cache
 // model name is the name of the model for the current request, used for eviction policy
-func (bc *blockCache) startRequest(vllmReq Request, blockHashes []uint64, blockTokens [][]uint32) (int, error) {
+func (bc *blockCache) startRequest(req Request, blockHashes []uint64, blockTokens [][]uint32) (int, error) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
@@ -150,9 +159,9 @@ func (bc *blockCache) startRequest(vllmReq Request, blockHashes []uint64, blockT
 		return 0, nil
 	}
 
-	if _, exists := bc.requestToBlocks[vllmReq.GetRequestID()]; exists {
+	if _, exists := bc.requestToBlocks[req.GetRequestID()]; exists {
 		// request with the same id already exists
-		return 0, fmt.Errorf("request already exists for id %s", vllmReq.GetRequestID())
+		return 0, fmt.Errorf("request already exists for id %s", req.GetRequestID())
 	}
 
 	if len(blockHashes) != len(blockTokens) {
@@ -171,7 +180,7 @@ func (bc *blockCache) startRequest(vllmReq Request, blockHashes []uint64, blockT
 	// count number of new blocks + number of blocks that are in the unused blocks
 	// don't update the data until we are sure that it's ok
 	for i, blockHash := range blockHashes {
-		bKey := blockKey{hash: blockHash, modelName: vllmReq.GetModel()}
+		bKey := blockKey{hash: blockHash, modelName: req.GetModel()}
 		if _, exists := bc.unusedBlocks[bKey]; exists {
 			blockToMoveToUsed = append(blockToMoveToUsed, bKey)
 		} else if _, exists := bc.usedBlocks[bKey]; !exists {
@@ -232,20 +241,18 @@ func (bc *blockCache) startRequest(vllmReq Request, blockHashes []uint64, blockT
 				action:   eventActionStore,
 				hashes:   hashes,
 				tokens:   tokens,
-				loraName: vllmReq.GetLoraName(),
-				loraID:   vllmReq.GetLoraID(),
+				loraName: req.GetLoraName(),
+				loraID:   req.GetLoraID(),
 			}, bc.logger)
 	}
 
 	// store the request mapping
 	// store blockKeys and not only plain uint64
-	bKeys := make([]blockKey, len(blockHashes))
+	bc.requestToBlocks[req.GetRequestID()] = make([]blockKey, len(blockHashes))
 	for i, blockHash := range blockHashes {
-		bKey := blockKey{hash: blockHash, modelName: vllmReq.GetModel()}
-		bKeys[i] = bKey
+		bKey := blockKey{hash: blockHash, modelName: req.GetModel()}
+		bc.requestToBlocks[req.GetRequestID()][i] = bKey
 	}
-	bc.requestToBlocks[vllmReq.GetRequestID()] = make([]blockKey, len(blockHashes))
-	copy(bc.requestToBlocks[vllmReq.GetRequestID()], bKeys)
 
 	if bc.usageChan != nil {
 		usage := common.MetricInfo{
@@ -378,11 +385,11 @@ func (bc *blockCache) pickBlockToEvict() blockKey {
 	var bestLoadedHash blockKey
 	bestLoadedTime := time.Now()
 	var bestUnloadedHash blockKey
-	bestUnloadedTime := time.Now()
+	bestUnloadedTime := bestLoadedTime
 	hasUnloadedCandidate := false
 
 	for blockKey, t := range bc.unusedBlocks {
-		if bc.loadedModels[blockKey.modelName] {
+		if _, exists := bc.loadedModels[blockKey.modelName]; exists {
 			// this is a block with loaded model,
 			// check if it's the best candidate among loaded models
 			if t.Before(bestLoadedTime) {
@@ -392,7 +399,7 @@ func (bc *blockCache) pickBlockToEvict() blockKey {
 		} else {
 			// this is a block with unloaded model,
 			// check if it's the best candidate among unloaded models
-			if !hasUnloadedCandidate || t.Before(bestUnloadedTime) {
+			if t.Before(bestUnloadedTime) {
 				bestUnloadedHash = blockKey
 				bestUnloadedTime = t
 				hasUnloadedCandidate = true
@@ -408,7 +415,7 @@ func (bc *blockCache) pickBlockToEvict() blockKey {
 func (bc *blockCache) setModelLoaded(model string) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
-	bc.loadedModels[model] = true
+	bc.loadedModels[model] = struct{}{}
 }
 
 func (bc *blockCache) setModelUnloaded(model string) {

--- a/pkg/kv-cache/block_cache.go
+++ b/pkg/kv-cache/block_cache.go
@@ -35,13 +35,28 @@ const (
 	topicNameSeparator = "@"
 )
 
+// define the interface for requests that can be stored in the block cache
+// contains sub-set of openai server api request fields that are relevant for the block cache
+type Request interface {
+	GetRequestID() string
+	GetModel() string
+	GetLoraName() *string
+	GetLoraID() *int
+}
+
+type blockKey struct {
+	hash      uint64
+	modelName string
+}
+
 // blockCache represents a thread-safe cache for blocks with eviction policy
 type blockCache struct {
 	mu              sync.RWMutex
-	requestToBlocks map[string][]uint64                // request id -> array of it blocks (block hashes)
-	usedBlocks      map[uint64]int                     // block hash -> reference count
-	unusedBlocks    map[uint64]time.Time               // block hash -> last usage timestamp
-	blockToTokens   map[uint64][]uint32                // block hash -> block tokens
+	requestToBlocks map[string][]blockKey              // request id -> array of it blocks (block hashes)
+	usedBlocks      map[blockKey]int                   // block hash -> reference count
+	unusedBlocks    map[blockKey]time.Time             // block hash -> last usage timestamp
+	blockToTokens   map[blockKey][]uint32              // block hash -> block tokens
+	loadedModels    map[string]bool                    // models currently loaded (base model + loaded loras)
 	maxBlocks       int                                // maximum number of blocks in the cache
 	eventSender     *KVEventSender                     // emmits kv events
 	eventChan       common.Channel[EventData]          // channel for asynchronous event processing
@@ -57,9 +72,8 @@ func newBlockCache(ctx context.Context, config *common.Configuration, logger log
 		return nil, errors.New("IP should be defined in the environment (POD_IP)")
 	}
 
-	// TODO read size of channel from config
 	eChan := common.Channel[EventData]{
-		Channel: make(chan EventData, 10000),
+		Channel: make(chan EventData, config.KVCacheSize),
 		Name:    "block cache eventChan",
 	}
 
@@ -76,10 +90,11 @@ func newBlockCache(ctx context.Context, config *common.Configuration, logger log
 		eChan, config.EventBatchSize, delay, logger)
 
 	return &blockCache{
-		requestToBlocks: make(map[string][]uint64),
-		usedBlocks:      make(map[uint64]int),
-		unusedBlocks:    make(map[uint64]time.Time),
-		blockToTokens:   make(map[uint64][]uint32),
+		requestToBlocks: make(map[string][]blockKey),
+		usedBlocks:      make(map[blockKey]int),
+		unusedBlocks:    make(map[blockKey]time.Time),
+		blockToTokens:   make(map[blockKey][]uint32),
+		loadedModels:    make(map[string]bool),
 		maxBlocks:       config.KVCacheSize,
 		eventChan:       eChan,
 		usageChan:       usageChan,
@@ -104,9 +119,10 @@ func (bc *blockCache) discard() {
 
 	bc.disabled = true
 
-	bc.requestToBlocks = make(map[string][]uint64)
-	bc.usedBlocks = make(map[uint64]int)
-	bc.unusedBlocks = make(map[uint64]time.Time)
+	bc.requestToBlocks = make(map[string][]blockKey)
+	bc.usedBlocks = make(map[blockKey]int)
+	bc.unusedBlocks = make(map[blockKey]time.Time)
+	bc.blockToTokens = make(map[blockKey][]uint32)
 
 	common.WriteToChannel(bc.eventChan,
 		EventData{action: eventActionAllBlocksCleared},
@@ -124,7 +140,8 @@ func (bc *blockCache) activate() {
 
 // startRequest adds a request with its associated block hashes to the cache
 // and returns the number of blocks that were already in the cache
-func (bc *blockCache) startRequest(requestID string, loraName *string, blockHashes []uint64, blockTokens [][]uint32) (int, error) {
+// model name is the name of the model for the current request, used for eviction policy
+func (bc *blockCache) startRequest(vllmReq Request, blockHashes []uint64, blockTokens [][]uint32) (int, error) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
@@ -133,9 +150,9 @@ func (bc *blockCache) startRequest(requestID string, loraName *string, blockHash
 		return 0, nil
 	}
 
-	if _, exists := bc.requestToBlocks[requestID]; exists {
+	if _, exists := bc.requestToBlocks[vllmReq.GetRequestID()]; exists {
 		// request with the same id already exists
-		return 0, fmt.Errorf("request already exists for id %s", requestID)
+		return 0, fmt.Errorf("request already exists for id %s", vllmReq.GetRequestID())
 	}
 
 	if len(blockHashes) != len(blockTokens) {
@@ -146,25 +163,26 @@ func (bc *blockCache) startRequest(requestID string, loraName *string, blockHash
 	// blockAreadyInUse - blocks, which are already used by currently running request
 	// blockToMoveToUsed - blocks, which were used in past
 	// blocksToAdd - new blocks
-	blocksToAdd := make([]uint64, 0)
-	blockToMoveToUsed := make([]uint64, 0)
-	blockAreadyInUse := make([]uint64, 0)
+	blocksToAdd := make([]blockKey, 0)
+	blockToMoveToUsed := make([]blockKey, 0)
+	blockAreadyInUse := make([]blockKey, 0)
 
 	// first step - ensure that there is enough space for all blocks
 	// count number of new blocks + number of blocks that are in the unused blocks
 	// don't update the data until we are sure that it's ok
 	for i, blockHash := range blockHashes {
-		if _, exists := bc.unusedBlocks[blockHash]; exists {
-			blockToMoveToUsed = append(blockToMoveToUsed, blockHash)
-		} else if _, exists := bc.usedBlocks[blockHash]; !exists {
-			blocksToAdd = append(blocksToAdd, blockHash)
+		bKey := blockKey{hash: blockHash, modelName: vllmReq.GetModel()}
+		if _, exists := bc.unusedBlocks[bKey]; exists {
+			blockToMoveToUsed = append(blockToMoveToUsed, bKey)
+		} else if _, exists := bc.usedBlocks[bKey]; !exists {
+			blocksToAdd = append(blocksToAdd, bKey)
 		} else {
-			blockAreadyInUse = append(blockAreadyInUse, blockHash)
+			blockAreadyInUse = append(blockAreadyInUse, bKey)
 		}
 
 		// store block tokens if doesnot in the cache
-		if _, exists := bc.blockToTokens[blockHash]; !exists {
-			bc.blockToTokens[blockHash] = blockTokens[i]
+		if _, exists := bc.blockToTokens[bKey]; !exists {
+			bc.blockToTokens[bKey] = blockTokens[i]
 		}
 	}
 
@@ -183,36 +201,28 @@ func (bc *blockCache) startRequest(requestID string, loraName *string, blockHash
 		delete(bc.unusedBlocks, block)
 	}
 
-	// for new block - add them, if there is no empty slots - evict the oldest block
-	// send all blocks as a single batch
+	// for new block - add them, if there is no empty slots - evict a block using priority:
+	// 1. oldest unused block of an unloaded model
+	// 2. oldest unused block of any model
 	hashes := []uint64{}
 	tokens := []uint32{}
 
 	for _, block := range blocksToAdd {
 		if len(bc.usedBlocks)+len(bc.unusedBlocks) == bc.maxBlocks {
-			// cache is full but contains unused blocks - evict the oldest
-			var oldestUnusedHash uint64
-			oldestUnusedTime := time.Now()
-
-			for hash, t := range bc.unusedBlocks {
-				if t.Before(oldestUnusedTime) {
-					oldestUnusedHash = hash
-					oldestUnusedTime = t
-				}
-			}
-
-			delete(bc.unusedBlocks, oldestUnusedHash)
+			// cache is full but contains unused blocks - evict one block
+			evictHash := bc.pickBlockToEvict()
+			delete(bc.unusedBlocks, evictHash)
 			common.WriteToChannel(bc.eventChan,
-				EventData{action: eventActionRemove, hashes: []uint64{oldestUnusedHash}, tokens: bc.blockToTokens[oldestUnusedHash]},
+				EventData{action: eventActionRemove, hashes: []uint64{evictHash.hash},
+					tokens: bc.blockToTokens[evictHash]},
 				bc.logger)
-			// remove this block hash from the cache of block tokens
-			delete(bc.blockToTokens, oldestUnusedHash)
+			delete(bc.blockToTokens, evictHash)
 		}
 
 		// Add the new block
 		bc.usedBlocks[block] = 1
 
-		hashes = append(hashes, block)
+		hashes = append(hashes, block.hash)
 		tokens = append(tokens, bc.blockToTokens[block]...)
 	}
 
@@ -222,13 +232,20 @@ func (bc *blockCache) startRequest(requestID string, loraName *string, blockHash
 				action:   eventActionStore,
 				hashes:   hashes,
 				tokens:   tokens,
-				loraName: loraName,
+				loraName: vllmReq.GetLoraName(),
+				loraID:   vllmReq.GetLoraID(),
 			}, bc.logger)
 	}
 
 	// store the request mapping
-	bc.requestToBlocks[requestID] = make([]uint64, len(blockHashes))
-	copy(bc.requestToBlocks[requestID], blockHashes)
+	// store blockKeys and not only plain uint64
+	bKeys := make([]blockKey, len(blockHashes))
+	for i, blockHash := range blockHashes {
+		bKey := blockKey{hash: blockHash, modelName: vllmReq.GetModel()}
+		bKeys[i] = bKey
+	}
+	bc.requestToBlocks[vllmReq.GetRequestID()] = make([]blockKey, len(blockHashes))
+	copy(bc.requestToBlocks[vllmReq.GetRequestID()], bKeys)
 
 	if bc.usageChan != nil {
 		usage := common.MetricInfo{
@@ -258,7 +275,7 @@ func (bc *blockCache) finishRequest(requestID string) error {
 	now := time.Now()
 
 	// Decrease reference count for each block
-	errBlocks := make([]uint64, 0)
+	errBlocks := make([]blockKey, 0)
 	for _, blockHash := range blockHashes {
 		if refCount, exists := bc.usedBlocks[blockHash]; exists {
 			if refCount > 1 {
@@ -291,7 +308,7 @@ func (bc *blockCache) finishRequest(requestID string) error {
 			if i > 0 {
 				builder.WriteString(", ")
 			}
-			fmt.Fprintf(&builder, "%d", b)
+			fmt.Fprintf(&builder, "%d(%s)", b.hash, b.modelName)
 		}
 		return fmt.Errorf("not existing blocks %s for request %s", builder.String(), requestID)
 	}
@@ -311,7 +328,7 @@ func (bc *blockCache) getStats() (int, int, int) {
 // if block is in use by currently running requests the count will be positive, boolean is true
 // if block is in the unused list - count is 0, boolean is true
 // if block is not in both collections - count is 0, boolean is false
-func (bc *blockCache) getBlockInfo(blockHash uint64) (int, bool) {
+func (bc *blockCache) getBlockInfo(blockHash blockKey) (int, bool) {
 	bc.mu.RLock()
 	defer bc.mu.RUnlock()
 
@@ -325,6 +342,79 @@ func (bc *blockCache) getBlockInfo(blockHash uint64) (int, bool) {
 	}
 
 	return 0, false
+}
+
+// countCachedBlockPrefix returns the number of continuous blocks from the given list that are already in the cache
+func (bc *blockCache) countCachedBlockPrefix(blockHashes []uint64, modelName string) int {
+	bc.mu.RLock()
+	defer bc.mu.RUnlock()
+
+	if bc.disabled {
+		return 0
+	}
+
+	var count int
+	for _, blockHash := range blockHashes {
+		bKey := blockKey{hash: blockHash, modelName: modelName}
+		// Check if block is in used blocks (currently in use by running requests)
+		if _, exists := bc.usedBlocks[bKey]; exists {
+			count++
+		} else if _, exists := bc.unusedBlocks[bKey]; exists {
+			// Check if block is in unused blocks (was used in past)
+			count++
+		} else {
+			// return count once a block is not found in the cache
+			return count
+		}
+	}
+	return count
+}
+
+// pickBlockToEvict selects the best unused block to evict using priority:
+// 1. oldest unused block of an unloaded model
+// 2. oldest unused block of any model
+// Must be called with bc.mu held.
+func (bc *blockCache) pickBlockToEvict() blockKey {
+	var bestLoadedHash blockKey
+	bestLoadedTime := time.Now()
+	var bestUnloadedHash blockKey
+	bestUnloadedTime := time.Now()
+	hasUnloadedCandidate := false
+
+	for blockKey, t := range bc.unusedBlocks {
+		if bc.loadedModels[blockKey.modelName] {
+			// this is a block with loaded model,
+			// check if it's the best candidate among loaded models
+			if t.Before(bestLoadedTime) {
+				bestLoadedHash = blockKey
+				bestLoadedTime = t
+			}
+		} else {
+			// this is a block with unloaded model,
+			// check if it's the best candidate among unloaded models
+			if !hasUnloadedCandidate || t.Before(bestUnloadedTime) {
+				bestUnloadedHash = blockKey
+				bestUnloadedTime = t
+				hasUnloadedCandidate = true
+			}
+		}
+	}
+	if hasUnloadedCandidate {
+		return bestUnloadedHash
+	}
+	return bestLoadedHash
+}
+
+func (bc *blockCache) setModelLoaded(model string) {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+	bc.loadedModels[model] = true
+}
+
+func (bc *blockCache) setModelUnloaded(model string) {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+	delete(bc.loadedModels, model)
 }
 
 // ZMQ topic format is: kv@<pod-ip>@<model-name>

--- a/pkg/kv-cache/kv_cache.go
+++ b/pkg/kv-cache/kv_cache.go
@@ -50,7 +50,7 @@ type KVCacheHelper struct {
 func NewKVCacheHelper(ctx context.Context, config *common.Configuration, logger logr.Logger, usageChan common.Channel[common.MetricInfo],
 	prefixCacheStatsChan common.Channel[PrefixCacheStats], tokenizer tokenizer.Tokenizer) (*KVCacheHelper, error) {
 	if config.IP == "" {
-		return nil, errors.New("IP should be defined in the environment (POD_IP)")
+		return nil, errors.New("IP should be defined in the environment (POD_IP) for KV cache to work")
 	}
 
 	tokenProcConfig := kvblock.DefaultTokenProcessorConfig()
@@ -91,15 +91,14 @@ func (h *KVCacheHelper) Activate() {
 	h.blockCache.activate()
 }
 
-func (h *KVCacheHelper) OnRequestStart(vllmReq openaiserverapi.Request) (PrefixCacheStats, error) {
+func (h *KVCacheHelper) OnRequestStart(req openaiserverapi.Request) (PrefixCacheStats, error) {
 	h.logger.V(logging.TRACE).Info("KV cache - process request")
 
-	tokens := vllmReq.TokenizedPrompt().Tokens
-	modelName := vllmReq.GetModel()
+	tokens := req.TokenizedPrompt().Tokens
 
 	// compute per-block extra features from multimodal metadata (if present).
 	var extraFeatures []*kvblock.BlockExtraFeatures
-	mmFeatres := vllmReq.MMFeatures()
+	mmFeatres := req.MMFeatures()
 
 	if mmFeatres != nil {
 		extraFeatures = kvblock.ComputeBlockExtraFeatures(
@@ -108,7 +107,7 @@ func (h *KVCacheHelper) OnRequestStart(vllmReq openaiserverapi.Request) (PrefixC
 	}
 
 	// get block keys
-	blockKeys, err := h.tokensProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, modelName, extraFeatures)
+	blockKeys, err := h.tokensProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, req.GetModel(), extraFeatures)
 	if err != nil {
 		return PrefixCacheStats{}, fmt.Errorf("failed to convert tokens to block keys: %w", err)
 	}
@@ -121,13 +120,13 @@ func (h *KVCacheHelper) OnRequestStart(vllmReq openaiserverapi.Request) (PrefixC
 		blockTokens[i] = tokens[i*h.blockSize : i*h.blockSize+h.blockSize]
 	}
 
-	nBlocksAlreadyInCache, err := h.blockCache.startRequest(vllmReq, blockHashes, blockTokens)
+	nBlocksAlreadyInCache, err := h.blockCache.startRequest(req, blockHashes, blockTokens)
 	if err != nil {
 		return PrefixCacheStats{}, err
 	}
 
 	cachedTokens := nBlocksAlreadyInCache * h.blockSize
-	vllmReq.SetNumberOfCachedPromptTokens(cachedTokens)
+	req.SetNumberOfCachedPromptTokens(cachedTokens)
 
 	stats := PrefixCacheStats{
 		QueriedTokens: len(tokens),

--- a/pkg/kv-cache/kv_cache.go
+++ b/pkg/kv-cache/kv_cache.go
@@ -116,7 +116,7 @@ func (h *KVCacheHelper) OnRequestStart(vllmReq openaiserverapi.Request) (PrefixC
 	}
 
 	requestID := vllmReq.GetRequestID()
-	nBlocksAlreadyInCache, err := h.blockCache.startRequest(requestID, blockHashes, blockTokens)
+	nBlocksAlreadyInCache, err := h.blockCache.startRequest(requestID, vllmReq.GetLoraName(), blockHashes, blockTokens)
 	if err != nil {
 		return PrefixCacheStats{}, err
 	}

--- a/pkg/kv-cache/kv_cache.go
+++ b/pkg/kv-cache/kv_cache.go
@@ -18,6 +18,7 @@ package kvcache
 // contains all logic relevant to KV-cache support
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -48,6 +49,10 @@ type KVCacheHelper struct {
 
 func NewKVCacheHelper(ctx context.Context, config *common.Configuration, logger logr.Logger, usageChan common.Channel[common.MetricInfo],
 	prefixCacheStatsChan common.Channel[PrefixCacheStats], tokenizer tokenizer.Tokenizer) (*KVCacheHelper, error) {
+	if config.IP == "" {
+		return nil, errors.New("IP should be defined in the environment (POD_IP)")
+	}
+
 	tokenProcConfig := kvblock.DefaultTokenProcessorConfig()
 	tokenProcConfig.BlockSize = config.TokenBlockSize
 	if config.HashSeed != "" {
@@ -62,6 +67,7 @@ func NewKVCacheHelper(ctx context.Context, config *common.Configuration, logger 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create block cache: %w", err)
 	}
+
 	return &KVCacheHelper{
 		tokenizer:            tokenizer,
 		tokensProcessor:      tokensProcessor,
@@ -115,8 +121,7 @@ func (h *KVCacheHelper) OnRequestStart(vllmReq openaiserverapi.Request) (PrefixC
 		blockTokens[i] = tokens[i*h.blockSize : i*h.blockSize+h.blockSize]
 	}
 
-	requestID := vllmReq.GetRequestID()
-	nBlocksAlreadyInCache, err := h.blockCache.startRequest(requestID, vllmReq.GetLoraName(), blockHashes, blockTokens)
+	nBlocksAlreadyInCache, err := h.blockCache.startRequest(vllmReq, blockHashes, blockTokens)
 	if err != nil {
 		return PrefixCacheStats{}, err
 	}
@@ -135,4 +140,14 @@ func (h *KVCacheHelper) OnRequestStart(vllmReq openaiserverapi.Request) (PrefixC
 
 func (h *KVCacheHelper) OnRequestEnd(requestID string) error {
 	return h.blockCache.finishRequest(requestID)
+}
+
+// SetModelLoaded marks a model as loaded, affecting block eviction priority
+func (h *KVCacheHelper) SetModelLoaded(model string) {
+	h.blockCache.setModelLoaded(model)
+}
+
+// SetModelUnloaded marks a model as unloaded, its blocks become low-priority eviction candidates
+func (h *KVCacheHelper) SetModelUnloaded(model string) {
+	h.blockCache.setModelUnloaded(model)
 }

--- a/pkg/kv-cache/kv_cache.go
+++ b/pkg/kv-cache/kv_cache.go
@@ -107,7 +107,7 @@ func (h *KVCacheHelper) OnRequestStart(req openaiserverapi.Request) (PrefixCache
 	}
 
 	// get block keys
-	blockKeys, err := h.tokensProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, req.GetModel(), extraFeatures)
+	blockKeys, err := h.tokensProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, req.GetDisplayedModel(), extraFeatures)
 	if err != nil {
 		return PrefixCacheStats{}, fmt.Errorf("failed to convert tokens to block keys: %w", err)
 	}

--- a/pkg/kv-cache/kv_cache_sender.go
+++ b/pkg/kv-cache/kv_cache_sender.go
@@ -79,6 +79,7 @@ type EventData struct {
 	tokens   []uint32
 	hashes   []uint64
 	loraName *string
+	loraID   *int
 }
 
 type KVEventSender struct {
@@ -141,6 +142,7 @@ func (s *KVEventSender) Run(ctx context.Context) error {
 					Tokens:      eventData.tokens,
 					DeviceTier:  GPU,
 					ParentHash:  uint64(kvblock.EmptyBlockHash),
+					LoraID:      eventData.loraID,
 					LoraName:    eventData.loraName,
 				}
 			case eventActionRemove:
@@ -199,6 +201,8 @@ func (s *KVEventSender) publishHelper(ctx context.Context) error {
 				BlockHashes: convertUint64ToAnySlice(e.BlockHashes),
 				TokenIds:    e.Tokens,
 				Medium:      &GPU,
+				LoraID:      e.LoraID,
+				LoraName:    e.LoraName,
 			}
 		case *kvevents.BlockRemovedEvent:
 			raw = &msgpackBlockRemovedEvent{

--- a/pkg/kv-cache/kv_cache_sender.go
+++ b/pkg/kv-cache/kv_cache_sender.go
@@ -87,18 +87,20 @@ type KVEventSender struct {
 	topic        string
 	eventChan    common.Channel[EventData]
 	maxBatchSize int
+	blockSize    int
 	delay        time.Duration
 	batch        []kvevents.GenericEvent
 	logger       logr.Logger
 }
 
 func NewKVEventSender(publisher *common.Publisher, topic string, ch common.Channel[EventData], maxBatchSize int,
-	delay time.Duration, logger logr.Logger) *KVEventSender {
+	blockSize int, delay time.Duration, logger logr.Logger) *KVEventSender {
 	return &KVEventSender{
 		publisher:    publisher,
 		topic:        topic,
 		eventChan:    ch,
 		maxBatchSize: maxBatchSize,
+		blockSize:    blockSize,
 		delay:        delay,
 		batch:        make([]kvevents.GenericEvent, 0, maxBatchSize),
 		logger:       logger,
@@ -132,7 +134,6 @@ func (s *KVEventSender) Run(ctx context.Context) error {
 			}
 
 			// Encode eventData's hash value to msgpack.RawMessage
-			var err error
 			var event kvevents.GenericEvent
 
 			switch eventData.action {
@@ -151,9 +152,6 @@ func (s *KVEventSender) Run(ctx context.Context) error {
 				event = &kvevents.AllBlocksClearedEvent{DeviceTier: GPU}
 			default:
 				return fmt.Errorf("invalid event action %d", eventData.action)
-			}
-			if err != nil {
-				return fmt.Errorf("failed to marshal value: %w", err)
 			}
 
 			s.batch = append(s.batch, event)
@@ -197,12 +195,14 @@ func (s *KVEventSender) publishHelper(ctx context.Context) error {
 		switch e := event.(type) {
 		case *kvevents.BlockStoredEvent:
 			raw = &msgpackBlockStoredEvent{
-				Tag:         string(kvevents.EventTypeBlockStored),
-				BlockHashes: convertUint64ToAnySlice(e.BlockHashes),
-				TokenIds:    e.Tokens,
-				Medium:      &GPU,
-				LoraID:      e.LoraID,
-				LoraName:    e.LoraName,
+				Tag:             string(kvevents.EventTypeBlockStored),
+				BlockHashes:     convertUint64ToAnySlice(e.BlockHashes),
+				TokenIds:        e.Tokens,
+				Medium:          &e.DeviceTier,
+				LoraID:          e.LoraID,
+				LoraName:        e.LoraName,
+				ParentBlockHash: e.ParentHash,
+				BlockSize:       s.blockSize,
 			}
 		case *kvevents.BlockRemovedEvent:
 			raw = &msgpackBlockRemovedEvent{

--- a/pkg/kv-cache/kv_cache_sender.go
+++ b/pkg/kv-cache/kv_cache_sender.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
 	"github.com/vmihailenco/msgpack/v5"
 )
@@ -74,9 +75,10 @@ type msgpackAllBlocksClearedEvent struct {
 }
 
 type EventData struct {
-	action EventAction
-	tokens []uint32
-	hashes []uint64
+	action   EventAction
+	tokens   []uint32
+	hashes   []uint64
+	loraName *string
 }
 
 type KVEventSender struct {
@@ -134,7 +136,13 @@ func (s *KVEventSender) Run(ctx context.Context) error {
 
 			switch eventData.action {
 			case eventActionStore:
-				event = &kvevents.BlockStoredEvent{BlockHashes: eventData.hashes, Tokens: eventData.tokens, DeviceTier: GPU}
+				event = &kvevents.BlockStoredEvent{
+					BlockHashes: eventData.hashes,
+					Tokens:      eventData.tokens,
+					DeviceTier:  GPU,
+					ParentHash:  uint64(kvblock.EmptyBlockHash),
+					LoraName:    eventData.loraName,
+				}
 			case eventActionRemove:
 				event = &kvevents.BlockRemovedEvent{BlockHashes: eventData.hashes, DeviceTier: GPU}
 			case eventActionAllBlocksCleared:

--- a/pkg/kv-cache/kv_cache_test.go
+++ b/pkg/kv-cache/kv_cache_test.go
@@ -235,7 +235,7 @@ var _ = Describe("KV cache", Ordered, func() {
 						var err error
 						switch action.action {
 						case actionStartRequest:
-							_, err = blockCache.startRequest(action.request.id, action.request.blockHashes, action.request.tokens)
+							_, err = blockCache.startRequest(action.request.id, nil, action.request.blockHashes, action.request.tokens)
 						case actionFinishRequest:
 							err = blockCache.finishRequest(action.request.id)
 						}
@@ -346,19 +346,19 @@ var _ = Describe("KV cache", Ordered, func() {
 				req4 := testRequest{"req4", []uint64{5, 6}, [][]uint32{{1}, {2}}}
 
 				// blocks 1 and 2 stored
-				alreadyInCache, err := blockCache.startRequest(req1.id, req1.blockHashes, req1.tokens)
+				alreadyInCache, err := blockCache.startRequest(req1.id, nil, req1.blockHashes, req1.tokens)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(alreadyInCache).To(Equal(0))
 				// blocks 3 and 4 stored
-				alreadyInCache, err = blockCache.startRequest(req2.id, req2.blockHashes, req2.tokens)
+				alreadyInCache, err = blockCache.startRequest(req2.id, nil, req2.blockHashes, req2.tokens)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(alreadyInCache).To(Equal(0))
 				// no new blocks stored, reuse of 1 and 3
-				alreadyInCache, err = blockCache.startRequest(req3.id, req3.blockHashes, req3.tokens)
+				alreadyInCache, err = blockCache.startRequest(req3.id, nil, req3.blockHashes, req3.tokens)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(alreadyInCache).To(Equal(2))
 				// no space left - should fail
-				alreadyInCache, err = blockCache.startRequest(req4.id, req4.blockHashes, req4.tokens)
+				alreadyInCache, err = blockCache.startRequest(req4.id, nil, req4.blockHashes, req4.tokens)
 				Expect(err).To(HaveOccurred())
 				Expect(alreadyInCache).To(Equal(0))
 
@@ -369,7 +369,7 @@ var _ = Describe("KV cache", Ordered, func() {
 				// now 2 and 4 are not in use
 
 				// blocks 2 and 4 should be removed, and 5 and 6 stored
-				alreadyInCache, err = blockCache.startRequest(req4.id, req4.blockHashes, req4.tokens)
+				alreadyInCache, err = blockCache.startRequest(req4.id, nil, req4.blockHashes, req4.tokens)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(alreadyInCache).To(Equal(0))
 			}()
@@ -442,7 +442,7 @@ var _ = Describe("KV cache", Ordered, func() {
 							hashes, tokens := createRandomArray(testCase.minBlockLen, testCase.maxBlockLen,
 								testCase.maxHashValue, random)
 
-							_, err := blockCache.startRequest(reqID, hashes, tokens)
+							_, err := blockCache.startRequest(reqID, nil, hashes, tokens)
 							if err != nil {
 								// some operations may fail due to cache being full, which is expected
 								Expect(err.Error()).To(Equal(capacityError))

--- a/pkg/kv-cache/kv_cache_test.go
+++ b/pkg/kv-cache/kv_cache_test.go
@@ -43,8 +43,33 @@ const (
 
 type testRequest struct {
 	id          string
+	model       string
+	loraName    *string
+	loraID      *int
 	blockHashes []uint64
 	tokens      [][]uint32
+}
+
+// ensure testRequest implements the Request interface
+var _ Request = (*testRequest)(nil)
+
+func (t *testRequest) GetRequestID() string {
+	return t.id
+}
+
+func (t *testRequest) GetModel() string {
+	if t.model != "" {
+		return t.model
+	}
+	return common.TestModelName
+}
+
+func (t *testRequest) GetLoraName() *string {
+	return t.loraName
+}
+
+func (t *testRequest) GetLoraID() *int {
+	return t.loraID
 }
 
 type expectedBlockInfo struct {
@@ -122,10 +147,10 @@ var _ = Describe("KV cache", Ordered, func() {
 	Context("general tests", func() {
 		// check single request processing, ensure cache is valid after request processing started
 		// and after the processing was finished
-		req1 := testRequest{req1ID, []uint64{1, 2}, [][]uint32{{1}, {2}}}
-		req2 := testRequest{req2ID, []uint64{3, 4}, [][]uint32{{3}, {4}}}
-		req2_1 := testRequest{req2ID, []uint64{1, 3}, [][]uint32{{1}, {3}}}
-		req3 := testRequest{req3ID, []uint64{5, 6}, [][]uint32{{5}, {6}}}
+		req1 := testRequest{id: req1ID, blockHashes: []uint64{1, 2}, tokens: [][]uint32{{1}, {2}}}
+		req2 := testRequest{id: req2ID, blockHashes: []uint64{3, 4}, tokens: [][]uint32{{3}, {4}}}
+		req2_1 := testRequest{id: req2ID, blockHashes: []uint64{1, 3}, tokens: [][]uint32{{1}, {3}}}
+		req3 := testRequest{id: req3ID, blockHashes: []uint64{5, 6}, tokens: [][]uint32{{5}, {6}}}
 
 		testCases := []testCase{
 			{
@@ -235,7 +260,7 @@ var _ = Describe("KV cache", Ordered, func() {
 						var err error
 						switch action.action {
 						case actionStartRequest:
-							_, err = blockCache.startRequest(action.request.id, nil, action.request.blockHashes, action.request.tokens)
+							_, err = blockCache.startRequest(&action.request, action.request.blockHashes, action.request.tokens)
 						case actionFinishRequest:
 							err = blockCache.finishRequest(action.request.id)
 						}
@@ -268,7 +293,7 @@ var _ = Describe("KV cache", Ordered, func() {
 						// check specific blocks info if required
 						if len(action.expectedBlocksInfo) > 0 {
 							for block, expectedInfo := range action.expectedBlocksInfo {
-								refCount, exists := blockCache.getBlockInfo(block)
+								refCount, exists := blockCache.getBlockInfo(blockKey{hash: block, modelName: action.request.GetModel()})
 								if expectedInfo.exists {
 									Expect(exists).To(BeTrue())
 								} else {
@@ -340,25 +365,25 @@ var _ = Describe("KV cache", Ordered, func() {
 				// Make sure that the subscriber listens before the events are published
 				time.Sleep(time.Second)
 
-				req1 := testRequest{"req1", []uint64{1, 2}, [][]uint32{{1}, {2}}}
-				req2 := testRequest{"req2", []uint64{3, 4}, [][]uint32{{1}, {2}}}
-				req3 := testRequest{"req3", []uint64{1, 3}, [][]uint32{{1}, {2}}}
-				req4 := testRequest{"req4", []uint64{5, 6}, [][]uint32{{1}, {2}}}
+				req1 := testRequest{id: "req1", blockHashes: []uint64{1, 2}, tokens: [][]uint32{{1}, {2}}}
+				req2 := testRequest{id: "req2", blockHashes: []uint64{3, 4}, tokens: [][]uint32{{1}, {2}}}
+				req3 := testRequest{id: "req3", blockHashes: []uint64{1, 3}, tokens: [][]uint32{{1}, {2}}}
+				req4 := testRequest{id: "req4", blockHashes: []uint64{5, 6}, tokens: [][]uint32{{1}, {2}}}
 
 				// blocks 1 and 2 stored
-				alreadyInCache, err := blockCache.startRequest(req1.id, nil, req1.blockHashes, req1.tokens)
+				alreadyInCache, err := blockCache.startRequest(&req1, req1.blockHashes, req1.tokens)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(alreadyInCache).To(Equal(0))
 				// blocks 3 and 4 stored
-				alreadyInCache, err = blockCache.startRequest(req2.id, nil, req2.blockHashes, req2.tokens)
+				alreadyInCache, err = blockCache.startRequest(&req2, req2.blockHashes, req2.tokens)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(alreadyInCache).To(Equal(0))
 				// no new blocks stored, reuse of 1 and 3
-				alreadyInCache, err = blockCache.startRequest(req3.id, nil, req3.blockHashes, req3.tokens)
+				alreadyInCache, err = blockCache.startRequest(&req3, req3.blockHashes, req3.tokens)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(alreadyInCache).To(Equal(2))
 				// no space left - should fail
-				alreadyInCache, err = blockCache.startRequest(req4.id, nil, req4.blockHashes, req4.tokens)
+				alreadyInCache, err = blockCache.startRequest(&req4, req4.blockHashes, req4.tokens)
 				Expect(err).To(HaveOccurred())
 				Expect(alreadyInCache).To(Equal(0))
 
@@ -369,7 +394,7 @@ var _ = Describe("KV cache", Ordered, func() {
 				// now 2 and 4 are not in use
 
 				// blocks 2 and 4 should be removed, and 5 and 6 stored
-				alreadyInCache, err = blockCache.startRequest(req4.id, nil, req4.blockHashes, req4.tokens)
+				alreadyInCache, err = blockCache.startRequest(&req4, req4.blockHashes, req4.tokens)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(alreadyInCache).To(Equal(0))
 			}()
@@ -442,7 +467,12 @@ var _ = Describe("KV cache", Ordered, func() {
 							hashes, tokens := createRandomArray(testCase.minBlockLen, testCase.maxBlockLen,
 								testCase.maxHashValue, random)
 
-							_, err := blockCache.startRequest(reqID, nil, hashes, tokens)
+							req := testRequest{
+								id:          reqID,
+								blockHashes: hashes,
+								tokens:      tokens,
+							}
+							_, err := blockCache.startRequest(&req, hashes, tokens)
 							if err != nil {
 								// some operations may fail due to cache being full, which is expected
 								Expect(err.Error()).To(Equal(capacityError))

--- a/pkg/kv-cache/kv_cache_test.go
+++ b/pkg/kv-cache/kv_cache_test.go
@@ -57,7 +57,7 @@ func (t *testRequest) GetRequestID() string {
 	return t.id
 }
 
-func (t *testRequest) GetModel() string {
+func (t *testRequest) GetDisplayedModel() string {
 	if t.model != "" {
 		return t.model
 	}
@@ -293,7 +293,7 @@ var _ = Describe("KV cache", Ordered, func() {
 						// check specific blocks info if required
 						if len(action.expectedBlocksInfo) > 0 {
 							for block, expectedInfo := range action.expectedBlocksInfo {
-								refCount, exists := blockCache.getBlockInfo(blockKey{hash: block, modelName: action.request.GetModel()})
+								refCount, exists := blockCache.getBlockInfo(blockKey{hash: block, modelName: action.request.GetDisplayedModel()})
 								if expectedInfo.exists {
 									Expect(exists).To(BeTrue())
 								} else {
@@ -314,9 +314,9 @@ var _ = Describe("KV cache", Ordered, func() {
 				for i, seq := 0, uint64(1); i < expectedTotal; i, seq = storedCount+removedCount, seq+1 {
 					msg, err := sub.Recv()
 					Expect(err).NotTo(HaveOccurred())
-					stored, removed, _ := ParseKVEvent(msg.Frames, topic, seq)
-					storedCount += len(stored)
-					removedCount += len(removed)
+					stored, removed, _ := CountKVEventBlocks(msg.Frames, topic, seq)
+					storedCount += stored
+					removedCount += removed
 				}
 				Expect(removedCount).To(Equal(test.expectedRemovedBlocks))
 				Expect(storedCount).To(Equal(test.expectedStoredBlocks))
@@ -405,8 +405,10 @@ var _ = Describe("KV cache", Ordered, func() {
 			for {
 				msg, err := sub.Recv()
 				Expect(err).NotTo(HaveOccurred())
-				stored, removed, _ := ParseKVEvent(msg.Frames, topic, count)
-				storedBlocks = append(storedBlocks, stored...)
+				storedEvents, removed, _ := ParseKVEvent(msg.Frames, topic, count)
+				for _, e := range storedEvents {
+					storedBlocks = append(storedBlocks, e.BlockHashes...)
+				}
 				removedBlocks = append(removedBlocks, removed...)
 				count++
 
@@ -498,6 +500,432 @@ var _ = Describe("KV cache", Ordered, func() {
 				Expect(totalBlocks).To(Equal(unusedBlocks))
 			})
 		}
+	})
+
+	Context("model-aware blocks", func() {
+		const loraModel = "loraX"
+
+		It("same hash different model should be stored as separate blocks", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			config := &common.Configuration{
+				IP:          localhost,
+				Port:        1234,
+				Model:       common.TestModelName,
+				KVCacheSize: 10,
+			}
+
+			blockCache, err := newBlockCache(ctx, config, GinkgoLogr, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			reqA := testRequest{id: "reqA", model: common.TestModelName, blockHashes: []uint64{1, 2}, tokens: [][]uint32{{1}, {2}}}
+			reqB := testRequest{id: "reqB", model: loraModel, blockHashes: []uint64{1, 2}, tokens: [][]uint32{{1}, {2}}}
+
+			_, err = blockCache.startRequest(&reqA, reqA.blockHashes, reqA.tokens)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = blockCache.startRequest(&reqB, reqB.blockHashes, reqB.tokens)
+			Expect(err).NotTo(HaveOccurred())
+
+			// 4 distinct blocks (2 per model), 2 active requests
+			activeReqs, totalBlocks, unusedBlocks := blockCache.getStats()
+			Expect(activeReqs).To(Equal(2))
+			Expect(totalBlocks).To(Equal(4))
+			Expect(unusedBlocks).To(Equal(0))
+
+			// blocks are independent per model
+			refCount, exists := blockCache.getBlockInfo(blockKey{hash: 1, modelName: common.TestModelName})
+			Expect(exists).To(BeTrue())
+			Expect(refCount).To(Equal(1))
+
+			refCount, exists = blockCache.getBlockInfo(blockKey{hash: 1, modelName: loraModel})
+			Expect(exists).To(BeTrue())
+			Expect(refCount).To(Equal(1))
+
+			// finishing reqA only affects base model blocks
+			err = blockCache.finishRequest(reqA.id)
+			Expect(err).NotTo(HaveOccurred())
+
+			refCount, exists = blockCache.getBlockInfo(blockKey{hash: 1, modelName: common.TestModelName})
+			Expect(exists).To(BeTrue())
+			Expect(refCount).To(Equal(0)) // unused
+
+			refCount, exists = blockCache.getBlockInfo(blockKey{hash: 1, modelName: loraModel})
+			Expect(exists).To(BeTrue())
+			Expect(refCount).To(Equal(1)) // still in use
+		})
+
+		It("should not reuse blocks across models", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			config := &common.Configuration{
+				IP:          localhost,
+				Port:        1234,
+				Model:       common.TestModelName,
+				KVCacheSize: 10,
+			}
+
+			blockCache, err := newBlockCache(ctx, config, GinkgoLogr, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			reqA := testRequest{id: "reqA", model: common.TestModelName, blockHashes: []uint64{1, 2}, tokens: [][]uint32{{1}, {2}}}
+			_, err = blockCache.startRequest(&reqA, reqA.blockHashes, reqA.tokens)
+			Expect(err).NotTo(HaveOccurred())
+			err = blockCache.finishRequest(reqA.id)
+			Expect(err).NotTo(HaveOccurred())
+
+			// same hashes but different model - should NOT find them in cache
+			reqB := testRequest{id: "reqB", model: loraModel, blockHashes: []uint64{1, 2}, tokens: [][]uint32{{1}, {2}}}
+			alreadyInCache, err := blockCache.startRequest(&reqB, reqB.blockHashes, reqB.tokens)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(alreadyInCache).To(Equal(0))
+
+			_, totalBlocks, _ := blockCache.getStats()
+			Expect(totalBlocks).To(Equal(4))
+		})
+
+		It("countCachedBlockPrefix should be model-scoped", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			config := &common.Configuration{
+				IP:          localhost,
+				Port:        1234,
+				Model:       common.TestModelName,
+				KVCacheSize: 10,
+			}
+
+			blockCache, err := newBlockCache(ctx, config, GinkgoLogr, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			req := testRequest{id: "req1", model: common.TestModelName, blockHashes: []uint64{1, 2, 3}, tokens: [][]uint32{{1}, {2}, {3}}}
+			_, err = blockCache.startRequest(&req, req.blockHashes, req.tokens)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(blockCache.countCachedBlockPrefix([]uint64{1, 2, 3}, common.TestModelName)).To(Equal(3))
+			Expect(blockCache.countCachedBlockPrefix([]uint64{1, 2, 3}, loraModel)).To(Equal(0))
+		})
+	})
+
+	Context("model-aware eviction", func() {
+		const lora1 = "lora1"
+		const lora2 = "lora2"
+
+		It("should evict unloaded lora blocks before loaded lora blocks", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			config := &common.Configuration{
+				IP:          localhost,
+				Port:        1234,
+				Model:       common.TestModelName,
+				KVCacheSize: 4,
+			}
+
+			blockCache, err := newBlockCache(ctx, config, GinkgoLogr, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			// lora1 is loaded, lora2 is not
+			blockCache.setModelLoaded(lora1)
+
+			reqL1 := testRequest{id: "reqL1", model: lora1, blockHashes: []uint64{10, 20}, tokens: [][]uint32{{10}, {20}}}
+			reqL2 := testRequest{id: "reqL2", model: lora2, blockHashes: []uint64{30, 40}, tokens: [][]uint32{{30}, {40}}}
+
+			_, err = blockCache.startRequest(&reqL1, reqL1.blockHashes, reqL1.tokens)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = blockCache.startRequest(&reqL2, reqL2.blockHashes, reqL2.tokens)
+			Expect(err).NotTo(HaveOccurred())
+
+			// finish both - all 4 blocks become unused, cache is full
+			err = blockCache.finishRequest(reqL1.id)
+			Expect(err).NotTo(HaveOccurred())
+			err = blockCache.finishRequest(reqL2.id)
+			Expect(err).NotTo(HaveOccurred())
+
+			// add a new block - should evict from lora2 (unloaded) first
+			reqNew := testRequest{id: "reqNew", model: lora1, blockHashes: []uint64{50}, tokens: [][]uint32{{50}}}
+			_, err = blockCache.startRequest(&reqNew, reqNew.blockHashes, reqNew.tokens)
+			Expect(err).NotTo(HaveOccurred())
+
+			// lora2 block 30 (oldest unloaded) should be evicted
+			_, exists := blockCache.getBlockInfo(blockKey{hash: 30, modelName: lora2})
+			Expect(exists).To(BeFalse())
+
+			// lora1 blocks should still exist
+			_, exists = blockCache.getBlockInfo(blockKey{hash: 10, modelName: lora1})
+			Expect(exists).To(BeTrue())
+			_, exists = blockCache.getBlockInfo(blockKey{hash: 20, modelName: lora1})
+			Expect(exists).To(BeTrue())
+		})
+
+		It("should fall back to oldest loaded-model block when no unloaded blocks exist", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			config := &common.Configuration{
+				IP:          localhost,
+				Port:        1234,
+				Model:       common.TestModelName,
+				KVCacheSize: 3,
+			}
+
+			blockCache, err := newBlockCache(ctx, config, GinkgoLogr, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			blockCache.setModelLoaded(lora1)
+
+			// fill cache with lora1 blocks only (all loaded)
+			req1 := testRequest{id: "req1", model: lora1, blockHashes: []uint64{1, 2, 3}, tokens: [][]uint32{{1}, {2}, {3}}}
+			_, err = blockCache.startRequest(&req1, req1.blockHashes, req1.tokens)
+			Expect(err).NotTo(HaveOccurred())
+			err = blockCache.finishRequest(req1.id)
+			Expect(err).NotTo(HaveOccurred())
+
+			// add a new block - must evict from loaded model (only option)
+			reqNew := testRequest{id: "reqNew", model: lora1, blockHashes: []uint64{99}, tokens: [][]uint32{{99}}}
+			_, err = blockCache.startRequest(&reqNew, reqNew.blockHashes, reqNew.tokens)
+			Expect(err).NotTo(HaveOccurred())
+
+			// exactly one of the three original blocks should be evicted
+			surviving := 0
+			for i := 1; i <= 3; i++ {
+				_, exists := blockCache.getBlockInfo(blockKey{hash: uint64(i), modelName: lora1})
+				if exists {
+					surviving++
+				}
+			}
+			Expect(surviving).To(Equal(2), "expected exactly 1 eviction out of 3 blocks")
+		})
+
+		It("should prefer newly unloaded model blocks after setModelUnloaded", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			config := &common.Configuration{
+				IP:          localhost,
+				Port:        1234,
+				Model:       common.TestModelName,
+				KVCacheSize: 4,
+			}
+
+			blockCache, err := newBlockCache(ctx, config, GinkgoLogr, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			// both loras loaded
+			blockCache.setModelLoaded(lora1)
+			blockCache.setModelLoaded(lora2)
+
+			reqL1 := testRequest{id: "reqL1", model: lora1, blockHashes: []uint64{10, 20}, tokens: [][]uint32{{10}, {20}}}
+			reqL2 := testRequest{id: "reqL2", model: lora2, blockHashes: []uint64{30, 40}, tokens: [][]uint32{{30}, {40}}}
+
+			_, err = blockCache.startRequest(&reqL1, reqL1.blockHashes, reqL1.tokens)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = blockCache.startRequest(&reqL2, reqL2.blockHashes, reqL2.tokens)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = blockCache.finishRequest(reqL1.id)
+			Expect(err).NotTo(HaveOccurred())
+			err = blockCache.finishRequest(reqL2.id)
+			Expect(err).NotTo(HaveOccurred())
+
+			// unload lora2 - its blocks become low-priority eviction candidates
+			blockCache.setModelUnloaded(lora2)
+
+			// force eviction
+			reqNew := testRequest{id: "reqNew", model: lora1, blockHashes: []uint64{50}, tokens: [][]uint32{{50}}}
+			_, err = blockCache.startRequest(&reqNew, reqNew.blockHashes, reqNew.tokens)
+			Expect(err).NotTo(HaveOccurred())
+
+			// lora2 block (unloaded) should be evicted first
+			_, exists := blockCache.getBlockInfo(blockKey{hash: 30, modelName: lora2})
+			Expect(exists).To(BeFalse())
+
+			// lora1 blocks should remain
+			_, exists = blockCache.getBlockInfo(blockKey{hash: 10, modelName: lora1})
+			Expect(exists).To(BeTrue())
+			_, exists = blockCache.getBlockInfo(blockKey{hash: 20, modelName: lora1})
+			Expect(exists).To(BeTrue())
+		})
+	})
+
+	Context("lora fields in events", func() {
+
+		It("store events should carry lora metadata", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			config := &common.Configuration{
+				IP:             localhost,
+				Port:           1234,
+				Model:          common.TestModelName,
+				KVCacheSize:    10,
+				EventBatchSize: 1,
+			}
+
+			topic := CreateKVEventsTopic(localhost, config.Model)
+			sub, endpoint := common.CreateSub(ctx, topic)
+			config.ZMQEndpoint = endpoint
+			//nolint
+			defer sub.Close()
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+
+			blockCache, err := newBlockCache(ctx, config, GinkgoLogr, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			go func() {
+				blockCache.start(ctx)
+				wg.Done()
+			}()
+
+			defer func() {
+				cancel()
+				wg.Wait()
+			}()
+
+			loraName := "lora1"
+			loraID := 1
+
+			go func() {
+				time.Sleep(time.Second)
+
+				// base model request - no lora info
+				reqBase := testRequest{
+					id:          "reqBase",
+					model:       common.TestModelName,
+					blockHashes: []uint64{1, 2},
+					tokens:      [][]uint32{{1}, {2}},
+				}
+				_, err := blockCache.startRequest(&reqBase, reqBase.blockHashes, reqBase.tokens)
+				Expect(err).NotTo(HaveOccurred())
+
+				// lora request - with lora info
+				reqLora := testRequest{
+					id:          "reqLora",
+					model:       loraName,
+					loraName:    &loraName,
+					loraID:      &loraID,
+					blockHashes: []uint64{3, 4},
+					tokens:      [][]uint32{{3}, {4}},
+				}
+				_, err = blockCache.startRequest(&reqLora, reqLora.blockHashes, reqLora.tokens)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			// collect 2 store events
+			storedEvents := make([]StoredEventInfo, 0)
+			seq := uint64(1)
+			for len(storedEvents) < 2 {
+				msg, err := sub.Recv()
+				Expect(err).NotTo(HaveOccurred())
+				events, _, _ := ParseKVEvent(msg.Frames, topic, seq)
+				storedEvents = append(storedEvents, events...)
+				seq++
+			}
+
+			// first event (base model) should have nil lora fields
+			Expect(storedEvents[0].LoraName).To(BeNil())
+			Expect(storedEvents[0].LoraID).To(BeNil())
+			Expect(storedEvents[0].BlockHashes).To(Equal([]uint64{1, 2}))
+
+			// second event (lora) should carry lora metadata
+			Expect(storedEvents[1].LoraName).NotTo(BeNil())
+			Expect(*storedEvents[1].LoraName).To(Equal(loraName))
+			Expect(storedEvents[1].LoraID).NotTo(BeNil())
+			Expect(*storedEvents[1].LoraID).To(Equal(loraID))
+			Expect(storedEvents[1].BlockHashes).To(Equal([]uint64{3, 4}))
+		})
+
+		It("same prompt with base model and lora should produce separate events", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			config := &common.Configuration{
+				IP:             localhost,
+				Port:           1234,
+				Model:          common.TestModelName,
+				KVCacheSize:    10,
+				EventBatchSize: 1,
+			}
+
+			topic := CreateKVEventsTopic(localhost, config.Model)
+			sub, endpoint := common.CreateSub(ctx, topic)
+			config.ZMQEndpoint = endpoint
+			//nolint
+			defer sub.Close()
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+
+			blockCache, err := newBlockCache(ctx, config, GinkgoLogr, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			go func() {
+				blockCache.start(ctx)
+				wg.Done()
+			}()
+
+			defer func() {
+				cancel()
+				wg.Wait()
+			}()
+
+			loraName := "lora1"
+			loraID := 1
+
+			go func() {
+				time.Sleep(time.Second)
+
+				// same hashes, different models
+				req1 := testRequest{
+					id:          "req1",
+					model:       common.TestModelName,
+					blockHashes: []uint64{10, 20},
+					tokens:      [][]uint32{{10}, {20}},
+				}
+				_, err := blockCache.startRequest(&req1, req1.blockHashes, req1.tokens)
+				Expect(err).NotTo(HaveOccurred())
+
+				req2 := testRequest{
+					id:          "req2",
+					model:       loraName,
+					loraName:    &loraName,
+					loraID:      &loraID,
+					blockHashes: []uint64{10, 20},
+					tokens:      [][]uint32{{10}, {20}},
+				}
+				_, err = blockCache.startRequest(&req2, req2.blockHashes, req2.tokens)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			// both requests store new blocks (4 total) since models differ
+			storedEvents := make([]StoredEventInfo, 0)
+			seq := uint64(1)
+			totalStoredHashes := 0
+			for totalStoredHashes < 4 {
+				msg, err := sub.Recv()
+				Expect(err).NotTo(HaveOccurred())
+				events, _, _ := ParseKVEvent(msg.Frames, topic, seq)
+				for _, e := range events {
+					totalStoredHashes += len(e.BlockHashes)
+				}
+				storedEvents = append(storedEvents, events...)
+				seq++
+			}
+
+			Expect(totalStoredHashes).To(Equal(4))
+			Expect(storedEvents).To(HaveLen(2))
+
+			// first event: base model, no lora
+			Expect(storedEvents[0].LoraName).To(BeNil())
+			Expect(storedEvents[0].BlockHashes).To(Equal([]uint64{10, 20}))
+
+			// second event: lora
+			Expect(storedEvents[1].LoraName).NotTo(BeNil())
+			Expect(*storedEvents[1].LoraName).To(Equal(loraName))
+			Expect(*storedEvents[1].LoraID).To(Equal(loraID))
+			Expect(storedEvents[1].BlockHashes).To(Equal([]uint64{10, 20}))
+		})
 	})
 })
 

--- a/pkg/kv-cache/kv_test_helper.go
+++ b/pkg/kv-cache/kv_test_helper.go
@@ -27,39 +27,53 @@ import (
 
 var vllmAdapter *engineadapter.VLLMAdapter = engineadapter.NewVLLMAdapter()
 
-func ParseKVEvent(parts [][]byte, expectedTopic string, expectedSeq uint64) ([]uint64, []uint64, bool) {
+// StoredEventInfo holds parsed metadata from a single BlockStoredEvent
+type StoredEventInfo struct {
+	BlockHashes []uint64
+	LoraName    *string
+	LoraID      *int
+}
+
+func parseBatch(parts [][]byte, expectedTopic string, expectedSeq uint64) kvevents.EventBatch {
 	// The message should be [topic, seq, payload]
 	gomega.Expect(parts).To(gomega.HaveLen(3))
-
 	gomega.Expect(string(parts[0])).To(gomega.Equal(expectedTopic))
 
 	seq := binary.BigEndian.Uint64(parts[1])
 	gomega.Expect(seq).To(gomega.Equal(expectedSeq))
 
-	// vllmAdapter := engineadapter.NewVLLMAdapter()
 	rawMsg := kvevents.RawMessage{
 		Topic:    string(parts[0]),
 		Sequence: seq,
 		Payload:  parts[2],
 	}
 
-	// use vllm adapter from kv-cache to parse the message into a batch of generic events
 	_, _, batch, err := vllmAdapter.ParseMessage(&rawMsg)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+	return batch
+}
+
+// ParseKVEvent parses a ZMQ message and returns rich stored event info (with LoRA metadata),
+// removed block hashes, and whether an all-blocks-cleared event was received.
+func ParseKVEvent(parts [][]byte, expectedTopic string, expectedSeq uint64) ([]StoredEventInfo, []uint64, bool) {
+	batch := parseBatch(parts, expectedTopic, expectedSeq)
+
 	removed := make([]uint64, 0)
-	stored := make([]uint64, 0)
+	storedEvents := make([]StoredEventInfo, 0)
 	allCleared := false
 
 	for _, genEvent := range batch.Events {
 		switch genEvent.Type() {
 		case kvevents.EventTypeBlockStored:
-			var storeEvent *kvevents.BlockStoredEvent
 			storeEvent, ok := genEvent.(*kvevents.BlockStoredEvent)
 			gomega.Expect(ok).To(gomega.BeTrue())
-			stored = append(stored, storeEvent.BlockHashes...)
+			storedEvents = append(storedEvents, StoredEventInfo{
+				BlockHashes: storeEvent.BlockHashes,
+				LoraName:    storeEvent.LoraName,
+				LoraID:      storeEvent.LoraID,
+			})
 		case kvevents.EventTypeBlockRemoved:
-			var removeEvent *kvevents.BlockRemovedEvent
 			removeEvent, ok := genEvent.(*kvevents.BlockRemovedEvent)
 			gomega.Expect(ok).To(gomega.BeTrue())
 			removed = append(removed, removeEvent.BlockHashes...)
@@ -69,9 +83,39 @@ func ParseKVEvent(parts [][]byte, expectedTopic string, expectedSeq uint64) ([]u
 			allCleared = true
 		default:
 			ginkgo.Fail("unexpected tag " + string(genEvent.Type()))
-			continue
 		}
 	}
 
-	return stored, removed, allCleared
+	return storedEvents, removed, allCleared
+}
+
+// CountKVEventBlocks parses a ZMQ message and returns the total number of stored blocks,
+// total number of removed blocks, and whether an all-blocks-cleared event was received.
+func CountKVEventBlocks(parts [][]byte, expectedTopic string, expectedSeq uint64) (int, int, bool) {
+	batch := parseBatch(parts, expectedTopic, expectedSeq)
+
+	storedCount := 0
+	removedCount := 0
+	allCleared := false
+
+	for _, genEvent := range batch.Events {
+		switch genEvent.Type() {
+		case kvevents.EventTypeBlockStored:
+			storeEvent, ok := genEvent.(*kvevents.BlockStoredEvent)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			storedCount += len(storeEvent.BlockHashes)
+		case kvevents.EventTypeBlockRemoved:
+			removeEvent, ok := genEvent.(*kvevents.BlockRemovedEvent)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			removedCount += len(removeEvent.BlockHashes)
+		case kvevents.EventTypeAllBlocksCleared:
+			_, ok := genEvent.(*kvevents.AllBlocksClearedEvent)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			allCleared = true
+		default:
+			ginkgo.Fail("unexpected tag " + string(genEvent.Type()))
+		}
+	}
+
+	return storedCount, removedCount, allCleared
 }

--- a/pkg/llm-d-inference-sim/context.go
+++ b/pkg/llm-d-inference-sim/context.go
@@ -37,6 +37,8 @@ type lorasUsageInfo struct {
 	mux sync.RWMutex
 	// lora adapter name -> reference count (number of currently running requests)
 	loadedLoras map[string]int
+	// loraIDs indices of loaded loras, element i holds the name of the lora at index i+1, empty means a free slot
+	loraIDs []string
 	// channel for "there is a LoRA that can be removed" event
 	loraRemovable common.Channel[int]
 	// maximum number of LoRAs that can be used simultaneously
@@ -82,6 +84,7 @@ func (s *SimContext) initialize(ctx context.Context) error {
 		s.loraAdaptors.Store(lora.Name, lora.Path)
 	}
 	s.loras.maxLoras = s.Config.MaxLoras
+	s.loras.loraIDs = make([]string, s.Config.MaxLoras)
 	s.loras.loraRemovable = common.Channel[int]{
 		Channel: make(chan int, s.Config.MaxNumSeqs),
 		Name:    "loraRemovable",
@@ -154,7 +157,7 @@ func (s *SimContext) initDataset(ctx context.Context) error {
 }
 
 // isLora returns true if the given model name is one of loaded LoRAs
-func (s *SimContext) IsLora(model string) bool {
+func (s *SimContext) isLora(model string) bool {
 	for _, lora := range s.getLoras() {
 		if model == lora {
 			return true
@@ -168,7 +171,7 @@ func (s *SimContext) IsLora(model string) bool {
 // responses.  LoRA adapters keep their explicit name, while all base-model
 // requests are surfaced as the first alias from --served-model-name.
 func (s *SimContext) getDisplayedModelName(reqModel string) string {
-	if s.IsLora(reqModel) {
+	if s.isLora(reqModel) {
 		return reqModel
 	}
 	return s.Config.ServedModelNames[0]

--- a/pkg/llm-d-inference-sim/context.go
+++ b/pkg/llm-d-inference-sim/context.go
@@ -154,7 +154,7 @@ func (s *SimContext) initDataset(ctx context.Context) error {
 }
 
 // isLora returns true if the given model name is one of loaded LoRAs
-func (s *SimContext) isLora(model string) bool {
+func (s *SimContext) IsLora(model string) bool {
 	for _, lora := range s.getLoras() {
 		if model == lora {
 			return true
@@ -168,7 +168,7 @@ func (s *SimContext) isLora(model string) bool {
 // responses.  LoRA adapters keep their explicit name, while all base-model
 // requests are surfaced as the first alias from --served-model-name.
 func (s *SimContext) getDisplayedModelName(reqModel string) string {
-	if s.isLora(reqModel) {
+	if s.IsLora(reqModel) {
 		return reqModel
 	}
 	return s.Config.ServedModelNames[0]

--- a/pkg/llm-d-inference-sim/lora.go
+++ b/pkg/llm-d-inference-sim/lora.go
@@ -89,7 +89,7 @@ func (s *SimContext) UnloadLoraAdaptor(ctx *fasthttp.RequestCtx) {
 
 // Checks if the LoRA adaptor is loaded
 func (s *SimContext) loraIsLoaded(model string) bool {
-	if !s.isLora(model) {
+	if !s.IsLora(model) {
 		return true
 	}
 
@@ -102,7 +102,7 @@ func (s *SimContext) loraIsLoaded(model string) bool {
 
 // Load the LoRA adaptor if possible. Return false if not.
 func (s *SimContext) loadLora(model string) bool {
-	if !s.isLora(model) {
+	if !s.IsLora(model) {
 		return true
 	}
 
@@ -133,7 +133,7 @@ func (s *SimContext) loadLora(model string) bool {
 // (if the model is a LoRA). Can be called only for loaded LoRAs (that are
 // already in loras.loadedLoras)
 func (s *SimContext) incrementLora(model string) {
-	if !s.isLora(model) {
+	if !s.IsLora(model) {
 		return
 	}
 
@@ -145,7 +145,7 @@ func (s *SimContext) incrementLora(model string) {
 // decrementLora decrements the count of running requests using the model
 // (if the model is a LoRA)
 func (s *SimContext) decrementLora(model string) {
-	if model == "" || !s.isLora(model) {
+	if model == "" || !s.IsLora(model) {
 		return
 	}
 

--- a/pkg/llm-d-inference-sim/lora.go
+++ b/pkg/llm-d-inference-sim/lora.go
@@ -171,22 +171,19 @@ func (s *SimContext) decrementLora(model string) {
 // assignLoraID assigns the next free index to a lora if it doesn't already have one.
 // Caller must hold s.loras.mux (called from loadLora which holds the write lock).
 func (s *SimContext) assignLoraID(lora string) {
-	firstFreeIndex := -1
-
 	for i, name := range s.loras.loraIDs {
-		if firstFreeIndex == -1 && name == "" {
-			firstFreeIndex = i
-		}
 		if name == lora {
+			// the LoRA already has an assigned ID, no need to assign again
+			return
+		}
+		if name == "" {
+			// assign this free slot to the LoRA
+			s.loras.loraIDs[i] = lora
 			return
 		}
 	}
-	// if we are here, this means the lora doesn't have an index yet, assign it the first free index
-	if firstFreeIndex != -1 {
-		s.loras.loraIDs[firstFreeIndex] = lora
-	} else {
-		s.logger.Error(fmt.Errorf("no free index for LoRA %s", lora), "failed to assign index to LoRA")
-	}
+	// should't happen since loadLora checks maxLoras, but log just in case
+	s.logger.Error(fmt.Errorf("no free index for LoRA %s", lora), "failed to assign index to LoRA")
 }
 
 // freeLoraID releases the index held by the given lora.

--- a/pkg/llm-d-inference-sim/lora.go
+++ b/pkg/llm-d-inference-sim/lora.go
@@ -19,6 +19,7 @@ package llmdinferencesim
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
@@ -89,7 +90,7 @@ func (s *SimContext) UnloadLoraAdaptor(ctx *fasthttp.RequestCtx) {
 
 // Checks if the LoRA adaptor is loaded
 func (s *SimContext) loraIsLoaded(model string) bool {
-	if !s.IsLora(model) {
+	if !s.isLora(model) {
 		return true
 	}
 
@@ -102,7 +103,7 @@ func (s *SimContext) loraIsLoaded(model string) bool {
 
 // Load the LoRA adaptor if possible. Return false if not.
 func (s *SimContext) loadLora(model string) bool {
-	if !s.IsLora(model) {
+	if !s.isLora(model) {
 		return true
 	}
 
@@ -117,6 +118,10 @@ func (s *SimContext) loadLora(model string) bool {
 		// maxLoras, try to find a LoRA that is not in use, and unload it
 		for lora, count := range s.loras.loadedLoras {
 			if count == 0 {
+				s.freeLoraID(lora)
+				if s.kvcacheHelper != nil {
+					s.kvcacheHelper.SetModelUnloaded(lora)
+				}
 				delete(s.loras.loadedLoras, lora)
 				ok = true
 				break
@@ -125,6 +130,10 @@ func (s *SimContext) loadLora(model string) bool {
 	}
 	if ok {
 		s.loras.loadedLoras[model]++
+		s.assignLoraID(model)
+		if s.kvcacheHelper != nil {
+			s.kvcacheHelper.SetModelLoaded(model)
+		}
 	}
 	return ok
 }
@@ -133,7 +142,7 @@ func (s *SimContext) loadLora(model string) bool {
 // (if the model is a LoRA). Can be called only for loaded LoRAs (that are
 // already in loras.loadedLoras)
 func (s *SimContext) incrementLora(model string) {
-	if !s.IsLora(model) {
+	if !s.isLora(model) {
 		return
 	}
 
@@ -145,7 +154,7 @@ func (s *SimContext) incrementLora(model string) {
 // decrementLora decrements the count of running requests using the model
 // (if the model is a LoRA)
 func (s *SimContext) decrementLora(model string) {
-	if model == "" || !s.IsLora(model) {
+	if model == "" || !s.isLora(model) {
 		return
 	}
 
@@ -157,4 +166,49 @@ func (s *SimContext) decrementLora(model string) {
 		// last usage of this LoRA
 		common.WriteToChannel(s.loras.loraRemovable, 1, s.logger)
 	}
+}
+
+// assignLoraID assigns the next free index to a lora if it doesn't already have one.
+// Caller must hold s.loras.mux (called from loadLora which holds the write lock).
+func (s *SimContext) assignLoraID(lora string) {
+	firstFreeIndex := -1
+
+	for i, name := range s.loras.loraIDs {
+		if firstFreeIndex == -1 && name == "" {
+			firstFreeIndex = i
+		}
+		if name == lora {
+			return
+		}
+	}
+	// if we are here, this means the lora doesn't have an index yet, assign it the first free index
+	if firstFreeIndex != -1 {
+		s.loras.loraIDs[firstFreeIndex] = lora
+	} else {
+		s.logger.Error(fmt.Errorf("no free index for LoRA %s", lora), "failed to assign index to LoRA")
+	}
+}
+
+// freeLoraID releases the index held by the given lora.
+// Caller must hold s.loras.mux (called from loadLora which holds the write lock).
+func (s *SimContext) freeLoraID(lora string) {
+	for i, name := range s.loras.loraIDs {
+		if name == lora {
+			s.loras.loraIDs[i] = ""
+			return
+		}
+	}
+}
+
+// GetLoraID returns the 1-based index for a loaded lora, or 0 if not loaded.
+func (s *SimContext) GetLoraID(lora string) int {
+	s.loras.mux.RLock()
+	defer s.loras.mux.RUnlock()
+
+	for i, name := range s.loras.loraIDs {
+		if name == lora {
+			return i + 1
+		}
+	}
+	return 0
 }

--- a/pkg/llm-d-inference-sim/request.go
+++ b/pkg/llm-d-inference-sim/request.go
@@ -129,17 +129,17 @@ func (b *baseRequestContext) validateContextWindow() (string, int) {
 
 func (reqCtx *baseRequestContext) handleRequest() (ResponseContext, *openaiserverapi.Error) {
 	req := reqCtx.request()
-	model := reqCtx.sim.getDisplayedModelName(req.GetModel())
+	dispModel := req.GetDisplayedModel()
 
 	// increment running requests count
 	common.WriteToChannel(reqCtx.sim.metrics.runReqChan, common.MetricInfo{Value: 1}, reqCtx.sim.logger)
 
-	if reqCtx.sim.isLora(model) {
+	if reqCtx.sim.isLora(dispModel) {
 		// set the lora index now that the lora is confirmed loaded
-		req.SetModelLoraID(reqCtx.sim.GetLoraID(model))
+		req.SetModelLoraID(reqCtx.sim.GetLoraID(dispModel))
 		// update loraInfo metric to reflect that
 		// the request has changed its status from waiting to running
-		common.WriteToChannel(reqCtx.sim.metrics.lorasChan, loraUsage{model, runningUsageState}, reqCtx.sim.logger)
+		common.WriteToChannel(reqCtx.sim.metrics.lorasChan, loraUsage{dispModel, runningUsageState}, reqCtx.sim.logger)
 	}
 
 	if err := reqCtx.tokenize(); err != nil {
@@ -175,7 +175,7 @@ func (reqCtx *baseRequestContext) handleRequest() (ResponseContext, *openaiserve
 			logprobs = req.GetLogprobs()
 		}
 		sendUsageData := !req.IsStream() || req.IncludeUsage()
-		respCtx := req.createResponseContext(reqCtx, model, &openaiserverapi.Tokenized{},
+		respCtx := req.createResponseContext(reqCtx, dispModel, &openaiserverapi.Tokenized{},
 			&finishReason, &usageData, sendUsageData, logprobs, nil)
 		return respCtx, nil
 	}
@@ -219,7 +219,7 @@ func (reqCtx *baseRequestContext) handleRequest() (ResponseContext, *openaiserve
 		finishReason = common.RemoteDecodeFinishReason
 	}
 
-	respCtx := req.createResponseContext(reqCtx, model, responseTokens, &finishReason,
+	respCtx := req.createResponseContext(reqCtx, dispModel, responseTokens, &finishReason,
 		&usageData, sendUsageData, logprobs, toolCalls)
 
 	return respCtx, nil

--- a/pkg/llm-d-inference-sim/request.go
+++ b/pkg/llm-d-inference-sim/request.go
@@ -134,7 +134,7 @@ func (reqCtx *baseRequestContext) handleRequest() (ResponseContext, *openaiserve
 	// increment running requests count
 	common.WriteToChannel(reqCtx.sim.metrics.runReqChan, common.MetricInfo{Value: 1}, reqCtx.sim.logger)
 
-	if reqCtx.sim.isLora(model) {
+	if reqCtx.sim.IsLora(model) {
 		// update loraInfo metric to reflect that
 		// the request has changed its status from waiting to running
 		common.WriteToChannel(reqCtx.sim.metrics.lorasChan, loraUsage{model, runningUsageState}, reqCtx.sim.logger)

--- a/pkg/llm-d-inference-sim/request.go
+++ b/pkg/llm-d-inference-sim/request.go
@@ -134,7 +134,9 @@ func (reqCtx *baseRequestContext) handleRequest() (ResponseContext, *openaiserve
 	// increment running requests count
 	common.WriteToChannel(reqCtx.sim.metrics.runReqChan, common.MetricInfo{Value: 1}, reqCtx.sim.logger)
 
-	if reqCtx.sim.IsLora(model) {
+	if reqCtx.sim.isLora(model) {
+		// set the lora index now that the lora is confirmed loaded
+		req.SetModelLoraID(reqCtx.sim.GetLoraID(model))
 		// update loraInfo metric to reflect that
 		// the request has changed its status from waiting to running
 		common.WriteToChannel(reqCtx.sim.metrics.lorasChan, loraUsage{model, runningUsageState}, reqCtx.sim.logger)

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -240,29 +240,28 @@ func (s *VllmSimulator) processing(ctx context.Context) {
 			}
 		case reqCtx := <-s.newRequests.Channel:
 			// A new request was received. Find a free worker, and check that the request can run LoRA wise.
-			model := reqCtx.request().GetModel()
-
 			worker := s.getFreeWorker()
 			if worker == nil {
+				// use real model name for the logs
 				s.Context.logger.V(logging.TRACE).Info("No free worker - sending the request to the waiting queue",
-					"model", model, "req id", reqCtx.request().GetRequestID())
+					"model", reqCtx.request().GetModel(), "req id", reqCtx.request().GetRequestID())
 				// no free worker, add this request to the waiting queue
 				s.addRequestToQueue(reqCtx)
 				break
 			}
 
 			// check if lora usage allows the request to run
-			if s.Context.isLora(model) && !s.Context.loadLora(model) {
+			if s.Context.isLora(reqCtx.request().GetDisplayedModel()) && !s.Context.loadLora(reqCtx.request().GetDisplayedModel()) {
 				// free the worker
 				s.freeWorkers <- worker
 				s.Context.logger.V(logging.TRACE).Info("LoRA cannot be loaded - sending the request to the waiting queue",
-					"LoRA", model, "req id", reqCtx.request().GetRequestID())
+					"LoRA", reqCtx.request().GetDisplayedModel(), "req id", reqCtx.request().GetRequestID())
 				// LoRA max reached, try to enqueue
 				s.addRequestToQueue(reqCtx)
 				break
 			}
 
-			s.Context.logger.V(logging.TRACE).Info("Sending the request to the processing channel", "model", model,
+			s.Context.logger.V(logging.TRACE).Info("Sending the request to the processing channel", "model", reqCtx.request().GetModel(),
 				"req id", reqCtx.request().GetRequestID(), "worker", worker.id)
 			common.WriteToChannel(worker.reqChan, reqCtx, s.Context.logger)
 		}
@@ -273,6 +272,7 @@ func (s *VllmSimulator) findRequestAndSendToProcess(worker *worker) bool {
 	nextReq := s.dequeue()
 	if nextReq != nil {
 		// send this request for processing in this worker
+		// use model defined in the requiest for the logs to present real model name in the logs
 		s.Context.logger.V(logging.TRACE).Info("Sending request to processing", "model", nextReq.request().GetModel(),
 			"req", nextReq.request().GetRequestID(), "worker", worker.id)
 		common.WriteToChannel(worker.reqChan, nextReq, s.Context.logger)
@@ -298,8 +298,8 @@ func (s *VllmSimulator) addRequestToQueue(reqCtx requestContext) {
 	// increment the waiting requests metric
 	common.WriteToChannel(s.Context.metrics.waitingReqChan, common.MetricInfo{Value: 1}, s.Context.logger)
 	// update loraInfo metrics with the new waiting request
-	if s.Context.isLora(reqCtx.request().GetModel()) {
-		common.WriteToChannel(s.Context.metrics.lorasChan, loraUsage{reqCtx.request().GetModel(), waitingUsageState},
+	if s.Context.isLora(reqCtx.request().GetDisplayedModel()) {
+		common.WriteToChannel(s.Context.metrics.lorasChan, loraUsage{reqCtx.request().GetDisplayedModel(), waitingUsageState},
 			s.Context.logger)
 	}
 }
@@ -311,11 +311,16 @@ func (s *VllmSimulator) HandleRequest(req Request) (bool, *common.Channel[*Respo
 		return false, nil, &failure, true
 	}
 
+	// the model defined in the request should be checked here
 	if !s.isValidModel(req.GetModel()) {
 		err := openaiserverapi.NewError(fmt.Sprintf("The model `%s` does not exist.",
 			req.GetModel()), fasthttp.StatusNotFound, nil)
 		return false, nil, &err, false
 	}
+
+	// the model is valid, update the displayed model which will be different from the model mentioned in the request only in case of base model aliases
+	// in this case the first alias is used, in all other cases the model from the request is used as the displayed model
+	req.SetDisplayedModel(s.Context.getDisplayedModelName(req.GetModel()))
 
 	errMsg, errCode := req.validate(s.toolsValidator)
 	if errMsg != "" {
@@ -351,9 +356,9 @@ func (s *VllmSimulator) dequeue() requestContext {
 	// Find first request for a loaded LoRA
 	for elem := s.waitingQueue.Front(); elem != nil; elem = elem.Next() {
 		item, ok := elem.Value.(waitingQueueItem)
-		if ok && item.reqCtx != nil && s.Context.loraIsLoaded(item.reqCtx.request().GetModel()) {
+		if ok && item.reqCtx != nil && s.Context.loraIsLoaded(item.reqCtx.request().GetDisplayedModel()) {
 			s.waitingQueue.Remove(elem)
-			s.Context.incrementLora(item.reqCtx.request().GetModel())
+			s.Context.incrementLora(item.reqCtx.request().GetDisplayedModel())
 			common.WriteToChannel(s.Context.metrics.reqQueueTimeChan, time.Since(item.enqueueTime).Seconds(),
 				s.Context.logger)
 			return item.reqCtx
@@ -363,7 +368,7 @@ func (s *VllmSimulator) dequeue() requestContext {
 	// All the requests require a LoRA that is not loaded, check if we can load a LoRA
 	for elem := s.waitingQueue.Front(); elem != nil; elem = elem.Next() {
 		item, ok := elem.Value.(waitingQueueItem)
-		if ok && item.reqCtx != nil && s.Context.loadLora(item.reqCtx.request().GetModel()) {
+		if ok && item.reqCtx != nil && s.Context.loadLora(item.reqCtx.request().GetDisplayedModel()) {
 			s.waitingQueue.Remove(elem)
 			common.WriteToChannel(s.Context.metrics.reqQueueTimeChan, time.Since(item.enqueueTime).Seconds(),
 				s.Context.logger)
@@ -431,7 +436,7 @@ func (s *VllmSimulator) ResponseSentCallback(reqCtx requestContext) {
 	// decrement running requests count
 	common.WriteToChannel(s.Context.metrics.runReqChan, common.MetricInfo{Value: -1}, s.Context.logger)
 
-	model := reqCtx.request().GetModel()
+	model := reqCtx.request().GetDisplayedModel()
 	if s.Context.isLora(model) {
 		// update loraInfo metrics to reflect that the request processing has been finished
 		common.WriteToChannel(s.Context.metrics.lorasChan, loraUsage{model, doneUsageState},

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -252,7 +252,7 @@ func (s *VllmSimulator) processing(ctx context.Context) {
 			}
 
 			// check if lora usage allows the request to run
-			if s.Context.IsLora(model) && !s.Context.loadLora(model) {
+			if s.Context.isLora(model) && !s.Context.loadLora(model) {
 				// free the worker
 				s.freeWorkers <- worker
 				s.Context.logger.V(logging.TRACE).Info("LoRA cannot be loaded - sending the request to the waiting queue",
@@ -321,11 +321,6 @@ func (s *VllmSimulator) HandleRequest(req Request) (bool, *common.Channel[*Respo
 	if errMsg != "" {
 		err := openaiserverapi.NewError(errMsg, errCode, nil)
 		return false, nil, &err, false
-	}
-
-	// update whether the model is a LoRA adapter based on the request
-	if s.Context.IsLora(req.GetModel()) {
-		req.SetModelLora()
 	}
 
 	channel := common.Channel[*ResponseInfo]{
@@ -437,7 +432,7 @@ func (s *VllmSimulator) ResponseSentCallback(reqCtx requestContext) {
 	common.WriteToChannel(s.Context.metrics.runReqChan, common.MetricInfo{Value: -1}, s.Context.logger)
 
 	model := reqCtx.request().GetModel()
-	if s.Context.IsLora(model) {
+	if s.Context.isLora(model) {
 		// update loraInfo metrics to reflect that the request processing has been finished
 		common.WriteToChannel(s.Context.metrics.lorasChan, loraUsage{model, doneUsageState},
 			s.Context.logger)

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -252,7 +252,7 @@ func (s *VllmSimulator) processing(ctx context.Context) {
 			}
 
 			// check if lora usage allows the request to run
-			if s.Context.isLora(model) && !s.Context.loadLora(model) {
+			if s.Context.IsLora(model) && !s.Context.loadLora(model) {
 				// free the worker
 				s.freeWorkers <- worker
 				s.Context.logger.V(logging.TRACE).Info("LoRA cannot be loaded - sending the request to the waiting queue",
@@ -321,6 +321,11 @@ func (s *VllmSimulator) HandleRequest(req Request) (bool, *common.Channel[*Respo
 	if errMsg != "" {
 		err := openaiserverapi.NewError(errMsg, errCode, nil)
 		return false, nil, &err, false
+	}
+
+	// update whether the model is a LoRA adapter based on the request
+	if s.Context.IsLora(req.GetModel()) {
+		req.SetModelLora()
 	}
 
 	channel := common.Channel[*ResponseInfo]{
@@ -432,7 +437,7 @@ func (s *VllmSimulator) ResponseSentCallback(reqCtx requestContext) {
 	common.WriteToChannel(s.Context.metrics.runReqChan, common.MetricInfo{Value: -1}, s.Context.logger)
 
 	model := reqCtx.request().GetModel()
-	if s.Context.isLora(model) {
+	if s.Context.IsLora(model) {
 		// update loraInfo metrics to reflect that the request processing has been finished
 		common.WriteToChannel(s.Context.metrics.lorasChan, loraUsage{model, doneUsageState},
 			s.Context.logger)

--- a/pkg/llm-d-inference-sim/worker.go
+++ b/pkg/llm-d-inference-sim/worker.go
@@ -48,7 +48,7 @@ func (w *worker) waitForRequests() {
 			return
 		case reqCtx := <-w.reqChan.Channel:
 			w.processor.processRequest(reqCtx)
-			w.finishedChan <- &requestCompleted{worker: w, model: reqCtx.request().GetModel()}
+			w.finishedChan <- &requestCompleted{worker: w, model: reqCtx.request().GetDisplayedModel()}
 		}
 
 	}

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -34,6 +34,10 @@ type Request interface {
 	IsStream() bool
 	// GetModel returns model name as defined in the request
 	GetModel() string
+	// GetLoraName returns the LoRA name as defined in the request, if request's model is the base mode - returns nil
+	GetLoraName() *string
+	// SetModelLora defines that the model name is a LoRA adapter
+	SetModelLora()
 	// IncludeUsage returns true if usage statistics should be include in the response
 	IncludeUsage() bool
 	// GetNumberOfCachedPromptTokens returns the number of tokens in the prompt that are
@@ -96,6 +100,8 @@ type baseCompletionRequest struct {
 	StreamOptions StreamOptions `json:"stream_options"`
 	// Model defines Model name to use for "inference", could be base Model name or one of available LoRA adapters
 	Model string `json:"model"`
+	// isModelLora defines whether the model is a LoRA adapter
+	isModelLora bool
 	// KVParams kv transfer related fields
 	KVParams *KVTransferParams `json:"kv_transfer_params"`
 	// The number of tokens in the prompt that are in the local KV Cache
@@ -182,6 +188,17 @@ func (b *baseCompletionRequest) IsStream() bool {
 
 func (b *baseCompletionRequest) GetModel() string {
 	return b.Model
+}
+
+func (b *baseCompletionRequest) GetLoraName() *string {
+	if b.isModelLora {
+		return &b.Model
+	}
+	return nil
+}
+
+func (b *baseCompletionRequest) SetModelLora() {
+	b.isModelLora = true
 }
 
 func (b *baseCompletionRequest) IncludeUsage() bool {

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -17,7 +17,9 @@ limitations under the License.
 // Contains structures and functions related to requests for all supported APIs
 package openaiserverapi
 
-import "github.com/llm-d/llm-d-kv-cache/pkg/tokenization"
+import (
+	"github.com/llm-d/llm-d-kv-cache/pkg/tokenization"
+)
 
 const (
 	RoleAssistant = "assistant"
@@ -34,10 +36,11 @@ type Request interface {
 	IsStream() bool
 	// GetModel returns model name as defined in the request
 	GetModel() string
-	// GetLoraName returns the LoRA name as defined in the request, if request's model is the base mode - returns nil
+	// GetLoraName returns the LoRA name or nil if model is the base model
 	GetLoraName() *string
-	// SetModelLora defines that the model name is a LoRA adapter
-	SetModelLora()
+	GetLoraID() *int
+	// SetModelLoraID sets the LoRA ID for the request, ID == 0 means the base model
+	SetModelLoraID(id int)
 	// IncludeUsage returns true if usage statistics should be include in the response
 	IncludeUsage() bool
 	// GetNumberOfCachedPromptTokens returns the number of tokens in the prompt that are
@@ -100,8 +103,8 @@ type baseCompletionRequest struct {
 	StreamOptions StreamOptions `json:"stream_options"`
 	// Model defines Model name to use for "inference", could be base Model name or one of available LoRA adapters
 	Model string `json:"model"`
-	// isModelLora defines whether the model is a LoRA adapter
-	isModelLora bool
+	// ID of the LoRA adapter if the model is a LoRA, 0 if the model is the base model
+	loraID int
 	// KVParams kv transfer related fields
 	KVParams *KVTransferParams `json:"kv_transfer_params"`
 	// The number of tokens in the prompt that are in the local KV Cache
@@ -191,14 +194,23 @@ func (b *baseCompletionRequest) GetModel() string {
 }
 
 func (b *baseCompletionRequest) GetLoraName() *string {
-	if b.isModelLora {
-		return &b.Model
+	if b.loraID > 0 {
+		name := b.Model
+		return &name
 	}
 	return nil
 }
 
-func (b *baseCompletionRequest) SetModelLora() {
-	b.isModelLora = true
+func (b *baseCompletionRequest) GetLoraID() *int {
+	if b.loraID > 0 {
+		id := b.loraID
+		return &id
+	}
+	return nil
+}
+
+func (b *baseCompletionRequest) SetModelLoraID(id int) {
+	b.loraID = id
 }
 
 func (b *baseCompletionRequest) IncludeUsage() bool {
@@ -347,24 +359,6 @@ func (c *ChatCompletionRequest) GetMaxCompletionTokens() *int64 {
 		return c.MaxCompletionTokens
 	}
 	return c.MaxTokens
-}
-
-// getLastUserMsg returns last message from this request's messages with user role,
-// if does not exist - returns an empty string
-func (req *ChatCompletionRequest) GetLastUserMsg() string {
-	if len(req.Messages) == 0 {
-		return ""
-	}
-
-	for i := len(req.Messages) - 1; i >= 0; i-- {
-		if req.Messages[i].Role == RoleUser {
-			// return last user message
-			return req.Messages[i].Content.PlainText()
-		}
-	}
-
-	// return last message
-	return req.Messages[len(req.Messages)-1].Content.PlainText()
 }
 
 // ExtractMaxTokens extracts the max tokens from the request

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -38,7 +38,7 @@ type Request interface {
 	GetModel() string
 	// GetDisplayedModel returns model name to be used in the processing
 	// in case served model names were defined on the simulator load, and this request
-	// contains one of aliases of the base model - the first alias is usedas the model name
+	// contains one of aliases of the base model - the first alias is used as the model name
 	// in all other cases - the model name is used as is from the request
 	GetDisplayedModel() string
 	// SetDisplayedModel sets the displayed model name for the request

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -36,6 +36,13 @@ type Request interface {
 	IsStream() bool
 	// GetModel returns model name as defined in the request
 	GetModel() string
+	// GetDisplayedModel returns model name to be used in the processing
+	// in case served model names were defined on the simulator load, and this request
+	// contains one of aliases of the base model - the first alias is usedas the model name
+	// in all other cases - the model name is used as is from the request
+	GetDisplayedModel() string
+	// SetDisplayedModel sets the displayed model name for the request
+	SetDisplayedModel(model string)
 	// GetLoraName returns the LoRA name or nil if model is the base model
 	GetLoraName() *string
 	GetLoraID() *int
@@ -101,8 +108,13 @@ type baseCompletionRequest struct {
 	Stream bool `json:"stream"`
 	// StreamOptions defines streaming options in case Stream is set to true
 	StreamOptions StreamOptions `json:"stream_options"`
-	// Model defines Model name to use for "inference", could be base Model name or one of available LoRA adapters
+	// Model defines Model name to use for "inference",
+	// could be base Model name or one of available LoRA adapters
 	Model string `json:"model"`
+	// DisplayedModel is the model name to be used in the request processing and in the response,
+	// in case served model names were defined on the simulator load, and this request contains one of aliases of the base model - the first alias is used as the DisplayedModel name
+	// in all other cases - the Model name is used as is from the request
+	DisplayedModel string
 	// ID of the LoRA adapter if the model is a LoRA, 0 if the model is the base model
 	loraID int
 	// KVParams kv transfer related fields
@@ -191,6 +203,14 @@ func (b *baseCompletionRequest) IsStream() bool {
 
 func (b *baseCompletionRequest) GetModel() string {
 	return b.Model
+}
+
+func (b *baseCompletionRequest) GetDisplayedModel() string {
+	return b.DisplayedModel
+}
+
+func (b *baseCompletionRequest) SetDisplayedModel(model string) {
+	b.DisplayedModel = model
 }
 
 func (b *baseCompletionRequest) GetLoraName() *string {

--- a/pkg/tests/http_server_test.go
+++ b/pkg/tests/http_server_test.go
@@ -306,8 +306,8 @@ var _ = Describe("Server", func() {
 			}()
 			msg, err := sub.Recv()
 			Expect(err).NotTo(HaveOccurred())
-			stored, _, _ := kvcache.ParseKVEvent(msg.Frames, topic, uint64(1))
-			Expect(stored).To(HaveLen(1))
+			storedCount, _, _ := kvcache.CountKVEventBlocks(msg.Frames, topic, uint64(1))
+			Expect(storedCount).To(Equal(1))
 
 			// Sleep and check that AllBlocksCleared event was sent
 			go func() {
@@ -318,7 +318,7 @@ var _ = Describe("Server", func() {
 			}()
 			msg, err = sub.Recv()
 			Expect(err).NotTo(HaveOccurred())
-			_, _, allCleared := kvcache.ParseKVEvent(msg.Frames, topic, uint64(2))
+			_, _, allCleared := kvcache.CountKVEventBlocks(msg.Frames, topic, uint64(2))
 			Expect(allCleared).To(BeTrue())
 
 			checkSimSleeping(client, true)
@@ -341,8 +341,8 @@ var _ = Describe("Server", func() {
 			}()
 			msg, err = sub.Recv()
 			Expect(err).NotTo(HaveOccurred())
-			stored, _, _ = kvcache.ParseKVEvent(msg.Frames, topic, uint64(3))
-			Expect(stored).To(HaveLen(1))
+			storedCount, _, _ = kvcache.CountKVEventBlocks(msg.Frames, topic, uint64(3))
+			Expect(storedCount).To(Equal(1))
 
 			// Sleep again and wait for AllBlocksCleared
 			go func() {
@@ -354,7 +354,7 @@ var _ = Describe("Server", func() {
 
 			msg, err = sub.Recv()
 			Expect(err).NotTo(HaveOccurred())
-			_, _, allCleared = kvcache.ParseKVEvent(msg.Frames, topic, uint64(4))
+			_, _, allCleared = kvcache.CountKVEventBlocks(msg.Frames, topic, uint64(4))
 			Expect(allCleared).To(BeTrue())
 
 			checkSimSleeping(client, true)
@@ -385,8 +385,8 @@ var _ = Describe("Server", func() {
 			}()
 			msg, err = sub.Recv()
 			Expect(err).NotTo(HaveOccurred())
-			stored, _, _ = kvcache.ParseKVEvent(msg.Frames, topic, uint64(5))
-			Expect(stored).To(HaveLen(1))
+			storedCount, _, _ = kvcache.CountKVEventBlocks(msg.Frames, topic, uint64(5))
+			Expect(storedCount).To(Equal(1))
 		})
 	})
 })

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -1378,9 +1378,9 @@ var _ = Describe("Simulator", func() {
 			// read one event
 			msg, err := sub.Recv()
 			Expect(err).NotTo(HaveOccurred())
-			stored, removed, _ := kvcache.ParseKVEvent(msg.Frames, topic, 1)
-			Expect(stored).To(HaveLen(4))
-			Expect(removed).To(BeEmpty())
+			storedCount, removedCount, _ := kvcache.CountKVEventBlocks(msg.Frames, topic, 1)
+			Expect(storedCount).To(Equal(4))
+			Expect(removedCount).To(Equal(0))
 		})
 
 		It("completions", func() {
@@ -1409,9 +1409,9 @@ var _ = Describe("Simulator", func() {
 			// read one event
 			msg, err := sub.Recv()
 			Expect(err).NotTo(HaveOccurred())
-			stored, removed, _ := kvcache.ParseKVEvent(msg.Frames, topic, 1)
-			Expect(stored).To(HaveLen(2))
-			Expect(removed).To(BeEmpty())
+			storedCount, removedCount, _ := kvcache.CountKVEventBlocks(msg.Frames, topic, 1)
+			Expect(storedCount).To(Equal(2))
+			Expect(removedCount).To(Equal(0))
 		})
 	})
 })

--- a/pkg/tokenizer/hf_tokenizer.go
+++ b/pkg/tokenizer/hf_tokenizer.go
@@ -37,6 +37,7 @@ type HFTokenizer struct {
 // HF Tokenizer
 func NewHFTokenizer(ctx context.Context, logger logr.Logger, udsSocketPath, model string) (*HFTokenizer, error) {
 	crlog.SetLogger(logger)
+	logger.V(logging.INFO).Info("Connecting to UDS tokenizer", "socket path", udsSocketPath)
 	udsTokenizer, err := tokenization.NewUdsTokenizer(ctx,
 		&tokenization.UdsTokenizerConfig{SocketFile: udsSocketPath}, model)
 
@@ -45,7 +46,7 @@ func NewHFTokenizer(ctx context.Context, logger logr.Logger, udsSocketPath, mode
 		return nil, err
 	}
 
-	logger.V(logging.DEBUG).Info("Connected to UDS tokenizer", "socket path", udsSocketPath)
+	logger.V(logging.INFO).Info("Connected to UDS tokenizer")
 	return &HFTokenizer{ctx: ctx, model: model, udsTokenizer: udsTokenizer, logger: logger}, nil
 }
 


### PR DESCRIPTION
## Summary
- LoRA-aware block cache: Block keys now include model name alongside the hash, so blocks belonging to different LoRAs/base model are distinguished. Eviction prioritizes blocks of unloaded models before evicting blocks of loaded ones.
- LoRA ID assignment: Each loaded LoRA is assigned a stable 1-based index (loraIDs slot). IDs are freed when a LoRA is unloaded and reassigned on load. The base model has no LoRA ID (0).
- LoRA fields in KV events: BlockStoredEvent now carries LoraName, LoraID, and ParentHash fields, propagated through EventData and the msgpack publisher.

Fixes #272
