### PR TITLE
feat(models): return LoRA path as root in /v1/models (#443)

### DIFF
--- a/pkg/llm-d-inference-sim/context.go
+++ b/pkg/llm-d-inference-sim/context.go
@@ -79,7 +79,10 @@ func (s *SimContext) initialize(ctx context.Context) error {
 	}
 
 	for _, lora := range s.Config.LoraModules {
-		s.loraAdaptors.Store(lora.Name, "")
+		// Store the LoRA path alongside the name so /v1/models can surface
+		// it in `root` for each adapter (vLLM behavior). Previously this
+		// was an unused empty string.
+		s.loraAdaptors.Store(lora.Name, lora.Path)
 	}
 	s.loras.maxLoras = s.Config.MaxLoras
 	s.loras.loraRemovable = common.Channel[int]{
@@ -219,12 +222,22 @@ func (s *SimContext) CreateModelsResponse() *vllmapi.ModelsResponse {
 	// add LoRA adapter's info
 	parent := s.Config.ServedModelNames[0]
 	for _, lora := range s.getLoras() {
+		// Prefer the configured / loaded LoRA path for `root` (matches real
+		// vLLM behavior -- #443). Fall back to the LoRA name when no path
+		// was recorded, which preserves the prior shape for adapters that
+		// arrived without a path (older Store(name, "") call sites).
+		loraRoot := lora
+		if path, ok := s.loraAdaptors.Load(lora); ok {
+			if pathStr, isStr := path.(string); isStr && pathStr != "" {
+				loraRoot = pathStr
+			}
+		}
 		modelsResp.Data = append(modelsResp.Data, vllmapi.ModelsResponseModelInfo{
 			ID:          lora,
 			Object:      vllmapi.ObjectModel,
 			Created:     time.Now().Unix(),
 			OwnedBy:     "vllm",
-			Root:        lora,
+			Root:        loraRoot,
 			Parent:      &parent,
 			MaxModelLen: s.Config.MaxModelLen,
 		})

--- a/pkg/llm-d-inference-sim/lora.go
+++ b/pkg/llm-d-inference-sim/lora.go
@@ -58,7 +58,8 @@ func (s *SimContext) LoadLoraAdaptor(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	s.loraAdaptors.Store(req.LoraName, "")
+	// Record the path so /v1/models can surface it in `root` (#443).
+	s.loraAdaptors.Store(req.LoraName, req.LoraPath)
 }
 
 func (s *SimContext) UnloadLoraAdaptor(ctx *fasthttp.RequestCtx) {

--- a/pkg/llm-d-inference-sim/models_test.go
+++ b/pkg/llm-d-inference-sim/models_test.go
@@ -89,4 +89,31 @@ var _ = Describe("CreateModelsResponse", func() {
 		Expect(resp.Data[0].Root).To(Equal("meta-llama/Llama-3-8B"))
 		Expect(resp.Data[0].MaxModelLen).To(Equal(1024))
 	})
+
+	It("should set root to LoRA path when the adaptor was loaded with one (#443)", func() {
+		s := &SimContext{
+			Config: &common.Configuration{
+				Model:            "Qwen/Qwen3-0.6B-Base",
+				ServedModelNames: []string{"base-model"},
+				MaxModelLen:      32768,
+			},
+		}
+		// Simulate a LoRA loaded with a path (either via Configuration
+		// LoraModules or the load-adapter HTTP endpoint).
+		s.loraAdaptors.Store("lora1", "path/to/lora1")
+		// A second adapter registered without a path (e.g. legacy
+		// call site that stored an empty string) must still fall back
+		// to the LoRA name for Root.
+		s.loraAdaptors.Store("lora2", "")
+
+		resp := s.CreateModelsResponse()
+		Expect(resp.Data).To(HaveLen(3))
+
+		loraEntries := make(map[string]string)
+		for _, model := range resp.Data[1:] {
+			loraEntries[model.ID] = model.Root
+		}
+		Expect(loraEntries).To(HaveKeyWithValue("lora1", "path/to/lora1"))
+		Expect(loraEntries).To(HaveKeyWithValue("lora2", "lora2"))
+	})
 })


### PR DESCRIPTION
Fixes #443. vLLM's `/v1/models` response sets the `root` field of each LoRA adapter to its filesystem/remote path; this simulator was returning the LoRA name there because `loraAdaptors.Store` was always called with an empty string as the value.

## Changes

- `pkg/llm-d-inference-sim/context.go`: `Config.LoraModules` registration now stores `Store(lora.Name, lora.Path)` instead of `Store(lora.Name, "")`, so the path is retrievable later.
- `pkg/llm-d-inference-sim/lora.go::LoadLoraAdaptor`: the `/load-lora` HTTP handler stores `req.LoraPath` instead of an empty string (the handler already parses `lora_path` from the request body — the path was just being discarded).
- `pkg/llm-d-inference-sim/context.go::CreateModelsResponse`: for each LoRA, look up the stored path and use it as `root`. Fall back to the LoRA name when no path was recorded (preserves behavior for any adapter registered via legacy `Store(name, "")` or test-only `Store(name, true)` call sites).

## Before / After

Request:
```
GET /v1/models
```

Before (LoRA with `lora_path=path/to/lora1`):
```json
{
  "id": "lora1",
  "root": "lora1",
  "parent": "base-model",
  ...
}
```

After:
```json
{
  "id": "lora1",
  "root": "path/to/lora1",
  "parent": "base-model",
  ...
}
```

## Backward compatibility

The LoRA-list helper `getLoras()` returns `[]string` (names) and still does. Three call sites (`helpers.go:33`, `context.go:158`, `context.go:221`) call it; only the models response at `context.go:221` uses the path, via a direct `loraAdaptors.Load()` lookup. The other two sites are unaffected.

The fallback `loraRoot := lora` handles the test-only `Store(name, true)` pattern and any external caller that might be storing a non-string value in the sync.Map — type-assertion miss returns the LoRA name.

## Testing

- `go build ./...` — clean.
- `go test ./pkg/llm-d-inference-sim/...` — all existing tests pass, including the existing `should include max_model_len for LoRA adapters` which stores `true` (bool) as the map value and exercises the fallback path unmodified.
- New test: `should set root to LoRA path when the adaptor was loaded with one (#443)` — seeds `lora1` with a path and `lora2` with an empty string, asserts `root="path/to/lora1"` for lora1 and `root="lora2"` (name fallback) for lora2.

Fixes #443

---

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
