### PR TITLE
fix: support structured content blocks in echo mode for chat/completions

### DIFF
--- a/pkg/llm-d-inference-sim/chat_completion.go
+++ b/pkg/llm-d-inference-sim/chat_completion.go
@@ -79,7 +79,7 @@ func (c *ChatCompletionRequest) createResponseContext(reqCtx requestContext, dis
 func (c *chatCompletionReqCtx) tokenizedPromptForEcho() (*openaiserverapi.Tokenized, error) {
 	lastMsg := ""
 	if len(c.req.Messages) > 0 {
-		lastMsg = c.req.Messages[len(c.req.Messages)-1].Content.Raw
+		lastMsg = c.req.Messages[len(c.req.Messages)-1].Content.ReadableText()
 	}
 	tokens, strTokens, err := c.sim.Tokenizer.RenderText(lastMsg)
 	if err != nil {

--- a/pkg/openai-server-api/content_test.go
+++ b/pkg/openai-server-api/content_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openaiserverapi
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Content ReadableText", func() {
+	It("returns raw string when content is plain text", func() {
+		c := Content{Raw: "hello world"}
+		Expect(c.ReadableText()).To(Equal("hello world"))
+	})
+
+	It("returns text block content for structured text", func() {
+		c := Content{
+			Structured: []ContentBlock{
+				{Type: "text", Text: "Describe this"},
+			},
+		}
+		Expect(c.ReadableText()).To(Equal("Describe this"))
+	})
+
+	It("returns image_url block as image: <url>", func() {
+		c := Content{
+			Structured: []ContentBlock{
+				{Type: "image_url", ImageURL: ImageBlock{Url: "https://example.com/img.png"}},
+			},
+		}
+		Expect(c.ReadableText()).To(Equal("image: https://example.com/img.png"))
+	})
+
+	It("joins multiple blocks with newlines", func() {
+		c := Content{
+			Structured: []ContentBlock{
+				{Type: "text", Text: "Describe this"},
+				{Type: "image_url", ImageURL: ImageBlock{Url: "https://example.com/img.png"}},
+			},
+		}
+		Expect(c.ReadableText()).To(Equal("Describe this\nimage: https://example.com/img.png"))
+	})
+
+	It("returns empty string for empty structured content", func() {
+		c := Content{Structured: []ContentBlock{}}
+		Expect(c.ReadableText()).To(Equal(""))
+	})
+
+	It("returns empty string for zero-value content", func() {
+		c := Content{}
+		Expect(c.ReadableText()).To(Equal(""))
+	})
+
+	It("skips unknown block types", func() {
+		c := Content{
+			Structured: []ContentBlock{
+				{Type: "text", Text: "hello"},
+				{Type: "unknown", Text: "ignored"},
+				{Type: "image_url", ImageURL: ImageBlock{Url: "https://example.com/img.png"}},
+			},
+		}
+		Expect(c.ReadableText()).To(Equal("hello\nimage: https://example.com/img.png"))
+	})
+
+	It("does not modify PlainText behavior", func() {
+		c := Content{
+			Structured: []ContentBlock{
+				{Type: "text", Text: "hello"},
+				{Type: "image_url", ImageURL: ImageBlock{Url: "https://example.com/img.png"}},
+			},
+		}
+		Expect(c.PlainText()).To(Equal("hello "))
+	})
+})

--- a/pkg/openai-server-api/response.go
+++ b/pkg/openai-server-api/response.go
@@ -174,6 +174,22 @@ func (mc Content) MarshalJSON() ([]byte, error) {
 	return json.Marshal("")
 }
 
+func (mc Content) ReadableText() string {
+	if mc.Raw != "" {
+		return mc.Raw
+	}
+	var parts []string
+	for _, block := range mc.Structured {
+		switch block.Type {
+		case "text":
+			parts = append(parts, block.Text)
+		case "image_url":
+			parts = append(parts, "image: "+block.ImageURL.Url)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
 func (mc Content) PlainText() string {
 	if mc.Raw != "" {
 		return mc.Raw

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -358,6 +358,86 @@ var _ = Describe("Simulator", func() {
 		Entry(nil, common.MMModelName, common.ModeEcho, 10),
 	)
 
+	It("echo mode with structured content blocks", func() {
+		ctx := context.TODO()
+		args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeEcho}
+		client, err := startServerWithArgs(ctx, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient := openai.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithHTTPClient(client),
+			option.WithMaxRetries(0))
+
+		params := openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.UserMessage(
+					[]openai.ChatCompletionContentPartUnionParam{
+						openai.TextContentPart("Describe this"),
+						openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+							URL: "https://example.com/img.png",
+						}),
+					},
+				),
+			},
+			Model: common.TestModelName,
+		}
+
+		resp, err := openaiclient.Chat.Completions.New(ctx, params)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Choices).ShouldNot(BeEmpty())
+
+		msg := resp.Choices[0].Message.Content
+		Expect(msg).To(Equal("Describe this\nimage: https://example.com/img.png"))
+	})
+
+	It("echo mode with structured content blocks streaming", func() {
+		ctx := context.TODO()
+		args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeEcho}
+		client, err := startServerWithArgs(ctx, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient := openai.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithHTTPClient(client),
+			option.WithMaxRetries(0))
+
+		params := openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.UserMessage(
+					[]openai.ChatCompletionContentPartUnionParam{
+						openai.TextContentPart("Describe this"),
+						openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+							URL: "https://example.com/img.png",
+						}),
+					},
+				),
+			},
+			Model:         common.TestModelName,
+			StreamOptions: openai.ChatCompletionStreamOptionsParam{IncludeUsage: param.NewOpt(true)},
+		}
+
+		stream := openaiclient.Chat.Completions.NewStreaming(ctx, params)
+		defer func() {
+			err := stream.Close()
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		var tokens []string
+		for stream.Next() {
+			chunk := stream.Current()
+			for _, choice := range chunk.Choices {
+				if choice.Delta.Content != "" {
+					tokens = append(tokens, choice.Delta.Content)
+				}
+			}
+		}
+		Expect(stream.Err()).NotTo(HaveOccurred())
+
+		msg := strings.Join(tokens, "")
+		Expect(msg).To(Equal("Describe this\nimage: https://example.com/img.png"))
+	})
+
 	Context("namespace and pod headers", func() {
 		It("Should not include namespace, pod and port headers in chat completion response when env is not set", func() {
 			httpResp := sendSimpleChatRequest(nil, false)


### PR DESCRIPTION
## Summary

Fixes #438

Echo mode returned empty responses for `/v1/chat/completions` when message content used structured blocks (array of `{type, text}` objects) instead of a plain string. The root cause was `tokenizedPromptForEcho()` reading `Content.Raw` directly, which is empty for structured content.

- Added `ReadableText()` method on `Content` that serializes all block types into a readable string (text as-is, image_url as `image: <url>`, blocks separated by newlines)
- Updated `tokenizedPromptForEcho()` to use `ReadableText()` instead of `Content.Raw`
- `PlainText()` is not modified
