### PR TITLE
fix: implement MarshalJSON for `FakeMetricWithFunction` — restore `Configuration.Copy` round-trip

### DIFF
--- a/pkg/common/config_fake_metrics.go
+++ b/pkg/common/config_fake_metrics.go
@@ -182,6 +182,26 @@ func (f *FakeMetricWithFunction) UnmarshalJSON(data []byte) error {
 	return f.parseFunction(s)
 }
 
+// MarshalJSON mirrors UnmarshalJSON so that round-tripping (used by
+// Configuration.Copy) produces an output the unmarshaller can read back.
+// Without this, the default marshaller serializes the struct as a JSON object
+// (FixedValue/Function/IsFunction) which UnmarshalJSON rejects.
+func (f FakeMetricWithFunction) MarshalJSON() ([]byte, error) {
+	if !f.IsFunction {
+		return json.Marshal(f.FixedValue)
+	}
+	if f.Function == nil {
+		return nil, errors.New("FakeMetricWithFunction marked as function but Function is nil")
+	}
+	encoded := fmt.Sprintf("%s:%s:%s:%s",
+		f.Function.Name,
+		strconv.FormatFloat(f.Function.Start, 'g', -1, 64),
+		strconv.FormatFloat(f.Function.End, 'g', -1, 64),
+		f.Function.Period,
+	)
+	return json.Marshal(encoded)
+}
+
 type LorasMetrics struct {
 	// RunningLoras is a comma separated list of running LoRAs
 	RunningLoras string `json:"running"`

--- a/pkg/common/config_fake_metrics.go
+++ b/pkg/common/config_fake_metrics.go
@@ -197,7 +197,7 @@ func (f FakeMetricWithFunction) MarshalJSON() ([]byte, error) {
 		f.Function.Name,
 		strconv.FormatFloat(f.Function.Start, 'g', -1, 64),
 		strconv.FormatFloat(f.Function.End, 'g', -1, 64),
-		f.Function.Period,
+		f.Function.Period.String(),
 	)
 	return json.Marshal(encoded)
 }

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -768,3 +768,59 @@ var _ = Describe("PYTHONHASHSEED environment variable", func() {
 		Expect(config.HashSeed).To(Equal("env-seed"))
 	})
 })
+
+// Configuration.Copy uses a json.Marshal+Unmarshal round-trip to deep-copy the
+// configuration. FakeMetricWithFunction defines a custom UnmarshalJSON that
+// only accepts a JSON number or string, so MarshalJSON must produce the same
+// shape — otherwise the round-trip cannot reproduce its own output, which
+// breaks Copy for any non-nil FakeMetrics (the data-parallel path in
+// simulator.New calls Copy once per rank > 0).
+var _ = Describe("Configuration.Copy", func() {
+	It("should round-trip a non-nil FakeMetrics with a fixed-value metric", func() {
+		c := &Configuration{
+			FakeMetrics: &FakeMetrics{
+				RunningRequests: FakeMetricWithFunction{FixedValue: 5},
+			},
+		}
+
+		got, err := c.Copy()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.FakeMetrics).NotTo(BeNil())
+		Expect(got.FakeMetrics.RunningRequests.IsFunction).To(BeFalse())
+		Expect(got.FakeMetrics.RunningRequests.FixedValue).To(Equal(5.0))
+	})
+
+	It("should round-trip a non-nil FakeMetrics with a function-valued metric", func() {
+		c := &Configuration{
+			FakeMetrics: &FakeMetrics{
+				WaitingRequests: FakeMetricWithFunction{
+					IsFunction: true,
+					Function: &FunctionInfo{
+						Name:   OscillateFuncName,
+						Start:  0,
+						End:    10,
+						Period: 5 * time.Second,
+					},
+				},
+			},
+		}
+
+		got, err := c.Copy()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.FakeMetrics).NotTo(BeNil())
+		Expect(got.FakeMetrics.WaitingRequests.IsFunction).To(BeTrue())
+		Expect(got.FakeMetrics.WaitingRequests.Function).NotTo(BeNil())
+		Expect(got.FakeMetrics.WaitingRequests.Function.Name).To(Equal(OscillateFuncName))
+		Expect(got.FakeMetrics.WaitingRequests.Function.Start).To(Equal(0.0))
+		Expect(got.FakeMetrics.WaitingRequests.Function.End).To(Equal(10.0))
+		Expect(got.FakeMetrics.WaitingRequests.Function.Period).To(Equal(5 * time.Second))
+	})
+
+	It("should round-trip an empty (zero-value) FakeMetrics", func() {
+		c := &Configuration{FakeMetrics: &FakeMetrics{}}
+
+		got, err := c.Copy()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.FakeMetrics).NotTo(BeNil())
+	})
+})


