### PR TITLE
Add support for request message content type 'output_text'

### DIFF
--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -704,7 +704,7 @@ func (c *InputContent) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	if raw.Type != "" && raw.Type != ResponsesInputText {
+	if raw.Type != "" && raw.Type != ResponsesInputText && raw.Type != ResponsesOutputText {
 		return fmt.Errorf("unsupported input content type %q", raw.Type)
 	}
 	c.Type = ResponsesInputText


### PR DESCRIPTION
This  content type is used in the /responses request in stateless mode (request contains the full conversation, including assistant responses with type 'output_text')