### PR TITLE
docs: fix README docker run example for vLLM render server

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ To run the vLLM simulator in a standalone test environment with a real model:
 
 1. Start the vLLM render server (requires a container engine, e.g. Docker or Podman):
    ```bash
-   docker run --rm -p 8082:8082 vllm/vllm-openai-cpu:v0.19.1 \
-     --entrypoint vllm launch render Qwen/Qwen2.5-0.5B-Instruct --port=8082
+   docker run --rm -p 8082:8082 --entrypoint vllm \
+     vllm/vllm-openai-cpu:v0.19.1 launch render Qwen/Qwen2.5-0.5B-Instruct --port=8082
    ```
    Alternatively, use the `run-render` Makefile target, which runs the same container via your configured container engine (Docker or Podman):
    ```bash


### PR DESCRIPTION
fixes: https://github.com/llm-d/llm-d-inference-sim/issues/533

Update the README to move `--entrypoint` before the image name so the docker run example is valid for Docker/Podman.