### PR TITLE
fix typos detected by nightly scan (#509)

### DIFF
--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -461,7 +461,7 @@ type baseTextCompletionsRequest struct {
 // TextCompletionsParsedRequest is the wire form of a /completions request.
 // On the wire `prompt` may be a single string or an array of strings; the
 // custom UnmarshalJSON below normalizes both forms into Prompt — a plain
-// string becomes a one-element slice. Used only between JSON unmarshaling
+// string becomes a one-element slice. Used only between JSON unmarshalling
 // and the simulator's split step; workers never see this type.
 type TextCompletionsParsedRequest struct {
 	baseTextCompletionsRequest

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -529,7 +529,7 @@ var _ = Describe("Simulator", func() {
 		Expect(oneBody.Choices[0].Index).To(BeEquivalentTo(0))
 		Expect(oneBody.Choices[0].Text).To(Equal(prompt1))
 
-		// Invalid prompt type (number) — must be rejected at JSON unmarshaling.
+		// Invalid prompt type (number) — must be rejected at JSON unmarshalling.
 		badResp := post(fmt.Sprintf(`{"model":%q,"prompt":123}`, common.TestModelName), "")
 		defer func() { Expect(badResp.Body.Close()).To(Succeed()) }()
 		Expect(badResp.StatusCode).To(Equal(400))


### PR DESCRIPTION
Fixes #509.

Changes `unmarshaling` to `unmarshalling` in two comments flagged by the nightly typo scan:

- `pkg/openai-server-api/request.go:464`
- `pkg/tests/simulator_test.go:532`

The repo already uses `unmarshalling` in `pkg/openai-server-api/tool_choice.go`, so this also makes the spelling consistent across the codebase. Comments only — no code or API changes.