### PR TITLE
feat: adds `--force-dummy-tokenizer` flag to force the use of the dummy tokenizer regardless of model name.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,7 @@ All latency-related parameters are defined in duration format, e.g., 100ms. Inte
 - `render-url`: URL of the vLLM render service used for tokenization. Required when the model is a real HuggingFace model; omit for simulated/dummy models. Default is `http://localhost:8082`.
 - `render-timeout`: Timeout for tokenizer render requests (e.g. `30s`). Default is `30s`.
 - `mm-render-timeout`: Timeout for multi-modal tokenizer render requests (e.g. `60s`). Default is `60s`.
+- `force-dummy-tokenizer`: Force the use of dummy tokenizer even if a real model name is provided. When this flag is set, the system bypasses loading the real tokenizer and uses a regex-based dummy tokenizer instead. This is useful for testing scenarios where you want to use a real model name but avoid the overhead of downloading and loading the actual tokenizer. Default is `false`.
 
 ## Embeddings
 - `default-embedding-dimensions`: default size of embedding vectors returned by `/v1/embeddings` when the request does not specify a `dimensions` field, optional, defaults to 384.

--- a/docs/tokenization.md
+++ b/docs/tokenization.md
@@ -25,6 +25,7 @@ This mode is activated when the `--model` parameter specifies a name that does n
 ## Performance Considerations
 **Important:** If you want to avoid the cost and operational overhead of running the render service:
 - Use a "fake" or non-existent model name (e.g., `--model fake-model`)
+- Or use the `--force-dummy-tokenizer` flag with any model name
 - This is recommended for testing scenarios where exact tokenization accuracy is not required
 - The render service is only required when you need accurate token counts matching actual HuggingFace models
 
@@ -35,6 +36,7 @@ This mode is activated when the `--model` parameter specifies a name that does n
 | `--render-url` | URL of the vLLM render service. Used only in HuggingFace Mode. | `http://localhost:8082` |
 | `--render-timeout` | Timeout for tokenizer render requests (Go duration, e.g. `30s`). | `30s` |
 | `--mm-render-timeout` | Timeout for multi-modal tokenizer render requests. | `60s` |
+| `--force-dummy-tokenizer` | Force the use of dummy tokenizer even if a real model name is provided | `false` |
 
 
 ## Examples
