### PR TITLE
fix: align /v1/models response with real vLLM behavior (#440)

### DIFF
--- a/pkg/llm-d-inference-sim/context.go
+++ b/pkg/llm-d-inference-sim/context.go
@@ -206,12 +206,13 @@ func (s *SimContext) CreateModelsResponse() *vllmapi.ModelsResponse {
 	// Advertise every public model alias
 	for _, alias := range s.Config.ServedModelNames {
 		modelsResp.Data = append(modelsResp.Data, vllmapi.ModelsResponseModelInfo{
-			ID:      alias,
-			Object:  vllmapi.ObjectModel,
-			Created: time.Now().Unix(),
-			OwnedBy: "vllm",
-			Root:    alias,
-			Parent:  nil,
+			ID:          alias,
+			Object:      vllmapi.ObjectModel,
+			Created:     time.Now().Unix(),
+			OwnedBy:     "vllm",
+			Root:        s.Config.Model,
+			Parent:      nil,
+			MaxModelLen: s.Config.MaxModelLen,
 		})
 	}
 
@@ -219,12 +220,13 @@ func (s *SimContext) CreateModelsResponse() *vllmapi.ModelsResponse {
 	parent := s.Config.ServedModelNames[0]
 	for _, lora := range s.getLoras() {
 		modelsResp.Data = append(modelsResp.Data, vllmapi.ModelsResponseModelInfo{
-			ID:      lora,
-			Object:  vllmapi.ObjectModel,
-			Created: time.Now().Unix(),
-			OwnedBy: "vllm",
-			Root:    lora,
-			Parent:  &parent,
+			ID:          lora,
+			Object:      vllmapi.ObjectModel,
+			Created:     time.Now().Unix(),
+			OwnedBy:     "vllm",
+			Root:        lora,
+			Parent:      &parent,
+			MaxModelLen: s.Config.MaxModelLen,
 		})
 	}
 

--- a/pkg/llm-d-inference-sim/models_test.go
+++ b/pkg/llm-d-inference-sim/models_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmdinferencesim
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+)
+
+var _ = Describe("CreateModelsResponse", func() {
+	It("should set root to actual model path, not alias", func() {
+		s := &SimContext{
+			Config: &common.Configuration{
+				Model:            "Qwen/Qwen3-0.6B-Base",
+				ServedModelNames: []string{"alias1", "alias2"},
+				MaxModelLen:      32768,
+			},
+		}
+
+		resp := s.CreateModelsResponse()
+		Expect(resp.Data).To(HaveLen(2))
+
+		for _, model := range resp.Data {
+			Expect(model.Root).To(Equal("Qwen/Qwen3-0.6B-Base"))
+			Expect(model.MaxModelLen).To(Equal(32768))
+			Expect(model.Parent).To(BeNil())
+		}
+		Expect(resp.Data[0].ID).To(Equal("alias1"))
+		Expect(resp.Data[1].ID).To(Equal("alias2"))
+	})
+
+	It("should include max_model_len for LoRA adapters", func() {
+		s := &SimContext{
+			Config: &common.Configuration{
+				Model:            "Qwen/Qwen3-0.6B-Base",
+				ServedModelNames: []string{"base-model"},
+				MaxModelLen:      4096,
+			},
+		}
+		s.loraAdaptors.Store("lora1", true)
+		s.loraAdaptors.Store("lora2", true)
+
+		resp := s.CreateModelsResponse()
+		Expect(resp.Data).To(HaveLen(3))
+
+		for _, model := range resp.Data {
+			Expect(model.MaxModelLen).To(Equal(4096))
+		}
+
+		base := resp.Data[0]
+		Expect(base.ID).To(Equal("base-model"))
+		Expect(base.Root).To(Equal("Qwen/Qwen3-0.6B-Base"))
+		Expect(base.Parent).To(BeNil())
+
+		for _, model := range resp.Data[1:] {
+			Expect(model.Parent).ToNot(BeNil())
+			Expect(*model.Parent).To(Equal("base-model"))
+		}
+	})
+
+	It("should use model name as root when no aliases are set", func() {
+		s := &SimContext{
+			Config: &common.Configuration{
+				Model:            "meta-llama/Llama-3-8B",
+				ServedModelNames: []string{"meta-llama/Llama-3-8B"},
+				MaxModelLen:      1024,
+			},
+		}
+
+		resp := s.CreateModelsResponse()
+		Expect(resp.Data).To(HaveLen(1))
+		Expect(resp.Data[0].ID).To(Equal("meta-llama/Llama-3-8B"))
+		Expect(resp.Data[0].Root).To(Equal("meta-llama/Llama-3-8B"))
+		Expect(resp.Data[0].MaxModelLen).To(Equal(1024))
+	})
+})

--- a/pkg/vllm-api/vllm-models.go
+++ b/pkg/vllm-api/vllm-models.go
@@ -44,6 +44,8 @@ type ModelsResponseModelInfo struct {
 	Root string `json:"root"`
 	// Parent is name of base model when the model is LoRA adapter, if the model is not a LoRA - null
 	Parent *string `json:"parent"`
+	// MaxModelLen is the model's context window
+	MaxModelLen int `json:"max_model_len"`
 }
 
 // modelsResponse is the response of /models API


### PR DESCRIPTION
## Summary

Fixes #440. The `/v1/models` response diverged from real vLLM in two ways:

- **`root` field** returned the alias name instead of the actual model path — now uses `Config.Model`
- **`max_model_len` field** was missing — now included in each model entry

## Test plan

- Added unit tests for `CreateModelsResponse` covering alias root, LoRA adapters, and no-alias scenarios