### PR TITLE
SIM_MODEL override + optional HTTP request/response logging (log-http)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,20 @@
 # Command line parameters
 The simulator can be configured using either command-line arguments or a YAML file. Parameter names are consistent across both methods.
 
+## Configuration precedence
+For a setting that can come from a YAML file, an environment variable, and command-line flags, the simulator resolves the value in this order (first wins):
+
+1. **Command-line flags** — for example `--model` or `--hash-seed`.
+2. **Environment variables** — only where documented for that setting (for example `SIM_MODEL` for `model`, or `PYTHONHASHSEED` for `hash-seed`, when the corresponding flag is not passed).
+3. **YAML configuration file** — when you pass `--config` and the file defines the field.
+4. **Built-in defaults** — when nothing else set the value.
+
+Some environment variables (for example `POD_NAME`, `POD_NAMESPACE`) are not overrides of a YAML field in this sense; they populate separate runtime fields after parsing.
+
 ## General
 - `config`: the path to a yaml configuration file that can contain the simulator's command line parameters. If a parameter is defined in both the config file and the command line, the command line value overwrites the configuration file value. An example configuration file can be found at [manifests/config.yaml](../manifests/config.yaml)
 - `port`: the port the simulator listents on, default is 8000
-- `model`: the currently 'loaded' model, mandatory
+- `model`: the currently 'loaded' model, mandatory. If you omit `--model` on the command line, a non-empty `SIM_MODEL` environment variable can supply the model; see [Configuration precedence](#configuration-precedence) and [Environment variables](#environment-variables).
 - `served-model-name`: model names exposed by the API (a list of space-separated strings)
 - `lora-modules`: a list of LoRA adapters (a list of space-separated JSON strings): '{"name": "name", "path": "lora_path", "base_model_name": "id"}', optional, empty by default
 - `max-loras`: maximum number of LoRAs in a single batch, optional, default is one
@@ -56,7 +66,7 @@ All latency-related parameters are defined in duration format, e.g., 100ms. Inte
 - `kv-cache-size`: the maximum number of token blocks in kv cache
 - `global-cache-hit-threshold`: default cache hit threshold [0, 1] for all requests. If a request specifies cache_hit_threshold, it takes precedence over this global value
 - `block-size`: token block size for contiguous chunks of tokens, possible values: 8,16,32,64,128
-- `hash-seed`: seed for hash generation (if not set, is read from PYTHONHASHSEED environment variable)
+- `hash-seed`: seed for hash generation. If you omit `--hash-seed` on the command line, a non-empty `PYTHONHASHSEED` environment variable can supply the seed; see [Configuration precedence](#configuration-precedence) and [Environment variables](#environment-variables).
 - `zmq-endpoint`: ZMQ address to publish events
 - `event-batch-size`: the maximum number of kv-cache events to be sent together, defaults to 16
 
@@ -153,6 +163,8 @@ In addition, as we are using klog, the following parameters are available:
 - `vmodule`: comma-separated list of pattern=N settings for file-filtered logging
 
 # Environment variables
+- `SIM_MODEL`: when non-empty and **`--model` is not passed on the command line**, sets the model name. In that case it overrides the `model` value from the YAML file (if any) and the default. If you pass `--model`, it always wins. Useful in Kubernetes when the same image arguments are reused and the model name comes from the pod environment.
+- `PYTHONHASHSEED`: when **`--hash-seed` is not passed on the command line**, a non-empty value supplies the hash seed and overrides `hash-seed` from the YAML file (if any) and the default. If you pass `--hash-seed`, it always wins. Matches common Python hash randomization behavior.
 - `POD_NAME`: the simulator pod name. If defined, the response will contain the HTTP header `x-inference-pod` with this value, and the HTTP header `x-inference-port` with the port that the request was received on 
 - `POD_NAMESPACE`: the simulator pod namespace. If defined, the response will contain the HTTP header `x-inference-namespace` with this value
 - `POD_IP`: the simulator pod IP address. Used in kv-events topic name.

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -205,7 +205,7 @@ type Configuration struct {
 
 	// TokenBlockSize is token block size for contiguous chunks of tokens, possible values: 8,16,32,64,128, defaults to 16
 	TokenBlockSize int `yaml:"block-size" json:"block-size"`
-	// HashSeed is the seed for hash generation (if not set, is read from PYTHONHASHSEED environment variable)
+	// HashSeed is the seed for hash generation. Effective value follows configuration precedence in the docs (command-line --hash-seed, else PYTHONHASHSEED, else YAML, else default).
 	HashSeed string `yaml:"hash-seed" json:"hash-seed"`
 
 	// ZMQEndpoint is the ZMQ address to publish events, the default value is tcp://localhost:5557

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -658,3 +658,55 @@ var _ = Describe("Simulator configuration", func() {
 		})
 	}
 })