@@ -48,4 +50,9 @@ Running with HuggingFace tokenization (requires a vLLM render service):
 Running with simulated tokenization (no render service required):
 ```bash
 ./bin/llm-d-inference-sim --model test-sim-model
+```
+
+Running with simulated tokenization (forcing dummy tokenizer with a real model name):
+```bash
+./bin/llm-d-inference-sim --model meta-llama/Llama-3.1-8B-Instruct --force-dummy-tokenizer
 ```

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -261,6 +261,8 @@ type Configuration struct {
 	RenderTimeout time.Duration `yaml:"render-timeout" json:"render-timeout"`
 	// MMRenderTimeout is the timeout for multi-modal tokenizer render requests
 	MMRenderTimeout time.Duration `yaml:"mm-render-timeout" json:"mm-render-timeout"`
+	// ForceDummyTokenizer forces the use of the dummy tokenizer even if a real model name is provided
+	ForceDummyTokenizer bool `yaml:"force-dummy-tokenizer" json:"force-dummy-tokenizer"`
 
 	// StartupDuration defines how long /health/ready returns 503 to simulate GPU model loading.
 	// After this duration from startup, /health/ready returns 200. Default is 0 (immediately ready).

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -166,6 +166,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.StringVar(&config.RenderURL, "render-url", config.RenderURL, "URL of the tokenizer render service")
 	f.DurationVar(&config.RenderTimeout, "render-timeout", config.RenderTimeout, "Timeout for tokenizer render requests (e.g. 30s)")
 	f.DurationVar(&config.MMRenderTimeout, "mm-render-timeout", config.MMRenderTimeout, "Timeout for multi-modal tokenizer render requests (e.g. 60s)")
+	f.BoolVar(&config.ForceDummyTokenizer, "force-dummy-tokenizer", config.ForceDummyTokenizer, "Force the use of dummy tokenizer even if a real model name is provided")
 
 	f.DurationVar(&config.StartupDuration, "startup-duration", config.StartupDuration,
 		"Duration to return 503 on /health/ready to simulate GPU loading (e.g. 30s). Default is 0 (immediately ready)")

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -2664,28 +2664,6 @@ var _ = Describe("Simulator", func() {
 				Expect(simulator.Context.Tokenizer).To(BeAssignableToTypeOf(&tokenizer.SimpleTokenizer{}))
 			})
 
-			It("should use dummy tokenizer for text completions when flag is set", func() {
-				ctx := context.TODO()
-				// Use a real model name but force dummy tokenizer
-				args := []string{"cmd", "--model", common.QwenModelName, "--mode", common.ModeEcho, "--force-dummy-tokenizer"}
-				simulator, _, _, err := startServerHandle(ctx, "", args, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Verify that the dummy tokenizer was actually created
-				Expect(simulator.Context.Tokenizer).To(BeAssignableToTypeOf(&tokenizer.SimpleTokenizer{}))
-			})
-
-			It("should use dummy tokenizer for streaming when flag is set", func() {
-				ctx := context.TODO()
-				// Use a real model name but force dummy tokenizer
-				args := []string{"cmd", "--model", common.QwenModelName, "--mode", common.ModeRandom, "--force-dummy-tokenizer"}
-				simulator, _, _, err := startServerHandle(ctx, "", args, nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Verify that the dummy tokenizer was actually created
-				Expect(simulator.Context.Tokenizer).To(BeAssignableToTypeOf(&tokenizer.SimpleTokenizer{}))
-			})
-
 			It("should work with YAML config file", func() {
 				ctx := context.TODO()
 				// Create a temporary config file with force-dummy-tokenizer set

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/dataset"
 	kvcache "github.com/llm-d/llm-d-inference-sim/pkg/kv-cache"
 	openaiserverapi "github.com/llm-d/llm-d-inference-sim/pkg/openai-server-api"
+	"github.com/llm-d/llm-d-inference-sim/pkg/tokenizer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openai/openai-go/v3"
@@ -2649,6 +2650,88 @@ var _ = Describe("Simulator", func() {
 			storedCount, removedCount, _ := kvcache.CountKVEventBlocks(msg.Frames, topic, 1)
 			Expect(storedCount).To(Equal(2))
 			Expect(removedCount).To(Equal(0))
+		})
+
+		Context("force-dummy-tokenizer flag", func() {
+			It("should use dummy tokenizer when flag is set with real model", func() {
+				ctx := context.TODO()
+				// Use a real model name but force dummy tokenizer
+				args := []string{"cmd", "--model", common.QwenModelName, "--mode", common.ModeRandom, "--force-dummy-tokenizer"}
+				simulator, _, _, err := startServerHandle(ctx, "", args, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify that the dummy tokenizer was actually created
+				Expect(simulator.Context.Tokenizer).To(BeAssignableToTypeOf(&tokenizer.SimpleTokenizer{}))
+			})
+
+			It("should use dummy tokenizer for text completions when flag is set", func() {
+				ctx := context.TODO()
+				// Use a real model name but force dummy tokenizer
+				args := []string{"cmd", "--model", common.QwenModelName, "--mode", common.ModeEcho, "--force-dummy-tokenizer"}
+				simulator, _, _, err := startServerHandle(ctx, "", args, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify that the dummy tokenizer was actually created
+				Expect(simulator.Context.Tokenizer).To(BeAssignableToTypeOf(&tokenizer.SimpleTokenizer{}))
+			})
+
+			It("should use dummy tokenizer for streaming when flag is set", func() {
+				ctx := context.TODO()
+				// Use a real model name but force dummy tokenizer
+				args := []string{"cmd", "--model", common.QwenModelName, "--mode", common.ModeRandom, "--force-dummy-tokenizer"}
+				simulator, _, _, err := startServerHandle(ctx, "", args, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify that the dummy tokenizer was actually created
+				Expect(simulator.Context.Tokenizer).To(BeAssignableToTypeOf(&tokenizer.SimpleTokenizer{}))
+			})
+
+			It("should work with YAML config file", func() {
+				ctx := context.TODO()
+				// Create a temporary config file with force-dummy-tokenizer set
+				configContent := `model: ` + common.QwenModelName + `
+mode: random
+force-dummy-tokenizer: true
+`
+				configFile := "/tmp/test-tokenizer-config.yaml"
+				err := writeTestConfig(configFile, configContent)
+				Expect(err).NotTo(HaveOccurred())
+				defer func() {
+					err := removeTestConfig(configFile)
+					Expect(err).NotTo(HaveOccurred())
+				}()
+
+				args := []string{"cmd", "--config", configFile}
+				simulator, _, _, err := startServerHandle(ctx, "", args, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify that the dummy tokenizer was actually created
+				Expect(simulator.Context.Tokenizer).To(BeAssignableToTypeOf(&tokenizer.SimpleTokenizer{}))
+			})
+
+			It("should override YAML config with command line flag", func() {
+				ctx := context.TODO()
+				// Create a config file with force-dummy-tokenizer set to false
+				configContent := `model: ` + common.QwenModelName + `
+mode: random
+force-dummy-tokenizer: false
+`
+				configFile := "/tmp/test-tokenizer-override-config.yaml"
+				err := writeTestConfig(configFile, configContent)
+				Expect(err).NotTo(HaveOccurred())
+				defer func() {
+					err := removeTestConfig(configFile)
+					Expect(err).NotTo(HaveOccurred())
+				}()
+
+				// Override with command line flag
+				args := []string{"cmd", "--config", configFile, "--force-dummy-tokenizer"}
+				simulator, _, _, err := startServerHandle(ctx, "", args, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify that the dummy tokenizer was actually created
+				Expect(simulator.Context.Tokenizer).To(BeAssignableToTypeOf(&tokenizer.SimpleTokenizer{}))
+			})
 		})
 	})
 })

--- a/pkg/tests/test_utils_test.go
+++ b/pkg/tests/test_utils_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/communication"
 	vllmsim "github.com/llm-d/llm-d-inference-sim/pkg/llm-d-inference-sim"
 	openaiserverapi "github.com/llm-d/llm-d-inference-sim/pkg/openai-server-api"
+	"github.com/llm-d/llm-d-inference-sim/pkg/tokenizer"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
@@ -129,12 +130,23 @@ func startServerHelper(ctx context.Context, mode string, args []string, envs map
 	}
 	s.Context.SetConfig(config)
 
-	gomega.Expect(config.Model).To(gomega.BeElementOf(common.TestModelName, common.QwenModelName, common.QwenModelName))
-	switch config.Model {
-	case common.TestModelName:
-		s.Context.Tokenizer = tokenizerMngr.TestTokenizer()
-	case common.QwenModelName:
-		s.Context.Tokenizer = tokenizerMngr.RealTokenizer()
+	// Initialize tokenizer based on configuration
+	if config.ForceDummyTokenizer {
+		// When force-dummy-tokenizer is set, create the tokenizer using tokenizer.New()
+		// which will respect the flag and create a SimpleTokenizer
+		s.Context.Tokenizer, err = tokenizer.New(ctx, config, logger)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	} else {
+		// Use test tokenizers for normal test cases
+		gomega.Expect(config.Model).To(gomega.BeElementOf(common.TestModelName, common.QwenModelName, common.QwenModelName))
+		switch config.Model {
+		case common.TestModelName:
+			s.Context.Tokenizer = tokenizerMngr.TestTokenizer()
+		case common.QwenModelName:
+			s.Context.Tokenizer = tokenizerMngr.RealTokenizer()
+		}
 	}
 
 	// calculate number of tokens for user message,
@@ -660,4 +672,14 @@ func getChatPromptTokensCountForTestModel(message string) int64 {
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	return int64(len(tokens))
+}
+
+// writeTestConfig writes a test configuration file
+func writeTestConfig(path string, content string) error {
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+// removeTestConfig removes a test configuration file
+func removeTestConfig(path string) error {
+	return os.Remove(path)
 }

--- a/pkg/tokenizer/test_utils.go
+++ b/pkg/tokenizer/test_utils.go
@@ -74,14 +74,15 @@ func (tm *TokenizerManager) Init(ctx context.Context, logger logr.Logger) error 
 	// renderURL := "http://localhost:8001/"
 	// var err error
 	// create tokenizer for Qwen model
-	tm.qwenTokenizer, err = tm.newTokenizer(ctx, logger, renderURL, common.QwenModelName, 10*time.Second, 30*time.Second)
+	// Use longer timeout (30s) for render requests as the container may need time to fully initialize
+	tm.qwenTokenizer, err = tm.newTokenizer(ctx, logger, renderURL, common.QwenModelName, 30*time.Second, 60*time.Second)
 	if err != nil {
 		cleanup()
 		return err
 	}
 
 	// create tokenizer for multimodal model
-	tm.mmTokenizer, err = tm.newTokenizer(ctx, logger, renderURL, common.QwenModelName, 10*time.Second, 30*time.Second)
+	tm.mmTokenizer, err = tm.newTokenizer(ctx, logger, renderURL, common.QwenModelName, 30*time.Second, 60*time.Second)
 	if err != nil {
 		cleanup()
 		return err

--- a/pkg/tokenizer/tokenizer.go
+++ b/pkg/tokenizer/tokenizer.go
@@ -50,9 +50,13 @@ func New(ctx context.Context, config *common.Configuration, logger logr.Logger) 
 	var err error
 	var tokenizer Tokenizer
 
-	if modelExists(config.Model) {
+	switch {
+	case config.ForceDummyTokenizer:
+		logger.Info("Force dummy tokenizer flag is set, using simulated tokenizer", "model", config.Model)
+		tokenizer = NewSimpleTokenizer()
+	case modelExists(config.Model):
 		tokenizer, err = NewHFTokenizer(ctx, logger, config.RenderURL, config.Model, config.RenderTimeout, config.MMRenderTimeout)
-	} else {
+	default:
 		logger.Info("Model is not a real HF model, using simulated tokenizer", "model", config.Model)
 		tokenizer = NewSimpleTokenizer()
 	}


### PR DESCRIPTION
Fixes #502 

Currently, the simulator automatically selects the tokenizer based on whether the model name exists on HuggingFace. This means users who want to use real model names for testing but avoid tokenizer loading overhead must use fake model names. This flag provides explicit control over tokenizer selection.

Changes:
- Added `ForceDummyTokenizer` field to `Configuration` struct
- Added `--force-dummy-tokenizer` command-line flag
- Updated tokenizer initialization logic to check flag before model existence
- Updated documentation in `docs/tokenization.md` and `docs/configuration.md`

Usage:
```bash
# Use dummy tokenizer with a real model name
./bin/llm-d-inference-sim --model meta-llama/Llama-3.1-8B-Instruct --force-dummy-tokenizer