### PR TITLE
feat: optional full HTTP request/response logging (--log-http)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,7 @@ The simulator can be configured using either command-line arguments or a YAML fi
 - `startup-duration`: duration the simulator returns HTTP 503 on `/health/ready` to simulate GPU model loading time (e.g. `30s`, `2m`). After this duration elapses from startup, `/health/ready` returns 200. Optional, default is 0 (immediately ready).
 - `enable-sleep-mode`, `no-enable-sleep-mode`: Enable or disable sleep mode feature. When enabled, the simulator can be put to sleep via the `/sleep` endpoint and woken up via the `/wake_up` endpoint
 - `enable-request-id-headers`: Enable including X-Request-Id header in responses. When enabled, the simulator will include the request ID in response headers
+- `log-http`: When true, logs each HTTP request and response at INFO (method, URI, remote address, headers, and body when buffered). Streamed response bodies (for example SSE) are not logged. Use only in trusted environments; may include secrets such as `Authorization` headers.
 - `mm-encoder-only`, `no-mm-encoder-only`: Skip  (or don't skip) the language component of the model.
 
 ## Latency 

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -270,6 +270,9 @@ type Configuration struct {
 	// EnableRequestIDHeaders enables including X-Request-Id header in responses
 	EnableRequestIDHeaders bool `yaml:"enable-request-id-headers" json:"enable-request-id-headers"`
 
+	// LogHTTP logs full HTTP request and response details (method, URI, headers, bodies where buffered, status) for each request.
+	LogHTTP bool `yaml:"log-http" json:"log-http"`
+
 	// LatencyCalculator is the name of the latency calculator to use in the simulation of the response latencies.
 	// The default calculation is based on the current load of the simulator and on the configured latency
 	// parameters, e.g., time-to-first-token and prefill-time-per-token.

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -163,6 +163,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 
 	addToggle(f, &config.EnableSleepMode, "enable-sleep-mode", "Enable sleep mode", "Disable sleep mode")
 	f.BoolVar(&config.EnableRequestIDHeaders, "enable-request-id-headers", config.EnableRequestIDHeaders, "Enable including X-Request-Id header in responses")
+	f.BoolVar(&config.LogHTTP, "log-http", config.LogHTTP, "Log full HTTP request and response (method, URI, headers, bodies when buffered, status); streamed bodies are not logged")
 
 	f.IntVar(&config.FailureInjectionRate, "failure-injection-rate", config.FailureInjectionRate, "Probability (0-100) of injecting failures")
 	failureTypes := getParamValueFromArgs("failure-types")

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -45,6 +45,8 @@ const (
 	RequestIDHeader                  = "X-Request-Id"
 	CacheThresholdFinishReasonHeader = "X-Cache-Threshold-Finish-Reason"
 	XReturnErrorHeader               = "X-Return-Error"
+
+	maxHTTPLogBodyBytes = 512 * 1024
 )
 
 func (c *Communication) newListener() (net.Listener, error) {
@@ -84,9 +86,14 @@ func (c *Communication) startHTTPServer(listener net.Listener) (*fasthttp.Server
 	r.POST("/wake_up", c.HandleWakeUp)
 	r.GET("/is_sleeping", c.HandleIsSleeping)
 
+	handler := r.Handler
+	if c.simulator.Context.Config.LogHTTP {
+		handler = c.logHTTPMiddleware(handler)
+	}
+
 	server := &fasthttp.Server{
 		ErrorHandler: c.HandleError,
-		Handler:      r.Handler,
+		Handler:      handler,
 		Logger:       c,
 	}
 
@@ -697,6 +704,73 @@ func (c *Communication) HandleWakeUp(ctx *fasthttp.RequestCtx) {
 	c.simulator.IsSleeping = false
 
 	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
+}
+
+func formatRequestHeaders(h *fasthttp.RequestHeader) string {
+	var b strings.Builder
+	for key, value := range h.All() {
+		b.Write(key)
+		b.WriteString(": ")
+		b.Write(value)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func formatResponseHeaders(h *fasthttp.ResponseHeader) string {
+	var b strings.Builder
+	for key, value := range h.All() {
+		b.Write(key)
+		b.WriteString(": ")
+		b.Write(value)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func truncateBodyForLog(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	if len(body) <= maxHTTPLogBodyBytes {
+		return string(body)
+	}
+	return string(body[:maxHTTPLogBodyBytes]) + fmt.Sprintf(" ... [truncated, total %d bytes]", len(body))
+}
+
+func (c *Communication) logHTTPMiddleware(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		c.logHTTPRequest(ctx)
+		next(ctx)
+		c.logHTTPResponse(ctx)
+	}
+}
+
+func (c *Communication) logHTTPRequest(ctx *fasthttp.RequestCtx) {
+	c.logger.V(logging.INFO).Info("HTTP request",
+		"method", string(ctx.Method()),
+		"requestURI", string(ctx.RequestURI()),
+		"remoteAddr", ctx.RemoteAddr().String(),
+		"headers", formatRequestHeaders(&ctx.Request.Header),
+		"body", truncateBodyForLog(ctx.Request.Body()),
+	)
+}
+
+func (c *Communication) logHTTPResponse(ctx *fasthttp.RequestCtx) {
+	resp := &ctx.Response
+	if resp.BodyStream() != nil {
+		c.logger.V(logging.INFO).Info("HTTP response",
+			"statusCode", resp.StatusCode(),
+			"headers", formatResponseHeaders(&resp.Header),
+			"body", "<streamed response body not logged>",
+		)
+		return
+	}
+	c.logger.V(logging.INFO).Info("HTTP response",
+		"statusCode", resp.StatusCode(),
+		"headers", formatResponseHeaders(&resp.Header),
+		"body", truncateBodyForLog(resp.Body()),
+	)
 }
 
 // HandleFakeMetrics HTTP handler for /fake_metrics


### PR DESCRIPTION

**log-http / --log-http** — When enabled, logs each HTTP request and response at INFO: method, URI, remote address, headers, and body when it is buffered in memory. Bodies are truncated after 512 KiB. Streamed responses (for example SSE) log status and headers only, not the stream body. Documented in docs/configuration.md with a warning that logs may include sensitive data such as Authorization headers, so this should be used only in trusted environments.