### PR DESCRIPTION
## Summary

`FakeMetricWithFunction` defines a custom `UnmarshalJSON` but no matching `MarshalJSON`, leaving JSON marshal/unmarshal round-tripping asymmetric. As a result, starting the simulator with `--fake-metrics` and `--data-parallel-size > 1` fails.

This PR adds a `MarshalJSON` that mirrors `UnmarshalJSON`, and adds regression tests for `Configuration.Copy`.

## Problem

### Symptom

Starting the simulator with `--fake-metrics` and `--data-parallel-size > 1` fails with the error below (this also happens when `--fake-metrics` is just `'{}'`):

```
json: cannot unmarshal object into Go struct field
      FakeMetrics.fake-metrics.running-requests of type string
```

### Root cause

1. `FakeMetricWithFunction` defines `UnmarshalJSON`, which only accepts two input forms:
   - a JSON number — the fixed value (`FixedValue`)
   - a JSON string of the form `"name:start:end:period"` — a function-valued metric
2. However, no `MarshalJSON` is defined. The default marshaller therefore serializes the struct as a plain object:
   ```json
   { "FixedValue": 0, "Function": null, "IsFunction": false }
   ```
3. `Configuration.Copy` implements deep-copy via a `json.Marshal` → `json.Unmarshal` round-trip. `UnmarshalJSON` rejects the object form above, so the round-trip breaks.
4. `simulator.New` calls `Configuration.Copy` once per rank when `--data-parallel-size > 1`. Consequently, the data-parallel path is broken whenever `FakeMetrics` is non-nil — and `--fake-metrics "{}"` is enough to produce a non-nil zero-value struct that fails the same way.

In short: the type cannot read back the JSON it produces.

## Fix

Add a `MarshalJSON` that mirrors `UnmarshalJSON`:

- `IsFunction == false` → serialize `FixedValue` as a JSON number
- `IsFunction == true` → serialize as a `"name:start:end:period"` JSON string
- `IsFunction == true` but `Function == nil` (invalid state) → return an explicit error

With this, the round-trip is symmetric and `Configuration.Copy` works correctly regardless of whether `FakeMetrics` is set.

## Files changed

- `pkg/common/config_fake_metrics.go` — add `MarshalJSON` (+20)
- `pkg/common/config_test.go` — add 3 `Configuration.Copy` round-trip regression tests (+56)

## Reproduction

Before this patch, both invocations below fail with the same error:

```bash
./llm-d-inference-sim --model some-model --data-parallel-size 2 --fake-metrics '{}'
./llm-d-inference-sim --model some-model --data-parallel-size 2 \
  --fake-metrics '{"running-requests": 5}'
```

After this patch, both start up cleanly.

## Test plan

### Unit tests

The new unit tests cover the three round-trip scenarios:

- [x] Fixed-value metric (`FixedValue: 5`) survives `Copy` with `IsFunction`/value preserved
- [x] Function-valued metric (`Oscillate`, with start/end/period) survives `Copy` with all fields preserved
- [x] Zero-value `FakeMetrics{}` (non-nil but all fields zero) round-trips successfully

Run:

```bash
go test ./pkg/common/... -ginkgo.focus="Configuration.Copy"
# => Ran 3 of 88 Specs — 3 Passed | 0 Failed
```

**Negative control:** removing only `MarshalJSON` from `pkg/common/config_fake_metrics.go` and re-running the same tests causes all three to fail with the exact error this PR fixes:

```
json: cannot unmarshal object into Go struct field
      FakeMetrics.fake-metrics.running-requests of type string
```

So the regression tests actually catch the bug this PR resolves.

### Manual verification

All three scenarios were exercised end-to-end with `--data-parallel-size 2`, checking `/metrics` on both ranks:

- [x] `--fake-metrics '{}'` — both ranks start cleanly on `:18001`/`:18002`, no JSON errors
- [x] `--fake-metrics '{"running-requests": 5}'` — both ranks expose `vllm:num_requests_running{model_name="some-model"} 5`
- [x] `--fake-metrics '{"waiting-requests": "oscillate:0:10:5s"}'` — both ranks expose `vllm:num_requests_waiting` oscillating in `[0, 10]` (sampled `9` at t=0, `2` at t=2s)

## Impact

- **Bug-only fix.** Code paths that don't invoke `MarshalJSON` are unaffected.
- **API-compatible.** The serialization output matches the input form users already provide via `--fake-metrics` (a number, or a `"name:start:end:period"` string), so any external code reading the serialized form sees the same shape as the input form.
- **Regression-tested.** The added tests guard against this asymmetry regressing in the future.
