### PR TITLE
pkg: add n parameter for multiple completion choices

### DIFF
--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -83,21 +83,40 @@ type responseBuilder interface {
 	createRenderResponse(tokens [][]uint32, features *openaiserverapi.RenderMMFeatures) any
 }
 
-// aggregateUsage sums the per-choice usages. Callers must ensure every slot is
-// populated — by the time we reach here, every non-error response has carried
-// a non-nil RespCtx, so any nil slot is a bug and a nil deref here is the
-// right signal.
+// aggregateUsage combines per-choice usages. Completion tokens are always
+// summed across all choices. For prompt tokens, the aggregation depends on
+// whether choices share the same prompt (n parameter — same request ID) or
+// have different prompts (array-prompt text completions — different request
+// IDs). When all choices share the same request ID, prompt tokens are counted
+// once; otherwise they are summed.
+// Callers must ensure every slot is populated — by the time we reach here, every
+// non-error response has carried a non-nil RespCtx, so any nil slot is a bug and
+// a nil deref here is the right signal.
 func aggregateUsage(respCtxPerChoice []vllmsim.ResponseContext) *openaiserverapi.Usage {
 	if len(respCtxPerChoice) == 1 {
 		return respCtxPerChoice[0].UsageData()
 	}
 	agg := &openaiserverapi.Usage{}
+	firstID := respCtxPerChoice[0].RequestID()
+	allSameRequest := true
 	for _, rc := range respCtxPerChoice {
 		u := rc.UsageData()
-		agg.PromptTokens += u.PromptTokens
 		agg.CompletionTokens += u.CompletionTokens
-		agg.TotalTokens += u.TotalTokens
+		if rc.RequestID() != firstID {
+			allSameRequest = false
+		}
 	}
+	if allSameRequest {
+		// All choices share the same prompt (n parameter): count prompt tokens once.
+		agg.PromptTokens = respCtxPerChoice[0].UsageData().PromptTokens
+		agg.PromptTokensDetail = respCtxPerChoice[0].UsageData().PromptTokensDetail
+	} else {
+		// Different prompts (array-prompt text completions): sum prompt tokens.
+		for _, rc := range respCtxPerChoice {
+			agg.PromptTokens += rc.UsageData().PromptTokens
+		}
+	}
+	agg.TotalTokens = agg.PromptTokens + agg.CompletionTokens
 	return agg
 }
 
@@ -213,35 +232,35 @@ func (respBuilder *chatComplHTTPRespBuilder) createResponse(respCtxPerChoice []v
 	tokens []openaiserverapi.Tokenized) any {
 	respCtx := respCtxPerChoice[0]
 	baseResp := openaiserverapi.CreateBaseCompletionsResponse(
-		time.Now().Unix(), respCtx.DisplayModel(), respCtx.UsageData(), respCtx.RequestID(), respCtx.DoRemoteDecode())
-	baseChoice := openaiserverapi.CreateBaseResponseChoice(0, respCtx.FinishReason())
+		time.Now().Unix(), respCtx.DisplayModel(), aggregateUsage(respCtxPerChoice), respCtx.RequestID(), respCtx.DoRemoteDecode())
 	baseResp.Object = openaiserverapi.ChatCompletionObject
 
