### PR TITLE
feat: add Mooncake bootstrap /query endpoint

### DIFF
--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -50,6 +50,11 @@ type Communication struct {
 
 	// startTime records when the server started, used for startup-duration readiness check
 	startTime time.Time
+
+	// mooncakeEngines holds the per-rank engine ids served by /query, generated once so
+	// they stay stable for the simulator's lifetime
+	mooncakeEnginesOnce sync.Once
+	mooncakeEngines     map[string]map[string]string
 }
 
 func New(logger logr.Logger, simulator *vllmsim.VllmSimulator) *Communication {

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -791,22 +791,31 @@ func (c *Communication) HandleReady(ctx *fasthttp.RequestCtx) {
 	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
 }
 
+// mooncakeEngineMap returns the dp_rank -> {engine_id} map served by /query, generating
+// it once so the engine ids stay stable for the simulator's lifetime.
+func (c *Communication) mooncakeEngineMap() map[string]map[string]string {
+	c.mooncakeEnginesOnce.Do(func() {
+		dpSize := c.simulator.Context.Config().DPSize
+		engines := make(map[string]map[string]string, dpSize)
+		for rank := 0; rank < dpSize; rank++ {
+			engines[strconv.Itoa(rank)] = map[string]string{
+				"engine_id": c.simulator.Context.Random.GenerateUUIDString(),
+			}
+		}
+		c.mooncakeEngines = engines
+	})
+	return c.mooncakeEngines
+}
+
 // HandleMooncakeQuery emulates vLLM's Mooncake bootstrap endpoint (/query) served on
 // the prefill pod. The routing sidecar calls it to resolve the remote engine id used
 // for KV transfer, receiving a dp_rank -> {engine_id} map. The engine ids are
-// placeholders; a real vLLM prefill pod reports the ids of its running KV engines.
+// placeholders generated once per simulator lifetime; a real vLLM prefill pod reports
+// the ids of its running KV engines.
 func (c *Communication) HandleMooncakeQuery(ctx *fasthttp.RequestCtx) {
 	c.logger.V(logging.TRACE).Info("/query request received")
 
-	dpSize := c.simulator.Context.Config().DPSize
-	engines := make(map[string]map[string]string, dpSize)
-	for rank := 0; rank < dpSize; rank++ {
-		engines[strconv.Itoa(rank)] = map[string]string{
-			"engine_id": c.simulator.Context.Random.GenerateUUIDString(),
-		}
-	}
-
-	data, err := json.Marshal(engines)
+	data, err := json.Marshal(c.mooncakeEngineMap())
 	if err != nil {
 		c.logger.Error(err, "failed to marshal mooncake query response")
 		errToSend := openaiserverapi.NewError("Failed to marshal mooncake query response, "+err.Error(), fasthttp.StatusInternalServerError, nil)

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -83,6 +83,8 @@ func (c *Communication) startHTTPServer(listener net.Listener) (*fasthttp.Server
 	// supports standard Kubernetes health and readiness checks
 	r.GET("/health", c.HandleHealth)
 	r.GET("/health/ready", c.HandleHealthReady)
+	// emulates vLLM's Mooncake bootstrap endpoint on the prefill pod; the routing sidecar queries it to resolve remote engine ids
+	r.GET("/query", c.HandleMooncakeQuery)
 	r.GET("/ready", c.HandleReady)
 	r.POST("/tokenize", c.HandleTokenize)
 	r.POST("/sleep", c.HandleSleep)
@@ -787,6 +789,34 @@ func (c *Communication) HandleReady(ctx *fasthttp.RequestCtx) {
 	}
 	ctx.Response.Header.SetContentType("application/json")
 	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
+}
+
+// HandleMooncakeQuery emulates vLLM's Mooncake bootstrap endpoint (/query) served on
+// the prefill pod. The routing sidecar calls it to resolve the remote engine id used
+// for KV transfer, receiving a dp_rank -> {engine_id} map. The engine ids are
+// placeholders; a real vLLM prefill pod reports the ids of its running KV engines.
+func (c *Communication) HandleMooncakeQuery(ctx *fasthttp.RequestCtx) {
+	c.logger.V(logging.TRACE).Info("/query request received")
+
+	dpSize := c.simulator.Context.Config().DPSize
+	engines := make(map[string]map[string]string, dpSize)
+	for rank := 0; rank < dpSize; rank++ {
+		engines[strconv.Itoa(rank)] = map[string]string{
+			"engine_id": c.simulator.Context.Random.GenerateUUIDString(),
+		}
+	}
+
+	data, err := json.Marshal(engines)
+	if err != nil {
+		c.logger.Error(err, "failed to marshal mooncake query response")
+		errToSend := openaiserverapi.NewError("Failed to marshal mooncake query response, "+err.Error(), fasthttp.StatusInternalServerError, nil)
+		c.sendError(ctx, &errToSend, false)
+		return
+	}
+
+	ctx.Response.Header.SetContentType("application/json")
+	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
+	ctx.Response.SetBody(data)
 }
 
 // HandleIsSleeping handles /is_sleeping request according

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -2853,12 +2853,7 @@ force-dummy-tokenizer: false
 	})
 
 	Context("Mooncake bootstrap query", func() {
-		It("Should return a dp_rank to engine_id map on /query", func() {
-			ctx := context.TODO()
-			args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom}
-			client, err := startServerWithArgs(ctx, args)
-			Expect(err).NotTo(HaveOccurred())
-
+		queryEngines := func(client *http.Client) map[string]map[string]string {
 			resp, err := client.Get("http://localhost/query")
 			Expect(err).NotTo(HaveOccurred())
 			defer func() {
@@ -2872,9 +2867,30 @@ force-dummy-tokenizer: false
 
 			engines := map[string]map[string]string{}
 			Expect(json.Unmarshal(body, &engines)).To(Succeed())
+			return engines
+		}
+
+		It("Should return a dp_rank to engine_id map on /query", func() {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			engines := queryEngines(client)
 			Expect(engines).To(HaveKey("0"))
 			Expect(engines["0"]).To(HaveKey("engine_id"))
 			Expect(engines["0"]["engine_id"]).NotTo(BeEmpty())
+		})
+
+		It("Should return the same engine ids by multiple calls", func() {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			firstCall := queryEngines(client)
+			secondCall := queryEngines(client)
+			Expect(secondCall).To(Equal(firstCall))
 		})
 	})
 })

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -2851,4 +2851,30 @@ force-dummy-tokenizer: false
 			})
 		})
 	})
+
+	Context("Mooncake bootstrap query", func() {
+		It("Should return a dp_rank to engine_id map on /query", func() {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := client.Get("http://localhost/query")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				Expect(resp.Body.Close()).To(Succeed())
+			}()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			engines := map[string]map[string]string{}
+			Expect(json.Unmarshal(body, &engines)).To(Succeed())
+			Expect(engines).To(HaveKey("0"))
+			Expect(engines["0"]).To(HaveKey("engine_id"))
+			Expect(engines["0"]["engine_id"]).NotTo(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
# Notes
to support feature[ Mooncake connector in llm-d](https://github.com/llm-d/llm-d-router/issues/1010)  PR https://github.com/llm-d/llm-d-router/pull/1193 e2e require updates in sim to support new /query endpoint


# Changes
- GET /query so the routing sidecar can resolve remote engine_id for the Mooncake KV connector.
- return dp_rank -> {engine_id} map, seeded uuid per dp rank