### PR TITLE
fix: return LoRA model path in root field of /v1/models (#443)

### DIFF
--- a/pkg/llm-d-inference-sim/context.go
+++ b/pkg/llm-d-inference-sim/context.go
@@ -79,7 +79,7 @@ func (s *SimContext) initialize(ctx context.Context) error {
 	}
 
 	for _, lora := range s.Config.LoraModules {
-		s.loraAdaptors.Store(lora.Name, "")
+		s.loraAdaptors.Store(lora.Name, lora.Path)
 	}
 	s.loras.maxLoras = s.Config.MaxLoras
 	s.loras.loraRemovable = common.Channel[int]{
@@ -224,7 +224,7 @@ func (s *SimContext) CreateModelsResponse() *vllmapi.ModelsResponse {
 			Object:      vllmapi.ObjectModel,
 			Created:     time.Now().Unix(),
 			OwnedBy:     "vllm",
-			Root:        lora,
+			Root:        s.getLoraPath(lora),
 			Parent:      &parent,
 			MaxModelLen: s.Config.MaxModelLen,
 		})

--- a/pkg/llm-d-inference-sim/lora.go
+++ b/pkg/llm-d-inference-sim/lora.go
@@ -49,6 +49,20 @@ func (s *SimContext) getLoras() []string {
 	return loras
 }
 
+// getLoraPath returns the filesystem path recorded for the given LoRA name.
+// Falls back to the name when no path was supplied (dynamic load without
+// lora_path, or the non-string sentinel values stored by some tests).
+func (s *SimContext) getLoraPath(name string) string {
+	raw, ok := s.loraAdaptors.Load(name)
+	if !ok {
+		return name
+	}
+	if path, ok := raw.(string); ok && path != "" {
+		return path
+	}
+	return name
+}
+
 func (s *SimContext) LoadLoraAdaptor(ctx *fasthttp.RequestCtx) {
 	var req loadLoraRequest
 	err := json.Unmarshal(ctx.Request.Body(), &req)
@@ -58,7 +72,7 @@ func (s *SimContext) LoadLoraAdaptor(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	s.loraAdaptors.Store(req.LoraName, "")
+	s.loraAdaptors.Store(req.LoraName, req.LoraPath)
 }
 
 func (s *SimContext) UnloadLoraAdaptor(ctx *fasthttp.RequestCtx) {

--- a/pkg/llm-d-inference-sim/models_test.go
+++ b/pkg/llm-d-inference-sim/models_test.go
@@ -21,7 +21,17 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	vllmapi "github.com/llm-d/llm-d-inference-sim/pkg/vllm-api"
 )
+
+func findByID(models []vllmapi.ModelsResponseModelInfo, id string) *vllmapi.ModelsResponseModelInfo {
+	for i := range models {
+		if models[i].ID == id {
+			return &models[i]
+		}
+	}
+	return nil
+}
 
 var _ = Describe("CreateModelsResponse", func() {
 	It("should set root to actual model path, not alias", func() {
@@ -88,5 +98,28 @@ var _ = Describe("CreateModelsResponse", func() {
 		Expect(resp.Data[0].ID).To(Equal("meta-llama/Llama-3-8B"))
 		Expect(resp.Data[0].Root).To(Equal("meta-llama/Llama-3-8B"))
 		Expect(resp.Data[0].MaxModelLen).To(Equal(1024))
+	})
+
+	It("should set LoRA root to the adapter path when one is recorded", func() {
+		s := &SimContext{
+			Config: &common.Configuration{
+				Model:            "Qwen/Qwen3-0.6B-Base",
+				ServedModelNames: []string{"base-model"},
+				MaxModelLen:      4096,
+			},
+		}
+		s.loraAdaptors.Store("lora-with-path", "/lora/path/adapter1")
+		s.loraAdaptors.Store("lora-without-path", "")
+
+		resp := s.CreateModelsResponse()
+		Expect(resp.Data).To(HaveLen(3))
+
+		withPath := findByID(resp.Data, "lora-with-path")
+		Expect(withPath).ToNot(BeNil())
+		Expect(withPath.Root).To(Equal("/lora/path/adapter1"))
+
+		withoutPath := findByID(resp.Data, "lora-without-path")
+		Expect(withoutPath).ToNot(BeNil())
+		Expect(withoutPath.Root).To(Equal("lora-without-path"))
 	})
 })

--- a/pkg/tests/lora_test.go
+++ b/pkg/tests/lora_test.go
@@ -82,10 +82,18 @@ var _ = Describe("LoRAs", func() {
 			Expect(modelsResp).NotTo(BeNil())
 			Expect(modelsResp.Data).To(HaveLen(4))
 
+			// Root must reflect the LoRA's filesystem path, not its name.
+			// lora3/lora4 come from --lora-modules; lora1 from /load_lora_adapter.
+			expectedRoots := map[string]string{
+				"lora1": "/path/to/lora1",
+				"lora3": "/path/to/lora3",
+				"lora4": "/path/to/lora4",
+			}
 			for _, model := range modelsResp.Data {
 				if strings.HasPrefix(model.ID, "lora") {
 					Expect(model.Parent).ToNot(BeNil())
 					Expect(*model.Parent).To(Equal(common.TestModelName))
+					Expect(model.Root).To(Equal(expectedRoots[model.ID]))
 				} else {
 					Expect(model.Parent).To(BeNil())
 				}


### PR DESCRIPTION
Closes #443.

## Problem

LoRA entries in the \`/v1/models\` response used the adapter's name as both \`id\` and \`root\`. Real vLLM returns the LoRA's filesystem path as \`root\`, which the issue reports is what consumers expect.

## Root cause

\`SimContext.loraAdaptors\` is a \`sync.Map\` keyed by LoRA name. The path from \`LoraModule.Path\` (static config, \`context.go:82\`) and \`loadLoraRequest.LoraPath\` (dynamic load, \`lora.go:61\`) was being discarded at insertion — both call sites wrote an empty string as the value. With no path kept anywhere, \`CreateModelsResponse\` fell back to using the name for \`root\`.

## Fix

- Store the path as the map value at both insertion sites (config init and the load endpoint).
- Add a \`getLoraPath\` helper that reads the path back, falling back to the name when no path was supplied (preserves existing behavior for the dynamic-load-without-path case and for tests that store non-string sentinel values).
- Use \`getLoraPath(lora)\` for \`Root\` in \`CreateModelsResponse\`.

## After

\`\`\`json
{
  "id": "lora1",
  "object": "model",
  "created": 1776688922,
  "owned_by": "vllm",
  "root": "path/to/lora1",
  "parent": "base_model_alias",
  "max_model_len": 32768
}
\`\`\`

## Test

Added a spec to \`models_test.go\` that stores a path for one adapter and an empty string for another, and verifies \`root\` reflects the recorded path (falling back to name when none was set).

Ran:
- \`ginkgo --timeout=300s ./pkg/llm-d-inference-sim/ ./pkg/common/\` — 148/148 passing
- \`golangci-lint run ./pkg/llm-d-inference-sim/...\` — 0 issues