+
+var _ = Describe("Model environment variable", func() {
+	BeforeEach(func() {
+		Expect(os.Unsetenv(ModelEnv)).To(Succeed())
+	})
+	AfterEach(func() {
+		Expect(os.Unsetenv(ModelEnv)).To(Succeed())
+	})
+
+	It("does not override --model when the flag is passed", func() {
+		Expect(os.Setenv(ModelEnv, "from-env")).To(Succeed())
+		config, err := createSimConfig([]string{"cmd", "--model", TestModelName, "--mode", ModeRandom, "--seed", "100"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.Model).To(Equal(TestModelName))
+	})
+
+	It("overrides model from config file when --model is omitted", func() {
+		Expect(os.Setenv(ModelEnv, "env-override-model")).To(Succeed())
+		config, err := createSimConfig([]string{"cmd", "--config", "../../manifests/config.yaml"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.Model).To(Equal("env-override-model"))
+	})
+
+	It("does not change model when unset and --model is passed", func() {
+		config, err := createSimConfig([]string{"cmd", "--model", TestModelName, "--mode", ModeRandom, "--seed", "100"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.Model).To(Equal(TestModelName))
+	})
+})
+
+var _ = Describe("PYTHONHASHSEED environment variable", func() {
+	BeforeEach(func() {
+		Expect(os.Unsetenv(PythonHashSeedEnv)).To(Succeed())
+	})
+	AfterEach(func() {
+		Expect(os.Unsetenv(PythonHashSeedEnv)).To(Succeed())
+	})
+
+	It("does not override --hash-seed when the flag is passed", func() {
+		Expect(os.Setenv(PythonHashSeedEnv, "from-env")).To(Succeed())
+		config, err := createSimConfig([]string{"cmd", "--model", TestModelName, "--hash-seed", "from-flag", "--mode", ModeRandom, "--seed", "100"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.HashSeed).To(Equal("from-flag"))
+	})
+
+	It("applies when --hash-seed is omitted", func() {
+		Expect(os.Setenv(PythonHashSeedEnv, "env-seed")).To(Succeed())
+		config, err := createSimConfig([]string{"cmd", "--model", TestModelName, "--mode", ModeRandom, "--seed", "100"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.HashSeed).To(Equal("env-seed"))
+	})
+})

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -32,6 +32,10 @@ const (
 	vllmServerDevModeEnv = "VLLM_SERVER_DEV_MODE"
 	PodNameEnv           = "POD_NAME"
 	PodNsEnv             = "POD_NAMESPACE"
+	// ModelEnv is read when the --model flag is not passed; see configuration precedence in the docs.
+	ModelEnv = "SIM_MODEL"
+	// PythonHashSeedEnv is read when the --hash-seed flag is not passed; see configuration precedence in the docs.
+	PythonHashSeedEnv = "PYTHONHASHSEED"
 )
 
 // Needed to parse values that contain multiple strings
@@ -90,7 +94,8 @@ func addToggle(f *pflag.FlagSet, ptr *bool, name, nameUsage, noNameUsage string)
 }
 
 // ParseCommandParamsAndLoadConfig loads configuration, parses command line parameters, merges the values
-// (command line values overwrite the config file ones), and validates the configuration
+// (command line overwrites the config file; see documentation for configuration precedence involving environment variables),
+// and validates the configuration.
 func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	config := newConfig()
 
@@ -108,7 +113,8 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f := pflag.NewFlagSet("llm-d-inference-sim flags", pflag.ContinueOnError)
 
 	f.IntVar(&config.Port, "port", config.Port, "Port")
-	f.StringVar(&config.Model, "model", config.Model, "Currently 'loaded' model")
+	f.StringVar(&config.Model, "model", config.Model,
+		"Currently 'loaded' model (if omitted on the command line, "+ModelEnv+" may set the model; see docs)")
 	f.IntVar(&config.MaxNumSeqs, "max-num-seqs", config.MaxNumSeqs, "Maximum number of inference requests that could be processed at the same time")
 	f.IntVar(&config.MaxWaitingQueueLength, "max-waiting-queue-length", config.MaxWaitingQueueLength, "Maximum length of inference requests waiting queue")
 	f.IntVar(&config.MaxLoras, "max-loras", config.MaxLoras, "Maximum number of LoRAs in a single batch")
@@ -145,7 +151,8 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.IntVar(&config.KVCacheSize, "kv-cache-size", config.KVCacheSize, "Maximum number of token blocks in kv cache")
 	f.Float64Var(&config.GlobalCacheHitThreshold, "global-cache-hit-threshold", 0, "Default cache hit threshold [0, 1] for all requests. If a request specifies cache_hit_threshold, it takes precedence")
 	f.IntVar(&config.TokenBlockSize, "block-size", config.TokenBlockSize, "Token block size for contiguous chunks of tokens, possible values: 8,16,32,64,128")
-	f.StringVar(&config.HashSeed, "hash-seed", config.HashSeed, "Seed for hash generation (if not set, is read from PYTHONHASHSEED environment variable)")
+	f.StringVar(&config.HashSeed, "hash-seed", config.HashSeed,
+		"Seed for hash generation (if omitted on the command line, "+PythonHashSeedEnv+" may set it; see docs)")
 	f.StringVar(&config.ZMQEndpoint, "zmq-endpoint", config.ZMQEndpoint, "ZMQ address to publish events")
 	f.IntVar(&config.EventBatchSize, "event-batch-size", config.EventBatchSize, "Maximum number of kv-cache events to be sent together")
 	f.IntVar(&config.DPSize, "data-parallel-size", config.DPSize, "Number of ranks to run")
@@ -234,6 +241,13 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	config.PodNameSpace = os.Getenv(PodNsEnv)
 	config.VllmDevMode = os.Getenv(vllmServerDevModeEnv) == "1"
 
+	// Precedence for model and hash-seed: command-line flags > these env vars > YAML > defaults.
+	if !f.Changed("model") {
+		if v := os.Getenv(ModelEnv); v != "" {
+			config.Model = v
+		}
+	}
+
 	// Need to read in a variable to avoid merging the values with the config file ones
 	if loraModuleNames != nil {
 		config.LoraModulesString = loraModuleNames
@@ -253,10 +267,9 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 		config.FailureTypes = failureTypes
 	}
 
-	if config.HashSeed == "" {
-		hashSeed := os.Getenv("PYTHONHASHSEED")
-		if hashSeed != "" {
-			config.HashSeed = hashSeed
+	if !f.Changed("hash-seed") {
+		if v := os.Getenv(PythonHashSeedEnv); v != "" {
+			config.HashSeed = v
 		}
 	}
 


### PR DESCRIPTION
**Summary**
Implements reviewer feedback from [#447](https://github.com/llm-d/llm-d-inference-sim/pull/447): split from HTTP logging; env-driven overrides follow the usual precedence command-line → environment → YAML → defaults.

Behavior

**SIM_MODEL**: applied only when --model is not passed; overrides model from YAML/defaults. If --model is set, it always wins.
**PYTHONHASHSEED**: applied only when --hash-seed is not passed; overrides hash-seed from YAML/defaults. If --hash-seed is set, it always wins.