-	message := openaiserverapi.Message{Role: openaiserverapi.RoleAssistant}
-	if respCtx.ToolCalls() != nil {
-		message.ToolCalls = respCtx.ToolCalls()
-	} else {
-		respText := strings.Join(tokens[0].Strings, "")
-		message.Content = openaiserverapi.ChatComplContent{Raw: respText}
-	}
+	choices := make([]openaiserverapi.ChatRespChoice, len(tokens))
+	for i, t := range tokens {
+		choiceCtx := respCtxPerChoice[i]
+		baseChoice := openaiserverapi.CreateBaseResponseChoice(i, choiceCtx.FinishReason())
 
-	choice := openaiserverapi.CreateChatRespChoice(baseChoice, message)
-
-	// Generate logprobs if requested
-	if respCtx.Logprobs() != nil && respCtx.ToolCalls() == nil {
-		if logprobsData := common.GenerateChatLogprobs(tokens[0].Strings, *respCtx.Logprobs()); logprobsData != nil &&
-			len(logprobsData.Content) > 0 {
-			choice.Logprobs = logprobsData
+		message := openaiserverapi.Message{Role: openaiserverapi.RoleAssistant}
+		if choiceCtx.ToolCalls() != nil {
+			message.ToolCalls = choiceCtx.ToolCalls()
 		} else {
-			// Set to nil if generation failed or content is empty
-			choice.Logprobs = nil
+			respText := strings.Join(t.Strings, "")
+			message.Content = openaiserverapi.ChatComplContent{Raw: respText}
 		}
-	} else {
-		// Explicitly ensure logprobs is nil when not requested
-		choice.Logprobs = nil
+
+		choice := openaiserverapi.CreateChatRespChoice(baseChoice, message)
+
+		// Generate logprobs if requested
+		if choiceCtx.Logprobs() != nil && choiceCtx.ToolCalls() == nil {
+			if logprobsData := common.GenerateChatLogprobs(t.Strings, *choiceCtx.Logprobs()); logprobsData != nil &&
+				len(logprobsData.Content) > 0 {
+				choice.Logprobs = logprobsData
+			}
+		}
+		choices[i] = choice
 	}
 
-	resp := openaiserverapi.CreateChatCompletionsResponse(baseResp, []openaiserverapi.ChatRespChoice{choice})
+	resp := openaiserverapi.CreateChatCompletionsResponse(baseResp, choices)
 	resp.ECTransferParams = respCtx.ECTransferParams()
 	return resp
 }

--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -97,23 +97,22 @@ func aggregateUsage(respCtxPerChoice []vllmsim.ResponseContext) *openaiserverapi
 		return respCtxPerChoice[0].UsageData()
 	}
 	agg := &openaiserverapi.Usage{}
