### PR TITLE
Fix health checks in the disaggregation example

### DIFF
--- a/manifests/disaggregation/vllm-sim-pd.yaml
+++ b/manifests/disaggregation/vllm-sim-pd.yaml
@@ -32,13 +32,13 @@ spec:
           containerPort: 8082
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 8082
           initialDelaySeconds: 10
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 8082
           initialDelaySeconds: 5
           periodSeconds: 5
@@ -96,13 +96,13 @@ spec:
           containerPort: 8082
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 8082
           initialDelaySeconds: 10
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 8082
           initialDelaySeconds: 5
           periodSeconds: 5


### PR DESCRIPTION
I was not able to deploy the disaggregation example due to the failing healthchecks (see the HTTP error code 404) of the tokenizer:
```
kubectl logs -c uds-tokenizer -f vllm-sim-d-777f9877d9-gj2ct
INFO 04-28 12:03:13 [importing.py:44] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
INFO 04-28 12:03:13 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
2026-04-28 12:03:15,395 [DEBUG] [asyncio] Using selector: EpollSelector
2026-04-28 12:03:15,396 [DEBUG] [grpc._cython.cygrpc] [_cygrpc] Loaded running loop: id(loop)=134185737324928
2026-04-28 12:03:15,396 [DEBUG] [grpc._cython.cygrpc] Using AsyncIOEngine.POLLER as I/O engine
2026-04-28 12:03:15,397 [DEBUG] [grpc._cython.cygrpc] [_cygrpc] Loaded running loop: id(loop)=134185737324928
2026-04-28 12:03:15,398 [INFO] [root] TokenizationServiceServicer initialized
2026-04-28 12:03:15,398 [INFO] [root] gRPC reflection disabled (set `ENABLE_GRPC_REFLECTION=1` to enable)
2026-04-28 12:03:15,398 [INFO] [root] gRPC server configured to listen on /tmp/tokenizer/tokenizer-uds.socket
2026-04-28 12:03:15,399 [DEBUG] [grpc._cython.cygrpc] [_cygrpc] Loaded running loop: id(loop)=134185737324928
2026-04-28 12:03:15,399 [INFO] [root] gRPC server started on /tmp/tokenizer/tokenizer-uds.socket
2026-04-28 12:03:15,399 [INFO] [root] Probe server started on port 8082
2026-04-28 12:03:15,399 [INFO] [root] Server started.
2026-04-28 12:03:30,350 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:03:30 +0000] "GET /health HTTP/1.1" 404 193 "-" "kube-probe/1.35"
2026-04-28 12:03:35,056 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:03:35 +0000] "GET /health HTTP/1.1" 404 193 "-" "kube-probe/1.35"
2026-04-28 12:03:40,349 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:03:40 +0000] "GET /health HTTP/1.1" 404 193 "-" "kube-probe/1.35"
2026-04-28 12:03:45,056 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:03:45 +0000] "GET /health HTTP/1.1" 404 193 "-" "kube-probe/1.35"
2026-04-28 12:03:50,349 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:03:50 +0000] "GET /health HTTP/1.1" 404 193 "-" "kube-probe/1.35"
2026-04-28 12:03:55,058 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:03:55 +0000] "GET /health HTTP/1.1" 404 193 "-" "kube-probe/1.35"
2026-04-28 12:03:55,060 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:03:55 +0000] "GET /health HTTP/1.1" 404 193 "-" "kube-probe/1.35"
2026-04-28 12:03:55,119 [INFO] [root] Shutdown signal received
2026-04-28 12:03:55,119 [INFO] [root] Stopping gRPC server (grace=30.0s)...
2026-04-28 12:03:55,120 [INFO] [root] Server shutdown complete.
```

The endpoint `/healtzh` does the job:
```
2026-04-28 12:51:59,933 [DEBUG] [grpc._cython.cygrpc] [_cygrpc] Loaded running loop: id(loop)=135834987136640
2026-04-28 12:51:59,934 [INFO] [root] TokenizationServiceServicer initialized
2026-04-28 12:51:59,934 [INFO] [root] gRPC reflection disabled (set `ENABLE_GRPC_REFLECTION=1` to enable)
2026-04-28 12:51:59,934 [INFO] [root] gRPC server configured to listen on /tmp/tokenizer/tokenizer-uds.socket
2026-04-28 12:51:59,934 [DEBUG] [grpc._cython.cygrpc] [_cygrpc] Loaded running loop: id(loop)=135834987136640
2026-04-28 12:51:59,934 [INFO] [root] gRPC server started on /tmp/tokenizer/tokenizer-uds.socket
2026-04-28 12:51:59,935 [INFO] [root] Probe server started on port 8082
2026-04-28 12:51:59,935 [INFO] [root] Server started.
2026-04-28 12:52:00,266 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:52:00 +0000] "GET /healthz HTTP/1.1" 200 263 "-" "kube-probe/1.35"
2026-04-28 12:52:05,266 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:52:05 +0000] "GET /healthz HTTP/1.1" 200 264 "-" "kube-probe/1.35"
2026-04-28 12:52:09,437 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:52:09 +0000] "GET /healthz HTTP/1.1" 200 264 "-" "kube-probe/1.35"
2026-04-28 12:52:10,265 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:52:10 +0000] "GET /healthz HTTP/1.1" 200 264 "-" "kube-probe/1.35"
2026-04-28 12:52:15,266 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:52:15 +0000] "GET /healthz HTTP/1.1" 200 264 "-" "kube-probe/1.35"
2026-04-28 12:52:19,438 [INFO] [aiohttp.access] 10.42.0.1 [28/Apr/2026:12:52:19 +0000] "GET /healthz HTTP/1.1" 200 264 "-" "kube-probe/1.35"
...
```