### PR TITLE
fix: typo in simulator comment (requiest -> request)

### DIFF
--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -272,7 +272,7 @@ func (s *VllmSimulator) findRequestAndSendToProcess(worker *worker) bool {
 	nextReq := s.dequeue()
 	if nextReq != nil {
 		// send this request for processing in this worker
-		// use model defined in the requiest for the logs to present real model name in the logs
+		// use model defined in the request for the logs to present real model name in the logs
 		s.Context.logger.V(logging.TRACE).Info("Sending request to processing", "model", nextReq.request().GetModel(),
 			"req", nextReq.request().GetRequestID(), "worker", worker.id)
 		common.WriteToChannel(worker.reqChan, nextReq, s.Context.logger)


### PR DESCRIPTION
Closes #450.

Fixes the typo flagged by the nightly scanner: `requiest` -> `request` in a comment in `pkg/llm-d-inference-sim/simulator.go:275`.

Single character change in a comment line; no behavior change.