### PR TITLE
Extend /inference/v1/generate to support encode parameters

### DIFF
--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -485,8 +485,9 @@ func (respBuilder *generateHTTPRespBuilder) createResponse(respCtx vllmsim.Respo
 	choice.Index = 0
 	choice.FinishReason = respCtx.FinishReason()
 	return &openaiserverapi.GenerateResponse{
-		Choices:      []openaiserverapi.GenerateRespChoice{choice},
-		GenRequestID: respCtx.RequestID(),
+		Choices:          []openaiserverapi.GenerateRespChoice{choice},
+		GenRequestID:     respCtx.RequestID(),
+		ECTransferParams: respCtx.ECTransferParams(),
 	}
 }
 

--- a/pkg/llm-d-inference-sim/chat_completion.go
+++ b/pkg/llm-d-inference-sim/chat_completion.go
@@ -66,7 +66,7 @@ func (c *ChatCompletionsRequest) AsString() string {
 
 func (c *ChatCompletionsRequest) createResponseContext(reqCtx requestContext, displayModel string,
 	responseTokens *openaiserverapi.Tokenized, finishReason *string, usageData *openaiserverapi.Usage,
-	sendUsageData bool, logprobs *int, toolCalls []openaiserverapi.ToolCall) ResponseContext {
+	sendUsageData bool, logprobs *int, toolCalls []openaiserverapi.ToolCall, _ bool) ResponseContext {
 	base := newBaseResponseContext(reqCtx, displayModel, responseTokens, finishReason, usageData, sendUsageData,
 		logprobs, c.GetRequestID(), c.IsDoRemotePrefill(), c.IsDoRemoteDecode(), c.GetNumberOfCachedPromptTokens())
 	return &chatCompletionsResponseCtx{

--- a/pkg/llm-d-inference-sim/generate.go
+++ b/pkg/llm-d-inference-sim/generate.go
@@ -66,11 +66,18 @@ func (g *GenerateRequest) AsString() string {
 
 func (g *GenerateRequest) createResponseContext(reqCtx requestContext, displayModel string,
 	responseTokens *openaiserverapi.Tokenized, finishReason *string, usageData *openaiserverapi.Usage,
-	sendUsageData bool, logprobs *int, toolCalls []openaiserverapi.ToolCall) ResponseContext {
+	sendUsageData bool, logprobs *int, toolCalls []openaiserverapi.ToolCall, mmEncoderOnlyMode bool) ResponseContext {
 	base := newBaseResponseContext(reqCtx, displayModel, responseTokens, finishReason, usageData, sendUsageData,
 		logprobs, g.GetRequestID(), g.IsDoRemotePrefill(), g.IsDoRemoteDecode(), g.GetNumberOfCachedPromptTokens())
+
+	var ecParams map[string]openaiserverapi.ECTransferParams
+	if mmEncoderOnlyMode && g.Features != nil {
+		ecParams = buildECTransferParams(g.Features)
+	}
+
 	return &generateResponseCtx{
 		baseResponseContext: base,
+		ecTransferParams:    ecParams,
 	}
 }
 
@@ -103,10 +110,32 @@ var _ requestContext = (*generateReqCtx)(nil)
 // Implementation of responseContext for generation requests
 type generateResponseCtx struct {
 	baseResponseContext
+	ecTransferParams map[string]openaiserverapi.ECTransferParams
 }
 
 func (respCtx *generateResponseCtx) ToolCalls() []openaiserverapi.ToolCall {
 	return nil
 }
 
+func (respCtx *generateResponseCtx) ECTransferParams() map[string]openaiserverapi.ECTransferParams {
+	return respCtx.ecTransferParams
+}
+
 var _ ResponseContext = (*generateResponseCtx)(nil)
+
+// buildECTransferParams creates simulated ECTransferParams for each MM hash in the request features.
+func buildECTransferParams(features *openaiserverapi.EncodeMMFeatures) map[string]openaiserverapi.ECTransferParams {
+	params := make(map[string]openaiserverapi.ECTransferParams)
+
+	for _, hashes := range features.MMHashes {
+		for _, hash := range hashes {
+			params[hash] = openaiserverapi.ECTransferParams{
+				PeerHost:      "DUMMY",
+				PeerPort:      1234,
+				SizeBytes:     2359296,
+				NixlAgentData: []byte("NIXL_METADATA_PLACEHOLDER"),
+			}
+		}
+	}
+	return params
+}

--- a/pkg/llm-d-inference-sim/generation.go
+++ b/pkg/llm-d-inference-sim/generation.go
@@ -50,7 +50,7 @@ func (g *GenerationRequest) AsString() string {
 
 func (g *GenerationRequest) createResponseContext(reqCtx requestContext, displayModel string,
 	responseTokens *openaiserverapi.Tokenized, finishReason *string, usageData *openaiserverapi.Usage,
-	sendUsageData bool, logprobs *int, toolCalls []openaiserverapi.ToolCall) ResponseContext {
+	sendUsageData bool, logprobs *int, toolCalls []openaiserverapi.ToolCall, _ bool) ResponseContext {
 	base := newBaseResponseContext(reqCtx, displayModel, responseTokens, finishReason, usageData, sendUsageData,
 		logprobs, g.GetRequestID(), g.IsDoRemotePrefill(), g.IsDoRemoteDecode(), g.GetNumberOfCachedPromptTokens())
 	return &generationResponseCtx{

--- a/pkg/llm-d-inference-sim/request.go
+++ b/pkg/llm-d-inference-sim/request.go
@@ -31,8 +31,9 @@ type requestBuilder interface {
 	validate(toolsValidator *toolsValidator) (string, int)
 	buildRequestContext(simCtx *SimContext, channel common.Channel[*ResponseInfo]) requestContext
 	AsString() string
-	createResponseContext(reqCtx requestContext, displayModel string, responseTokens *openaiserverapi.Tokenized, finishReason *string,
-		usageData *openaiserverapi.Usage, sendUsageData bool, logprobs *int, toolCalls []openaiserverapi.ToolCall) ResponseContext
+	createResponseContext(reqCtx requestContext, displayModel string, responseTokens *openaiserverapi.Tokenized,
+		finishReason *string, usageData *openaiserverapi.Usage, sendUsageData bool, logprobs *int,
+		toolCalls []openaiserverapi.ToolCall, mmEncoderOnlyMode bool) ResponseContext
 }
 
 type Request interface {
@@ -175,7 +176,7 @@ func (reqCtx *baseRequestContext) handleRequest() (ResponseContext, *openaiserve
 		}
 		sendUsageData := !req.IsStream() || req.IncludeUsage()
 		respCtx := req.createResponseContext(reqCtx, dispModel, &openaiserverapi.Tokenized{},
-			&finishReason, &usageData, sendUsageData, logprobs, nil)
+			&finishReason, &usageData, sendUsageData, logprobs, nil, reqCtx.sim.Config.MMEncoderOnly)
 		return respCtx, nil
 	}
 
@@ -219,7 +220,7 @@ func (reqCtx *baseRequestContext) handleRequest() (ResponseContext, *openaiserve
 	}
 
 	respCtx := req.createResponseContext(reqCtx, dispModel, responseTokens, &finishReason,
-		&usageData, sendUsageData, logprobs, toolCalls)
+		&usageData, sendUsageData, logprobs, toolCalls, reqCtx.sim.Config.MMEncoderOnly)
 
 	return respCtx, nil
 }

--- a/pkg/llm-d-inference-sim/response.go
+++ b/pkg/llm-d-inference-sim/response.go
@@ -48,6 +48,7 @@ type ResponseContext interface {
 	CreationTime() int64
 	SetCreationTime(int64)
 	Logprobs() *int
+	ECTransferParams() map[string]openaiserverapi.ECTransferParams
 	setWG(*sync.WaitGroup)
 	Done()
 }
@@ -141,6 +142,10 @@ func (respCtx *baseResponseContext) Logprobs() *int {
 }
 
 func (respCtx *baseResponseContext) Instructions() *string {
+	return nil
+}
+
+func (respCtx *baseResponseContext) ECTransferParams() map[string]openaiserverapi.ECTransferParams {
 	return nil
 }
 

--- a/pkg/llm-d-inference-sim/responses.go
+++ b/pkg/llm-d-inference-sim/responses.go
@@ -52,7 +52,7 @@ func (r *ResponsesRequest) AsString() string {
 
 func (r *ResponsesRequest) createResponseContext(reqCtx requestContext, displayModel string,
 	responseTokens *openaiserverapi.Tokenized, finishReason *string, usageData *openaiserverapi.Usage, sendUsageData bool,
-	logprobs *int, toolCalls []openaiserverapi.ToolCall) ResponseContext {
+	logprobs *int, toolCalls []openaiserverapi.ToolCall, _ bool) ResponseContext {
 	base := newBaseResponseContext(reqCtx, displayModel, responseTokens, finishReason, usageData, sendUsageData,
 		logprobs, r.GetRequestID(), r.IsDoRemotePrefill(), r.IsDoRemoteDecode(), r.GetNumberOfCachedPromptTokens())
 	return &responsesResponseCtx{

--- a/pkg/llm-d-inference-sim/text_completion.go
+++ b/pkg/llm-d-inference-sim/text_completion.go
@@ -53,7 +53,7 @@ func (t *TextCompletionsRequest) AsString() string {
 
 func (t *TextCompletionsRequest) createResponseContext(reqCtx requestContext, displayModel string,
 	responseTokens *openaiserverapi.Tokenized, finishReason *string, usageData *openaiserverapi.Usage, sendUsageData bool,
-	logprobs *int, toolCalls []openaiserverapi.ToolCall) ResponseContext {
+	logprobs *int, toolCalls []openaiserverapi.ToolCall, _ bool) ResponseContext {
 	base := newBaseResponseContext(reqCtx, displayModel, responseTokens, finishReason, usageData, sendUsageData,
 		logprobs, t.GetRequestID(), t.IsDoRemotePrefill(), t.IsDoRemoteDecode(), t.GetNumberOfCachedPromptTokens())
 	return &textCompletionsResponseCtx{

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -711,32 +711,37 @@ func (req *ResponsesRequest) ExtractMaxTokens() *int64 {
 // GenerateRequest defines structure of generate request
 type GenerateRequest struct {
 	baseRequest
-	TokenIDs       []uint32        `json:"token_ids"`
-	SamplingParams *SamplingParams `json:"sampling_params"`
+	TokenIDs       []uint32          `json:"token_ids"`
+	SamplingParams *SamplingParams   `json:"sampling_params"`
+	Features       *EncodeMMFeatures `json:"features"`
 }
 
 type SamplingParams struct {
 	MaxTokens *int64 `json:"max_tokens"`
 }
 
+type EncodeMMFeatures struct {
+	MMHashes map[string][]string `json:"mm_hashes"`
+}
+
 var _ Request = (*GenerateRequest)(nil)
 
-func (c *GenerateRequest) GetTools() []Tool {
+func (g *GenerateRequest) GetTools() []Tool {
 	return nil
 }
 
-func (c *GenerateRequest) GetToolChoice() ToolChoice {
+func (g *GenerateRequest) GetToolChoice() ToolChoice {
 	return ToolChoice{}
 }
 
-func (c *GenerateRequest) GetMaxCompletionTokens() *int64 {
-	return c.SamplingParams.MaxTokens
+func (g *GenerateRequest) GetMaxCompletionTokens() *int64 {
+	return g.SamplingParams.MaxTokens
 }
 
-func (req *GenerateRequest) ExtractMaxTokens() *int64 {
-	return req.SamplingParams.MaxTokens
+func (g *GenerateRequest) ExtractMaxTokens() *int64 {
+	return g.SamplingParams.MaxTokens
 }
 
-func (t *GenerateRequest) GetLogprobs() *int {
+func (g *GenerateRequest) GetLogprobs() *int {
 	return nil
 }

--- a/pkg/openai-server-api/response.go
+++ b/pkg/openai-server-api/response.go
@@ -526,11 +526,19 @@ type ResponsesItemEvent struct {
 // GenerateResponse defines structure of generate response
 type GenerateResponse struct {
 	baseResponse
-	Choices      []GenerateRespChoice `json:"choices"`
-	GenRequestID string               `json:"request_id"`
+	Choices          []GenerateRespChoice        `json:"choices"`
+	GenRequestID     string                      `json:"request_id"`
+	ECTransferParams map[string]ECTransferParams `json:"ec_transfer_params"`
 }
 
 type GenerateRespChoice struct {
 	baseResponseChoice
 	TokenIDs []uint32 `json:"token_ids"`
+}
+
+type ECTransferParams struct {
+	PeerHost      string `json:"peer_host"`
+	PeerPort      int    `json:"peer_port"`
+	SizeBytes     int    `json:"size_bytes"`
+	NixlAgentData []byte `json:"nixl_agent_metadata_b64"`
 }

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -1688,6 +1688,74 @@ var _ = Describe("Simulator", func() {
 				"Missing sampling_params field",
 			),
 		)
+
+		It("Should return ec_transfer_params in MMEncoderOnly mode when features are present", func() {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mm-encoder-only"}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			reqBody := fmt.Sprintf(`{
+				"model": "%s",
+				"token_ids": [1, 32000, 32000, 32000],
+				"features": {
+					"mm_hashes": {"image": ["abc123hash", "def456hash"]},
+					"mm_placeholders": {"image": [{"offset": 1, "length": 3}]},
+					"kwargs_data": {"image": ["<base64-encoded-pixel-tensor-1>"]}
+				},
+				"sampling_params": {"max_tokens": 1}
+			}`, common.TestModelName)
+
+			resp, err := client.Post("http://localhost/inference/v1/generate", "application/json", strings.NewReader(reqBody))
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := resp.Body.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			var generateResp openaiserverapi.GenerateResponse
+			Expect(json.Unmarshal(body, &generateResp)).To(Succeed())
+			Expect(generateResp.GenRequestID).NotTo(BeEmpty())
+			Expect(generateResp.Choices).To(HaveLen(1))
+			Expect(generateResp.ECTransferParams).To(HaveLen(2))
+			Expect(generateResp.ECTransferParams).To(HaveKey("abc123hash"))
+			Expect(generateResp.ECTransferParams).To(HaveKey("def456hash"))
+			Expect(generateResp.ECTransferParams["abc123hash"].PeerPort).To(BeNumerically(">", 0))
+		})
+
+		It("Should not return ec_transfer_params when features are nil", func() {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mm-encoder-only"}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			reqBody := fmt.Sprintf(`{
+				"model": "%s",
+				"token_ids": [1, 2, 3, 4],
+				"sampling_params": {"max_tokens": 1}
+			}`, common.TestModelName)
+
+			resp, err := client.Post("http://localhost/inference/v1/generate", "application/json", strings.NewReader(reqBody))
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := resp.Body.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			var generateResp openaiserverapi.GenerateResponse
+			Expect(json.Unmarshal(body, &generateResp)).To(Succeed())
+			Expect(generateResp.ECTransferParams).To(BeNil())
+		})
 	})
 
 	Context("kv-events for requests", func() {


### PR DESCRIPTION
add features to the request and ec_transfer_params to the response