-	firstID := respCtxPerChoice[0].RequestID()
-	allSameRequest := true
+	// Track which request IDs we've already counted prompt tokens for.
+	// With the n parameter, multiple choices share the same request ID and
+	// prompt tokens should be counted once per unique ID. With array-prompt
+	// text completions each prompt has a distinct ID, so prompt tokens are
+	// summed across prompts. This handles the combined case (array + n)
+	// correctly: prompt tokens are counted once per prompt, not once per choice.
+	seenIDs := make(map[string]bool)
 	for _, rc := range respCtxPerChoice {
 		u := rc.UsageData()
 		agg.CompletionTokens += u.CompletionTokens
-		if rc.RequestID() != firstID {
-			allSameRequest = false
-		}
-	}
-	if allSameRequest {
-		// All choices share the same prompt (n parameter): count prompt tokens once.
-		agg.PromptTokens = respCtxPerChoice[0].UsageData().PromptTokens
-		agg.PromptTokensDetail = respCtxPerChoice[0].UsageData().PromptTokensDetail
-	} else {
-		// Different prompts (array-prompt text completions): sum prompt tokens.
-		for _, rc := range respCtxPerChoice {
-			agg.PromptTokens += rc.UsageData().PromptTokens
+		if !seenIDs[rc.RequestID()] {
+			seenIDs[rc.RequestID()] = true
+			agg.PromptTokens += u.PromptTokens
+			if u.PromptTokensDetail != nil && agg.PromptTokensDetail == nil {
+				agg.PromptTokensDetail = u.PromptTokensDetail
+			}
 		}
 	}
 	agg.TotalTokens = agg.PromptTokens + agg.CompletionTokens

--- a/pkg/llm-d-inference-sim/chat_completion.go
+++ b/pkg/llm-d-inference-sim/chat_completion.go
@@ -126,9 +126,17 @@ func (c *chatCompletionReqCtx) tokenizedPromptForEcho() (*openaiserverapi.Tokeni
 	return &openaiserverapi.Tokenized{Tokens: tokens, Strings: strTokens}, nil
 }
 
-// split is a no-op: chat completions always carry a single prompt.
+// split returns n copies of this request, one per completion choice. Each
+// sub-request shares the same underlying ChatCompletionsRequest so tokenization
+// and prompt data are computed once and reused. When n==1 (the default) this
+// degenerates to the original single-element slice.
 func (c *ChatCompletionsRequest) split() []Request {
-	return []Request{c}
+	n := c.GetN()
+	out := make([]Request, n)
+	for i := range n {
+		out[i] = c
+	}
+	return out
 }
 
 var _ Request = (*ChatCompletionsRequest)(nil)

--- a/pkg/llm-d-inference-sim/chat_completion.go
+++ b/pkg/llm-d-inference-sim/chat_completion.go
@@ -134,7 +134,8 @@ func (c *ChatCompletionsRequest) split() []Request {
 	n := c.GetN()
 	out := make([]Request, n)
 	for i := range n {
-		out[i] = c
+		cp := *c
+		out[i] = &cp
 	}
 	return out
 }

--- a/pkg/llm-d-inference-sim/text_completion.go
+++ b/pkg/llm-d-inference-sim/text_completion.go
@@ -96,11 +96,16 @@ func (t *TextCompletionsParsedRequest) AsString() string {
 
 // split converts the parsed wire form into one or more processing-form
 // TextCompletionsRequest values. Each sub-request gets the parent envelope and
-// a "<requestID>-<i>" id stamped by openaiserverapi.AsSingle.
+// a "<requestID>-<i>" id stamped by openaiserverapi.AsSingle. When n > 1 each
+// prompt produces n sub-requests, so the total is len(Prompt) * n.
 func (t *TextCompletionsParsedRequest) split() []Request {
-	out := make([]Request, len(t.Prompt))
+	n := t.GetN()
+	out := make([]Request, 0, len(t.Prompt)*n)
 	for i := range t.Prompt {
-		out[i] = &TextCompletionsRequest{TextCompletionsRequest: t.AsSingle(i)}
+		single := &TextCompletionsRequest{TextCompletionsRequest: t.AsSingle(i)}
+		for range n {
+			out = append(out, single)
+		}
 	}
 	return out
 }
@@ -146,9 +151,16 @@ func (t *TextCompletionsRequest) buildRequestContext(simCtx *SimContext, channel
 	return reqCtx
 }
 
-// split is a no-op: TextCompletionsRequest is already the single-prompt form.
+// split returns n copies of this request, one per completion choice. Each
+// sub-request shares the same underlying TextCompletionsRequest. When n==1
+// (the default) this degenerates to the original single-element slice.
 func (t *TextCompletionsRequest) split() []Request {
-	return []Request{t}
+	n := t.GetN()
+	out := make([]Request, n)
+	for i := range n {
+		out[i] = t
+	}
+	return out
 }
 
 func (t *TextCompletionsRequest) AsString() string {

--- a/pkg/llm-d-inference-sim/text_completion.go
+++ b/pkg/llm-d-inference-sim/text_completion.go
@@ -102,9 +102,8 @@ func (t *TextCompletionsParsedRequest) split() []Request {
 	n := t.GetN()
 	out := make([]Request, 0, len(t.Prompt)*n)
 	for i := range t.Prompt {
-		single := &TextCompletionsRequest{TextCompletionsRequest: t.AsSingle(i)}
 		for range n {
-			out = append(out, single)
+			out = append(out, &TextCompletionsRequest{TextCompletionsRequest: t.AsSingle(i)})
 		}
 	}
 	return out
@@ -158,7 +157,8 @@ func (t *TextCompletionsRequest) split() []Request {
 	n := t.GetN()
 	out := make([]Request, n)
 	for i := range n {
-		out[i] = t
+		cp := *t
+		out[i] = &cp
 	}
 	return out
 }

--- a/pkg/llm-d-inference-sim/worker.go
+++ b/pkg/llm-d-inference-sim/worker.go
@@ -76,9 +76,8 @@ func (s *VllmSimulator) processRequest(reqCtx requestContext) {
 
 	common.WriteToChannel(s.Context.metrics.requestSuccessChan,
 		requestSuccessEvent{
-			promptTokens:     respCtx.UsageData().PromptTokens,
-			generationTokens: respCtx.UsageData().CompletionTokens,
-			// currently only responses with a single choice are supported
+			promptTokens:       respCtx.UsageData().PromptTokens,
+			generationTokens:   respCtx.UsageData().CompletionTokens,
 			genTokensPerChoice: []int{respCtx.UsageData().CompletionTokens},
 			maxTokens:          req.GetMaxCompletionTokens(),
 			finishReason:       *respCtx.FinishReason()},

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -86,6 +86,8 @@ type Request interface {
 	ExtractMaxTokens() *int64
 	// GetLogprobs returns nil if no logprobs needed, or pointer to number of logprob options to include
 	GetLogprobs() *int
+	// GetN returns the number of completion choices to generate, defaulting to 1
+	GetN() int
 	// GetCacheHitThreshold returns the cache hit threshold (0-1) or nil if not set
 	GetCacheHitThreshold() *float64
 	// TokenizedPrompt returns the tokenized prompt
@@ -149,6 +151,9 @@ type baseCompletionsRequest struct {
 	// cacheThresholdFinishReason is a boolean value extracted from the request's HTTP header,
 	//  when true, forces a cache_threshold finish reason
 	cacheThresholdFinishReason bool
+	// N is the number of completion choices to generate for each prompt.
+	// Optional and defaults to 1.
+	N *int `json:"n,omitempty"`
 }
 
 type KVTransferParams struct {
@@ -284,6 +289,11 @@ func (b *baseRequest) GetIgnoreEOS() bool {
 	return b.IgnoreEOS
 }
 
+// GetN returns 1 for non-completions requests that don't support the n parameter.
+func (b *baseRequest) GetN() int {
+	return 1
+}
+
 // SetIgnoreEOS sets the value of IgnoreEOS
 func (b *baseRequest) SetIgnoreEOS(ignorEOS bool) {
 	b.IgnoreEOS = ignorEOS
@@ -342,6 +352,14 @@ func (b *baseRequest) SetMMFeatures(mmFeatures *RenderMMFeatures) {
 
 func (b *baseCompletionsRequest) IncludeUsage() bool {
 	return !b.Stream || (b.StreamOptions != nil && b.StreamOptions.IncludeUsage)
+}
+
+// GetN returns the number of completion choices to generate, defaulting to 1.
+func (b *baseCompletionsRequest) GetN() int {
+	if b.N == nil || *b.N <= 0 {
+		return 1
+	}
+	return *b.N
 }
 
 // GetCacheHitThreshold returns the cache hit threshold value

--- a/pkg/openai-server-api/request_test.go
+++ b/pkg/openai-server-api/request_test.go
@@ -55,6 +55,55 @@ var _ = Describe("render requests", func() {
 	})
 })
 
+var _ = Describe("GetN", func() {
+	It("returns 1 when N is nil", func() {
+		req := &baseCompletionsRequest{}
+		Expect(req.GetN()).To(Equal(1))
+	})
+
+	It("returns 1 when N is zero", func() {
+		n := 0
+		req := &baseCompletionsRequest{N: &n}
+		Expect(req.GetN()).To(Equal(1))
+	})
+
+	It("returns 1 when N is negative", func() {
+		n := -5
+		req := &baseCompletionsRequest{N: &n}
+		Expect(req.GetN()).To(Equal(1))
+	})
+
+	It("returns the value when N is positive", func() {
+		n := 3
+		req := &baseCompletionsRequest{N: &n}
+		Expect(req.GetN()).To(Equal(3))
+	})
+
+	It("unmarshals n from JSON", func() {
+		jsonData := []byte(`{"n": 5, "prompt": "test"}`)
+		var req TextCompletionsParsedRequest
+		err := json.Unmarshal(jsonData, &req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.GetN()).To(Equal(5))
+	})
+
+	It("unmarshals n from chat completions JSON", func() {
+		jsonData := []byte(`{"n": 3, "model": "test", "messages": [{"role": "user", "content": "hi"}]}`)
+		var req ChatCompletionsRequest
+		err := json.Unmarshal(jsonData, &req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.GetN()).To(Equal(3))
+	})
+
+	It("defaults to 1 when n is absent from JSON", func() {
+		jsonData := []byte(`{"model": "test", "messages": [{"role": "user", "content": "hi"}]}`)
+		var req ChatCompletionsRequest
+		err := json.Unmarshal(jsonData, &req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.GetN()).To(Equal(1))
+	})
+})
+
 var _ = Describe("TextCompletionsParsedRequest prompt", func() {
 	Context("UnmarshalJSON", func() {
 		It("should unmarshal a string prompt as a one-element slice", func() {

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -517,6 +517,60 @@ var _ = Describe("Simulator", func() {
 		Entry(nil, common.ModeEcho, 3),
 	)
 
+	It("text completions with array prompt and n parameter", func() {
+		ctx := context.TODO()
+		args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeEcho, "--max-num-seqs", "10"}
+		client, err := startServerWithArgs(ctx, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient := openai.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithHTTPClient(client))
+
+		prompts := []string{prompt1, prompt2}
+		n := 3
+
+		var expectedPromptTokens int64
+		for _, p := range prompts {
+			tokens, _, err := tokenizerMngr.TestTokenizer().RenderText(p)
+			Expect(err).NotTo(HaveOccurred())
+			expectedPromptTokens += int64(len(tokens))
+		}
+
+		resp, err := openaiclient.Completions.New(ctx, openai.CompletionNewParams{
+			Prompt: openai.CompletionNewParamsPromptUnion{OfArrayOfStrings: prompts},
+			Model:  openai.CompletionNewParamsModel(common.TestModelName),
+			N:      param.NewOpt(int64(n)),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Total choices = len(prompts) * n
+		totalChoices := len(prompts) * n
+		Expect(resp.Choices).To(HaveLen(totalChoices))
+
+		// Indexes must be 0..totalChoices-1 with no duplicates.
+		seen := make(map[int64]bool, totalChoices)
+		for _, c := range resp.Choices {
+			Expect(seen[c.Index]).To(BeFalse(), "duplicate choice index %d", c.Index)
+			seen[c.Index] = true
+		}
+		for i := int64(0); i < int64(totalChoices); i++ {
+			Expect(seen[i]).To(BeTrue(), "missing choice index %d", i)
+		}
+
+		// In echo mode, each group of n choices for a prompt should echo that prompt.
+		// Prompt 0 → choices 0..n-1, Prompt 1 → choices n..2n-1.
+		for _, c := range resp.Choices {
+			promptIdx := int(c.Index) / n
+			Expect(c.Text).To(Equal(prompts[promptIdx]),
+				"choice %d should echo prompt %d (%q)", c.Index, promptIdx, prompts[promptIdx])
+		}
+
+		// Prompt tokens counted once per prompt, not once per choice.
+		Expect(resp.Usage.PromptTokens).To(Equal(expectedPromptTokens))
+		Expect(resp.Usage.TotalTokens).To(Equal(resp.Usage.PromptTokens + resp.Usage.CompletionTokens))
+	})
+
 	DescribeTable("text completions with array prompt",
 		func(streaming bool) {
 			ctx := context.TODO()

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -301,6 +301,222 @@ var _ = Describe("Simulator", func() {
 		Entry(nil, common.QwenModelName, common.ModeRandom, 1000),
 	)
 
+	DescribeTable("chat completions with n parameter",
+		func(mode string, n int) {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", mode, "--max-num-seqs", "10"}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			openaiclient, params := getOpenAIClientAndChatParams(client, common.TestModelName, testUserMessage, false)
+			params.N = param.NewOpt(int64(n))
+			resp, err := openaiclient.Chat.Completions.New(ctx, params)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Exact number of choices must match n
+			Expect(resp.Choices).To(HaveLen(n))
+			Expect(string(resp.Object)).To(Equal(openaiserverapi.ChatCompletionObject))
+
+			// Prompt tokens should be counted once, not n times
+			Expect(resp.Usage.PromptTokens).To(Equal(userMsgChatTokens))
+			Expect(resp.Usage.CompletionTokens).To(BeNumerically(">", 0))
+			Expect(resp.Usage.TotalTokens).To(Equal(resp.Usage.PromptTokens + resp.Usage.CompletionTokens))
+
+			// Each choice must have valid content and a sequential index
+			seen := make(map[int64]bool, n)
+			for _, choice := range resp.Choices {
+				Expect(seen[choice.Index]).To(BeFalse(), "duplicate choice index %d", choice.Index)
+				seen[choice.Index] = true
+				msg := choice.Message.Content
+				Expect(msg).ShouldNot(BeEmpty())
+
+				if mode == common.ModeEcho {
+					Expect(msg).Should(Equal(testUserMessage))
+				} else {
+					Expect(dataset.IsValidText(msg)).To(BeTrue())
+				}
+			}
+			for i := int64(0); i < int64(n); i++ {
+				Expect(seen[i]).To(BeTrue(), "missing choice index %d", i)
+			}
+		},
+		func(mode string, n int) string {
+			return fmt.Sprintf("mode: %s n: %d", mode, n)
+		},
+		Entry(nil, common.ModeRandom, 1),
+		Entry(nil, common.ModeEcho, 1),
+		Entry(nil, common.ModeRandom, 3),
+		Entry(nil, common.ModeEcho, 3),
+		Entry(nil, common.ModeRandom, 5),
+	)
+
+	DescribeTable("chat completions streaming with n parameter",
+		func(mode string, n int) {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", mode, "--max-num-seqs", "10"}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			openaiclient, params := getOpenAIClientAndChatParams(client, common.TestModelName, testUserMessage, true)
+			params.N = param.NewOpt(int64(n))
+			stream := openaiclient.Chat.Completions.NewStreaming(ctx, params)
+			defer func() {
+				err := stream.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			tokensPerChoice := make(map[int64][]string)
+			roles := make(map[int64]string)
+			var chunk openai.ChatCompletionChunk
+			numberOfChunksWithUsage := 0
+			for stream.Next() {
+				chunk = stream.Current()
+				for _, choice := range chunk.Choices {
+					if choice.Delta.Role != "" {
+						roles[choice.Index] = choice.Delta.Role
+					} else if choice.FinishReason == "" {
+						tokensPerChoice[choice.Index] = append(tokensPerChoice[choice.Index], choice.Delta.Content)
+					}
+				}
+				if chunk.Usage.CompletionTokens != 0 || chunk.Usage.PromptTokens != 0 || chunk.Usage.TotalTokens != 0 {
+					numberOfChunksWithUsage++
+				}
+			}
+			Expect(stream.Err()).NotTo(HaveOccurred())
+
+			Expect(numberOfChunksWithUsage).To(Equal(1))
+			// Prompt tokens counted once
+			Expect(chunk.Usage.PromptTokens).To(Equal(userMsgChatTokens))
+			Expect(chunk.Usage.CompletionTokens).To(BeNumerically(">", 0))
+			Expect(chunk.Usage.TotalTokens).To(Equal(chunk.Usage.PromptTokens + chunk.Usage.CompletionTokens))
+
+			// Exactly n choices must have been seen
+			Expect(tokensPerChoice).To(HaveLen(n))
+			for i := int64(0); i < int64(n); i++ {
+				Expect(roles[i]).To(Equal("assistant"), "choice %d missing role", i)
+				msg := strings.Join(tokensPerChoice[i], "")
+				Expect(msg).ShouldNot(BeEmpty(), "choice %d has empty content", i)
+				if mode == common.ModeEcho {
+					Expect(msg).Should(Equal(testUserMessage))
+				} else {
+					Expect(dataset.IsValidText(msg)).To(BeTrue())
+				}
+			}
+		},
+		func(mode string, n int) string {
+			return fmt.Sprintf("mode: %s n: %d", mode, n)
+		},
+		Entry(nil, common.ModeRandom, 1),
+		Entry(nil, common.ModeEcho, 1),
+		Entry(nil, common.ModeRandom, 3),
+		Entry(nil, common.ModeEcho, 3),
+	)
+
+	DescribeTable("text completions with n parameter",
+		func(mode string, n int) {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", mode, "--max-num-seqs", "10"}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			openaiclient, params := getOpenAIClentAndCompletionParams(client, common.TestModelName, testUserMessage, false)
+			params.N = param.NewOpt(int64(n))
+			resp, err := openaiclient.Completions.New(ctx, params)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Exact number of choices must match n
+			Expect(resp.Choices).To(HaveLen(n))
+			Expect(string(resp.Object)).To(Equal(openaiserverapi.TextCompletionObject))
+
+			// Prompt tokens should be counted once
+			Expect(resp.Usage.PromptTokens).To(Equal(userMsgTokens))
+			Expect(resp.Usage.CompletionTokens).To(BeNumerically(">", 0))
+			Expect(resp.Usage.TotalTokens).To(Equal(resp.Usage.PromptTokens + resp.Usage.CompletionTokens))
+
+			// Each choice must have valid content and a sequential index
+			seen := make(map[int64]bool, n)
+			for _, choice := range resp.Choices {
+				Expect(seen[choice.Index]).To(BeFalse(), "duplicate choice index %d", choice.Index)
+				seen[choice.Index] = true
+				Expect(choice.Text).ShouldNot(BeEmpty())
+
+				if mode == common.ModeEcho {
+					Expect(choice.Text).Should(Equal(testUserMessage))
+				} else {
+					Expect(dataset.IsValidText(choice.Text)).To(BeTrue())
+				}
+			}
+			for i := int64(0); i < int64(n); i++ {
+				Expect(seen[i]).To(BeTrue(), "missing choice index %d", i)
+			}
+		},
+		func(mode string, n int) string {
+			return fmt.Sprintf("mode: %s n: %d", mode, n)
+		},
+		Entry(nil, common.ModeRandom, 1),
+		Entry(nil, common.ModeEcho, 1),
+		Entry(nil, common.ModeRandom, 3),
+		Entry(nil, common.ModeEcho, 3),
+		Entry(nil, common.ModeRandom, 5),
+	)
+
+	DescribeTable("text completions streaming with n parameter",
+		func(mode string, n int) {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", mode, "--max-num-seqs", "10"}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			openaiclient, params := getOpenAIClentAndCompletionParams(client, common.TestModelName, testUserMessage, true)
+			params.N = param.NewOpt(int64(n))
+			stream := openaiclient.Completions.NewStreaming(ctx, params)
+			defer func() {
+				err := stream.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			tokensPerChoice := make(map[int64][]string)
+			var chunk openai.Completion
+			numberOfChunksWithUsage := 0
+			for stream.Next() {
+				chunk = stream.Current()
+				for _, choice := range chunk.Choices {
+					if choice.FinishReason == "" {
+						tokensPerChoice[choice.Index] = append(tokensPerChoice[choice.Index], choice.Text)
+					}
+				}
+				if chunk.Usage.CompletionTokens != 0 || chunk.Usage.PromptTokens != 0 || chunk.Usage.TotalTokens != 0 {
+					numberOfChunksWithUsage++
+				}
+			}
+			Expect(stream.Err()).NotTo(HaveOccurred())
+
+			Expect(numberOfChunksWithUsage).To(Equal(1))
+			Expect(chunk.Usage.PromptTokens).To(Equal(userMsgTokens))
+			Expect(chunk.Usage.CompletionTokens).To(BeNumerically(">", 0))
+			Expect(chunk.Usage.TotalTokens).To(Equal(chunk.Usage.PromptTokens + chunk.Usage.CompletionTokens))
+
+			// Exactly n choices must have been seen
+			Expect(tokensPerChoice).To(HaveLen(n))
+			for i := int64(0); i < int64(n); i++ {
+				msg := strings.Join(tokensPerChoice[i], "")
+				Expect(msg).ShouldNot(BeEmpty(), "choice %d has empty content", i)
+				if mode == common.ModeEcho {
+					Expect(msg).Should(Equal(testUserMessage))
+				} else {
+					Expect(dataset.IsValidText(msg)).To(BeTrue())
+				}
+			}
+		},
+		func(mode string, n int) string {
+			return fmt.Sprintf("mode: %s n: %d", mode, n)
+		},
+		Entry(nil, common.ModeRandom, 1),
+		Entry(nil, common.ModeEcho, 1),
+		Entry(nil, common.ModeRandom, 3),
+		Entry(nil, common.ModeEcho, 3),
+	)
+
 	DescribeTable("text completions with array prompt",
 		func(streaming bool) {
 			ctx := context.TODO()


### PR DESCRIPTION
Add support for the OpenAI 'n' parameter which controls the number of completion choices generated per request. Each choice is independently generated with different content.

This PR solves https://github.com/llm-d/llm-d-inference-sim/issues/249 and already addresses review feedback on PR #262

Implementation details:
- split() returns n copies of the request for chat/text completions
- For array-prompt text completions, total sub-requests = prompts * n
- aggregateUsage() counts prompt tokens once per unique request ID, correctly handling all combinations: single prompt + n, array prompts, and array prompts + n
- Chat completion response builder updated to produce per-choice messages with independent logprobs