### PR TITLE
feat: Add streaming support to /inference/v1/generate

### DIFF
--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -555,13 +555,30 @@ func (respBuilder *generateHTTPRespBuilder) createResponse(respCtxPerChoice []vl
 	return resp
 }
 
-func (respBuilder *generateHTTPRespBuilder) createUsageChunk(_ []vllmsim.ResponseContext) sseChunk {
-	return nil
+func (respBuilder *generateHTTPRespBuilder) createUsageChunk(respCtxPerChoice []vllmsim.ResponseContext) sseChunk {
+	respCtx := respCtxPerChoice[0]
+	if !respCtx.SendUsageData() {
+		return nil
+	}
+	return &jsonDataChunk{data: &openaiserverapi.GenerateStreamResponse{
+		RequestID: respCtx.RequestID(),
+		Choices:   []openaiserverapi.GenerateRespChoice{},
+		Usage:     aggregateUsage(respCtxPerChoice),
+	}}
 }
 
-func (respBuilder *generateHTTPRespBuilder) createChunk(_ vllmsim.ResponseContext,
-	_ *openaiserverapi.Tokenized, _ *openaiserverapi.ToolCall, _ string, _ *string, _ int) sseChunk {
-	return nil
+func (respBuilder *generateHTTPRespBuilder) createChunk(respCtx vllmsim.ResponseContext,
+	tokens *openaiserverapi.Tokenized, _ *openaiserverapi.ToolCall, _ string, finishReason *string, choiceIdx int) sseChunk {
+	choice := openaiserverapi.GenerateRespChoice{}
+	choice.Index = choiceIdx
+	choice.FinishReason = finishReason
+	if tokens != nil {
+		choice.TokenIDs = tokens.Tokens
+	}
+	return &jsonDataChunk{data: &openaiserverapi.GenerateStreamResponse{
+		RequestID: respCtx.RequestID(),
+		Choices:   []openaiserverapi.GenerateRespChoice{choice},
+	}}
 }
 
 func (respBuilder *generateHTTPRespBuilder) createInitialChunk(_ vllmsim.ResponseContext) sseChunk {
@@ -572,11 +589,14 @@ func (respBuilder *generateHTTPRespBuilder) createFirstChunk(_ vllmsim.ResponseC
 	return nil
 }
 
-func (respBuilder *generateHTTPRespBuilder) createLastChunk(_ vllmsim.ResponseContext, _ string, _ int) sseChunk {
-	return nil
+func (respBuilder *generateHTTPRespBuilder) createLastChunk(respCtx vllmsim.ResponseContext, finishReason string, choiceIdx int) sseChunk {
+	if finishReason != common.StopFinishReason {
+		return nil
+	}
+	return respBuilder.createChunk(respCtx, nil, nil, "", respCtx.FinishReason(), choiceIdx)
 }
 
-func (*generateHTTPRespBuilder) createDoneChunk() sseChunk { return nil }
+func (*generateHTTPRespBuilder) createDoneChunk() sseChunk { return &doneMarker{} }
 
 func (*generateHTTPRespBuilder) createRenderResponse(_ [][]uint32,
 	_ *openaiserverapi.RenderMMFeatures) any {

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -883,6 +883,11 @@ type GenerateRequest struct {
 	TokenIDs       []uint32          `json:"token_ids"`
 	SamplingParams *SamplingParams   `json:"sampling_params"`
 	Features       *EncodeMMFeatures `json:"features"`
+	StreamOptions  *StreamOptions    `json:"stream_options,omitempty"`
+}
+
+func (g *GenerateRequest) IncludeUsage() bool {
+	return !g.Stream || (g.StreamOptions != nil && g.StreamOptions.IncludeUsage)
 }
 
 type SamplingParams struct {

--- a/pkg/openai-server-api/response.go
+++ b/pkg/openai-server-api/response.go
@@ -545,6 +545,12 @@ type GenerateRespChoice struct {
 	TokenIDs []uint32 `json:"token_ids"`
 }
 
+type GenerateStreamResponse struct {
+	RequestID string               `json:"request_id"`
+	Choices   []GenerateRespChoice `json:"choices"`
+	Usage     *Usage               `json:"usage,omitempty"`
+}
+
 type ECTransferParams struct {
 	PeerHost      string `json:"peer_host"`
 	PeerPort      int    `json:"peer_port"`

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -44,6 +44,7 @@ import (
 
 const prompt1 = "What is the weather like in New York today?"
 const prompt2 = "I hear it's very cold."
+const sseDoneMarker = "[DONE]"
 
 var _ = Describe("Simulator", func() {
 
@@ -1897,7 +1898,7 @@ var _ = Describe("Simulator", func() {
 
 				if strings.HasPrefix(line, "data: ") {
 					data := strings.TrimPrefix(line, "data: ")
-					if strings.TrimSpace(data) == "[DONE]" {
+					if strings.TrimSpace(data) == sseDoneMarker {
 						break
 					}
 
@@ -2580,6 +2581,144 @@ var _ = Describe("Simulator", func() {
 			Expect(generateResp.KVParams.RemotePort).To(BeNumerically(">", 0))
 			Expect(generateResp.KVParams.RemoteBlockIds).NotTo(BeEmpty())
 			Expect(generateResp.KVParams.RemoteEngineId).NotTo(BeEmpty())
+		})
+
+		It("Should stream SSE chunks for /inference/v1/generate with stream=true", func() {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			reqBody := fmt.Sprintf(`{
+				"model": "%s",
+				"token_ids": [1, 2, 3, 4],
+				"sampling_params": {"max_tokens": 5},
+				"stream": true
+			}`, common.TestModelName)
+
+			resp, err := client.Post("http://localhost/inference/v1/generate", "application/json", strings.NewReader(reqBody))
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := resp.Body.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Header.Get("Content-Type")).To(Equal("text/event-stream"))
+
+			reader := bufio.NewReader(resp.Body)
+			var tokenChunks []openaiserverapi.GenerateStreamResponse
+			var finishChunk *openaiserverapi.GenerateStreamResponse
+			var usageChunk *openaiserverapi.GenerateStreamResponse
+			gotDone := false
+
+			for {
+				line, err := reader.ReadString('\n')
+				if err == io.EOF {
+					break
+				}
+				Expect(err).NotTo(HaveOccurred())
+
+				if !strings.HasPrefix(line, "data: ") {
+					continue
+				}
+				data := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+				if data == sseDoneMarker {
+					gotDone = true
+					break
+				}
+
+				var streamResp openaiserverapi.GenerateStreamResponse
+				Expect(json.Unmarshal([]byte(data), &streamResp)).To(Succeed(), "failed to parse SSE chunk: %s", data)
+				if len(streamResp.Choices) == 0 {
+					Expect(streamResp.Usage).NotTo(BeNil(), "empty choices chunk must carry usage")
+					usageChunk = &streamResp
+					continue
+				}
+				choice := streamResp.Choices[0]
+				if choice.TokenIDs != nil {
+					tokenChunks = append(tokenChunks, streamResp)
+				}
+				if choice.FinishReason != nil {
+					finishChunk = &streamResp
+				}
+			}
+
+			Expect(tokenChunks).NotTo(BeEmpty(), "should have received at least one streaming chunk with token_ids")
+			for _, tc := range tokenChunks {
+				Expect(tc.RequestID).NotTo(BeEmpty())
+				Expect(tc.Choices[0].TokenIDs).NotTo(BeEmpty())
+			}
+
+			Expect(finishChunk).NotTo(BeNil(), "should have received a chunk with finish_reason")
+			Expect(finishChunk.RequestID).NotTo(BeEmpty())
+			Expect(*finishChunk.Choices[0].FinishReason).NotTo(BeEmpty())
+			Expect(finishChunk.Usage).To(BeNil(), "finish chunk should not carry usage")
+
+			Expect(usageChunk).To(BeNil(), "should not receive usage chunk without stream_options.include_usage")
+
+			Expect(gotDone).To(BeTrue(), "stream should end with [DONE]")
+		})
+
+		It("Should include usage chunk when stream_options.include_usage is true", func() {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			reqBody := fmt.Sprintf(`{
+				"model": "%s",
+				"token_ids": [1, 2, 3, 4],
+				"sampling_params": {"max_tokens": 5},
+				"stream": true,
+				"stream_options": {"include_usage": true}
+			}`, common.TestModelName)
+
+			resp, err := client.Post("http://localhost/inference/v1/generate", "application/json", strings.NewReader(reqBody))
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := resp.Body.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			reader := bufio.NewReader(resp.Body)
+			var usageChunk *openaiserverapi.GenerateStreamResponse
+			gotDone := false
+
+			for {
+				line, err := reader.ReadString('\n')
+				if err == io.EOF {
+					break
+				}
+				Expect(err).NotTo(HaveOccurred())
+
+				if !strings.HasPrefix(line, "data: ") {
+					continue
+				}
+				data := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+				if data == sseDoneMarker {
+					gotDone = true
+					break
+				}
+
+				var streamResp openaiserverapi.GenerateStreamResponse
+				Expect(json.Unmarshal([]byte(data), &streamResp)).To(Succeed(), "failed to parse SSE chunk: %s", data)
+				if len(streamResp.Choices) == 0 {
+					Expect(streamResp.Usage).NotTo(BeNil(), "empty choices chunk must carry usage")
+					usageChunk = &streamResp
+					continue
+				}
+			}
+
+			Expect(usageChunk).NotTo(BeNil(), "should have received a usage chunk with choices:[]")
+			Expect(usageChunk.Choices).To(BeEmpty(), "usage chunk should have empty choices")
+			Expect(usageChunk.Usage).NotTo(BeNil())
+			Expect(usageChunk.Usage.PromptTokens).To(BeNumerically(">", 0))
+			Expect(usageChunk.Usage.CompletionTokens).To(BeNumerically(">", 0))
+
+			Expect(gotDone).To(BeTrue(), "stream should end with [DONE]")
 		})
 	})
 


### PR DESCRIPTION
### Fixes #495

- Implement HTTP streaming (SSE) for `/inference/v1/generate` by filling in the previously stubbed `generateHTTPRespBuilder` methods. 
- The wire format mirrors the existing gRPC `GenerateStreamChunk`/`GenerateComplete` protobuf definitions.
- Includes streaming tests.

## Manual test results

Ran the simulator locally (`--model testmodel --mode random --port 8199`) and tested with curl.

### 1. `stream=true` (default, no `stream_options`)

```bash
curl -s -N http://localhost:8199/inference/v1/generate   -H "Content-Type: application/json"   -d '{"model":"testmodel","token_ids":[1,2,3,4],"sampling_params":{"max_tokens":5},"stream":true}'
```

```
data: {"request_id":"66661eae-c18b-548e-8366-3f5065e7e448","choices":[{"index":0,"finish_reason":null,"token_ids":[2062099468]}]}

data: {"request_id":"66661eae-c18b-548e-8366-3f5065e7e448","choices":[{"index":0,"finish_reason":"stop"}]}

data: [DONE]
```

### 2. `stream=true` with `stream_options.include_usage=true`

```bash
curl -s -N http://localhost:8199/inference/v1/generate   -H "Content-Type: application/json"   -d '{"model":"testmodel","token_ids":[1,2,3,4],"sampling_params":{"max_tokens":5},"stream":true,"stream_options":{"include_usage":true}}'
```

```
data: {"request_id":"21ec7e10-484a-57d3-8104-088b5aa3d980","choices":[{"index":0,"finish_reason":null,"token_ids":[966508396]}]}

data: {"request_id":"21ec7e10-484a-57d3-8104-088b5aa3d980","choices":[{"index":0,"finish_reason":null,"token_ids":[212720608]}]}

data: {"request_id":"21ec7e10-484a-57d3-8104-088b5aa3d980","choices":[{"index":0,"finish_reason":null,"token_ids":[1285136286]}]}

data: {"request_id":"21ec7e10-484a-57d3-8104-088b5aa3d980","choices":[{"index":0,"finish_reason":null,"token_ids":[1460690508]}]}

data: {"request_id":"21ec7e10-484a-57d3-8104-088b5aa3d980","choices":[{"index":0,"finish_reason":null,"token_ids":[1562217772]}]}

data: {"request_id":"21ec7e10-484a-57d3-8104-088b5aa3d980","choices":[{"index":0,"finish_reason":"length"}]}

data: {"request_id":"21ec7e10-484a-57d3-8104-088b5aa3d980","choices":[],"usage":{"prompt_tokens":4,"completion_tokens":5,"total_tokens":9,"prompt_tokens_detail":{"cached_tokens":0}}}

data: [DONE]
```
