### PR TITLE
Add support for /health/ready endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,7 +22,7 @@ In addition, a set of the vLLM HTTP endpoints are suppored:
 | /is_sleeping            | Checks if the simulator is currently in sleep mode |
 | /metrics                | Exposes Prometheus metrics (see [Metrics Guide](metrics.md)) |
 | /health                 | Standard health check endpoint |
-| /ready                  | Standard readiness endpoint |
+| /health/ready           | Ensure the GPU is "actually working" before allowing the system to send it live traffic |
 
 The simulator also provides a `POST /fake_metrics` endpoint that supports partial updates to [fake metric](configuration.md#fake-metrics) values at runtime. This endpoint is specific to the simulator and is available only when a `--fake-metrics` configuration is provided at startup. The request body must be a JSON object containing the metrics to update; any metrics not specified are left unchanged.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ The simulator can be configured using either command-line arguments or a YAML fi
 - `mode`: the simulator mode, optional, by default `random`
     - `echo`: returns the same text that was sent in the request
     - `random`: returns a sentence chosen at random from a set of pre-defined sentences or a given dataset
+- `startup-duration`: duration the simulator returns HTTP 503 on `/health/ready` to simulate GPU model loading time (e.g. `30s`, `2m`). After this duration elapses from startup, `/health/ready` returns 200. Optional, default is 0 (immediately ready).
 - `enable-sleep-mode`, `no-enable-sleep-mode`: Enable or disable sleep mode feature. When enabled, the simulator can be put to sleep via the `/sleep` endpoint and woken up via the `/wake_up` endpoint
 - `enable-request-id-headers`: Enable including X-Request-Id header in responses. When enabled, the simulator will include the request ID in response headers
 - `mm-encoder-only`, `no-mm-encoder-only`: Skip  (or don't skip) the language component of the model.

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -260,6 +260,10 @@ type Configuration struct {
 	// Tokenizer UDS socker path
 	UDSSocketPath string `yaml:"uds-socket-path" json:"uds-socket-path"`
 
+	// StartupDuration defines how long /health/ready returns 503 to simulate GPU model loading.
+	// After this duration from startup, /health/ready returns 200. Default is 0 (immediately ready).
+	StartupDuration time.Duration `yaml:"startup-duration" json:"startup-duration"`
+
 	// EnableSleepMode enables sleep mode
 	EnableSleepMode bool `yaml:"enable-sleep-mode" json:"enable-sleep-mode"`
 

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -158,6 +158,9 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 
 	f.StringVar(&config.UDSSocketPath, "uds-socket-path", config.UDSSocketPath, "UDS socket path for communication with HF tokenizer, default is '/tmp/tokenizer/tokenizer-uds.socket'")
 
+	f.DurationVar(&config.StartupDuration, "startup-duration", config.StartupDuration,
+		"Duration to return 503 on /health/ready to simulate GPU loading (e.g. 30s). Default is 0 (immediately ready)")
+
 	addToggle(f, &config.EnableSleepMode, "enable-sleep-mode", "Enable sleep mode", "Disable sleep mode")
 	f.BoolVar(&config.EnableRequestIDHeaders, "enable-request-id-headers", config.EnableRequestIDHeaders, "Enable including X-Request-Id header in responses")
 

--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -44,6 +44,8 @@ type Communication struct {
 	sleepMutex sync.RWMutex
 
 	pb.UnimplementedVllmEngineServer
+
+	deprecatedLogged bool
 }
 
 func New(logger logr.Logger, simulator *vllmsim.VllmSimulator) *Communication {

--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -46,14 +46,17 @@ type Communication struct {
 	pb.UnimplementedVllmEngineServer
 
 	deprecatedLogged bool
+
+	// startTime records when the server started, used for startup-duration readiness check
+	startTime time.Time
 }
 
 func New(logger logr.Logger, simulator *vllmsim.VllmSimulator) *Communication {
-	return &Communication{logger: logger, simulator: simulator}
+	return &Communication{logger: logger, simulator: simulator, startTime: time.Now()}
 }
 
 func Start(ctx context.Context, logger logr.Logger, simulator *vllmsim.VllmSimulator) error {
-	c := Communication{logger: logger, simulator: simulator}
+	c := Communication{logger: logger, simulator: simulator, startTime: time.Now()}
 	c.logger.V(logging.INFO).Info("Starting communication layer")
 	return c.start(ctx)
 }

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -76,6 +76,7 @@ func (c *Communication) startHTTPServer(listener net.Listener) (*fasthttp.Server
 	r.POST("/fake_metrics", c.HandleFakeMetrics)
 	// supports standard Kubernetes health and readiness checks
 	r.GET("/health", c.HandleHealth)
+	r.GET("/health/ready", c.HandleHealthReady)
 	r.GET("/ready", c.HandleReady)
 	r.POST("/tokenize", c.HandleTokenize)
 	r.POST("/sleep", c.HandleSleep)
@@ -605,15 +606,25 @@ func (c *Communication) HandleHealth(ctx *fasthttp.RequestCtx) {
 	c.logger.V(logging.TRACE).Info("Health request received")
 	ctx.Response.Header.SetContentType("application/json")
 	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
-	ctx.Response.SetBody([]byte("{}"))
+}
+
+// HandleHealth http handler for /health/ready
+func (c *Communication) HandleHealthReady(ctx *fasthttp.RequestCtx) {
+	c.logger.V(logging.TRACE).Info("Health ready request received")
+	ctx.Response.Header.SetContentType("application/json")
+	// c.simulator.IsReady()
+	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
 }
 
 // HandleReady http handler for /ready
 func (c *Communication) HandleReady(ctx *fasthttp.RequestCtx) {
 	c.logger.V(logging.TRACE).Info("Readiness request received")
+	if !c.deprecatedLogged {
+		c.deprecatedLogged = true
+		c.logger.V(logging.INFO).Info("/ready endpoint is deprecated and will be removed in a future release; please use /health/ready instead")
+	}
 	ctx.Response.Header.SetContentType("application/json")
 	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
-	ctx.Response.SetBody([]byte("{}"))
 }
 
 // HandleIsSleeping handles /is_sleeping request according

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -612,7 +612,10 @@ func (c *Communication) HandleHealth(ctx *fasthttp.RequestCtx) {
 func (c *Communication) HandleHealthReady(ctx *fasthttp.RequestCtx) {
 	c.logger.V(logging.TRACE).Info("Health ready request received")
 	ctx.Response.Header.SetContentType("application/json")
-	// c.simulator.IsReady()
+	if d := c.simulator.Context.Config.StartupDuration; d > 0 && time.Since(c.startTime) < d {
+		ctx.Response.Header.SetStatusCode(fasthttp.StatusServiceUnavailable)
+		return
+	}
 	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
 }
 

--- a/pkg/tests/http_server_test.go
+++ b/pkg/tests/http_server_test.go
@@ -57,6 +57,34 @@ var _ = Describe("Server", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	})
 
+	It("Should return 503 on /health/ready during startup-duration", func() {
+		ctx := context.TODO()
+		args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom,
+			"--startup-duration", "10s"}
+		client, err := startServerWithArgs(ctx, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, err := client.Get("http://localhost/health/ready")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusServiceUnavailable))
+	})
+
+	It("Should return 200 on /health/ready after startup-duration elapses", func() {
+		ctx := context.TODO()
+		args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom,
+			"--startup-duration", "100ms"}
+		client, err := startServerWithArgs(ctx, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() int {
+			resp, err := client.Get("http://localhost/health/ready")
+			if err != nil {
+				return 0
+			}
+			return resp.StatusCode
+		}, 5*time.Second, 50*time.Millisecond).Should(Equal(http.StatusOK))
+	})
+
 	Context("tokenize", Ordered, func() {
 		It("Should return correct response to /tokenize chat", func() {
 			ctx := context.TODO()

--- a/pkg/tests/http_server_test.go
+++ b/pkg/tests/http_server_test.go
@@ -47,12 +47,12 @@ var _ = Describe("Server", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	})
 
-	It("Should respond to /ready", func() {
+	It("Should respond to /health/ready", func() {
 		ctx := context.TODO()
 		client, err := startServer(ctx, common.ModeRandom)
 		Expect(err).NotTo(HaveOccurred())
 
-		resp, err := client.Get("http://localhost/ready")
+		resp, err := client.Get("http://localhost/health/ready")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	})


### PR DESCRIPTION
In vLLM  /health/ready returns success status (code 200) when the engine is ready to process inference requests.
Simulate this by adding a new command line parameter `--startup-duration` which defines the simulator startup time.
During this period `/health/ready` returns code 503.

Fixes #453 