### PR TITLE
feat(mm): support input_audio and video_url block types

### DIFF
--- a/pkg/openai-server-api/response.go
+++ b/pkg/openai-server-api/response.go
@@ -177,12 +177,23 @@ type ChatComplContent struct {
 }
 
 type ChatComplContentBlock struct {
-	Type     string              `json:"type"`
-	Text     string              `json:"text,omitempty"`
-	ImageURL ChatComplImageBlock `json:"image_url,omitempty"`
+	Type       string              `json:"type"`
+	Text       string              `json:"text,omitempty"`
+	ImageURL   ChatComplImageBlock `json:"image_url,omitempty"`
+	InputAudio ChatComplAudioBlock `json:"input_audio,omitempty"`
+	VideoURL   ChatComplVideoBlock `json:"video_url,omitempty"`
 }
 
 type ChatComplImageBlock struct {
+	Url string `json:"url,omitempty"`
+}
+
+type ChatComplAudioBlock struct {
+	Data   string `json:"data,omitempty"`
+	Format string `json:"format,omitempty"`
+}
+
+type ChatComplVideoBlock struct {
 	Url string `json:"url,omitempty"`
 }
 

--- a/pkg/tokenizer/tokenizer.go
+++ b/pkg/tokenizer/tokenizer.go
@@ -29,7 +29,11 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-const mmModalityImage = "image"
+const (
+	mmModalityImage = "image"
+	mmModalityAudio = "audio"
+	mmModalityVideo = "video"
+)
 
 type Tokenizer interface {
 	// RenderText renders plain text and returns token IDs and string tokens
@@ -119,35 +123,53 @@ func (st *SimpleTokenizer) RenderMessages(messages []openaiserverapi.Message) ([
 	return tokens, textTokens, features, nil
 }
 
-// stubMMFeaturesForMessages returns synthetic mm_features when any message
-// contains image_url blocks; otherwise nil.
+// stubMMFeaturesForMessages synthesizes per-modality mm_hashes and placeholders
+// for image_url, input_audio, and video_url blocks; nil if none present.
 func stubMMFeaturesForMessages(messages []openaiserverapi.Message, totalTokens int) *openaiserverapi.RenderMMFeatures {
-	var imageURLs []string
+	type item struct {
+		modality, prefix, identifier string
+		modalIndex                   int
+	}
+
+	var items []item
+	var imgIdx, audIdx, vidIdx int
 	for _, msg := range messages {
 		for _, block := range msg.Content.Structured {
-			if block.Type == "image_url" {
-				imageURLs = append(imageURLs, block.ImageURL.Url)
+			switch block.Type {
+			case "image_url":
+				if block.ImageURL.Url == "" {
+					continue
+				}
+				items = append(items, item{mmModalityImage, "img", block.ImageURL.Url, imgIdx})
+				imgIdx++
+			case "input_audio":
+				if block.InputAudio.Data == "" {
+					continue
+				}
+				items = append(items, item{mmModalityAudio, "audio", block.InputAudio.Data, audIdx})
+				audIdx++
+			case "video_url":
+				if block.VideoURL.Url == "" {
+					continue
+				}
+				items = append(items, item{mmModalityVideo, "video", block.VideoURL.Url, vidIdx})
+				vidIdx++
 			}
 		}
 	}
-	if len(imageURLs) == 0 {
+	if len(items) == 0 {
 		return nil
 	}
 
-	// One stub hash + placeholder per image. Spread the placeholders evenly
-	// across the prompt's token range so they look like distinct,
-	// non-overlapping image regions.
-	hashes := make([]string, len(imageURLs))
-	placeholders := make([]openaiserverapi.RenderPlaceholder, len(imageURLs))
-	// span: per-image slice of the token range — used as both the gap between
-	// successive image offsets and the default placeholder length. Floored at
-	// 1 so each image still gets a non-empty slot when images outnumber tokens.
-	span := max(totalTokens/len(imageURLs), 1)
-	for i, url := range imageURLs {
-		// Deterministic hash so repeat calls produce stable KV-cache keys.
-		hashes[i] = fmt.Sprintf("sim_img_%d_%x", i, fnv32(url))
-		// Place each image right after the previous one, clamped into the
-		// valid token range for the degenerate case totalTokens < numImages.
+	span := max(totalTokens/len(items), 1)
+	mmHashes := map[string][]string{}
+	mmPlaceholders := map[string][]openaiserverapi.RenderPlaceholder{}
+
+	for i, it := range items {
+		// Deterministic so repeats hit cache.
+		hash := fmt.Sprintf("sim_%s_%d_%x", it.prefix, it.modalIndex, fnv32(it.identifier))
+		mmHashes[it.modality] = append(mmHashes[it.modality], hash)
+
 		offset := i * span
 		if offset >= totalTokens {
 			offset = totalTokens - 1
@@ -163,11 +185,11 @@ func stubMMFeaturesForMessages(messages []openaiserverapi.Message, totalTokens i
 		if length < 1 {
 			length = 1
 		}
-		placeholders[i] = openaiserverapi.RenderPlaceholder{Offset: offset, Length: length}
+		mmPlaceholders[it.modality] = append(mmPlaceholders[it.modality], openaiserverapi.RenderPlaceholder{Offset: offset, Length: length})
 	}
 	return &openaiserverapi.RenderMMFeatures{
-		MMHashes:       map[string][]string{mmModalityImage: hashes},
-		MMPlaceholders: map[string][]openaiserverapi.RenderPlaceholder{mmModalityImage: placeholders},
+		MMHashes:       mmHashes,
+		MMPlaceholders: mmPlaceholders,
 	}
 }
 

--- a/pkg/tokenizer/tokenizer_test.go
+++ b/pkg/tokenizer/tokenizer_test.go
@@ -72,6 +72,94 @@ var _ = Describe("tokenizer", func() {
 		Expect(tokens).NotTo(BeEmpty())
 	})
 
+	Describe("stubMMFeaturesForMessages", func() {
+		text := func(s string) openaiserverapi.ChatComplContentBlock {
+			return openaiserverapi.ChatComplContentBlock{Type: "text", Text: s}
+		}
+		image := func(url string) openaiserverapi.ChatComplContentBlock {
+			return openaiserverapi.ChatComplContentBlock{
+				Type:     "image_url",
+				ImageURL: openaiserverapi.ChatComplImageBlock{Url: url},
+			}
+		}
+		audio := func(data, format string) openaiserverapi.ChatComplContentBlock {
+			return openaiserverapi.ChatComplContentBlock{
+				Type:       "input_audio",
+				InputAudio: openaiserverapi.ChatComplAudioBlock{Data: data, Format: format},
+			}
+		}
+		video := func(url string) openaiserverapi.ChatComplContentBlock {
+			return openaiserverapi.ChatComplContentBlock{
+				Type:     "video_url",
+				VideoURL: openaiserverapi.ChatComplVideoBlock{Url: url},
+			}
+		}
+		mkMsg := func(blocks ...openaiserverapi.ChatComplContentBlock) openaiserverapi.Message {
+			return openaiserverapi.Message{
+				Role:    openaiserverapi.RoleUser,
+				Content: openaiserverapi.ChatComplContent{Structured: blocks},
+			}
+		}
+
+		It("returns nil when no media blocks are present", func() {
+			feats := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(text("hello"))}, 100)
+			Expect(feats).To(BeNil())
+		})
+
+		It("emits an image hash keyed by image", func() {
+			feats := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(text("describe"), image("http://x/a.jpg"))}, 100)
+			Expect(feats).NotTo(BeNil())
+			Expect(feats.MMHashes).To(HaveKey(mmModalityImage))
+			Expect(feats.MMHashes[mmModalityImage]).To(HaveLen(1))
+			Expect(feats.MMHashes[mmModalityImage][0]).To(HavePrefix("sim_img_"))
+			Expect(feats.MMPlaceholders[mmModalityImage]).To(HaveLen(1))
+		})
+
+		It("emits an audio hash keyed by audio", func() {
+			feats := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(text("transcribe"), audio("base64data", "wav"))}, 100)
+			Expect(feats).NotTo(BeNil())
+			Expect(feats.MMHashes).To(HaveKey(mmModalityAudio))
+			Expect(feats.MMHashes[mmModalityAudio][0]).To(HavePrefix("sim_audio_"))
+		})
+
+		It("emits a video hash keyed by video", func() {
+			feats := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(text("watch"), video("http://x/v.mp4"))}, 100)
+			Expect(feats).NotTo(BeNil())
+			Expect(feats.MMHashes).To(HaveKey(mmModalityVideo))
+			Expect(feats.MMHashes[mmModalityVideo][0]).To(HavePrefix("sim_video_"))
+		})
+
+		It("returns all three modality keys for mixed multimedia", func() {
+			feats := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(
+				text("mixed"), image("http://x/a.jpg"), audio("data", "wav"), video("http://x/v.mp4"),
+			)}, 120)
+			Expect(feats).NotTo(BeNil())
+			Expect(feats.MMHashes).To(HaveKey(mmModalityImage))
+			Expect(feats.MMHashes).To(HaveKey(mmModalityAudio))
+			Expect(feats.MMHashes).To(HaveKey(mmModalityVideo))
+		})
+
+		It("produces deterministic hashes for identical input", func() {
+			msgs := []openaiserverapi.Message{mkMsg(image("http://x/a.jpg"), audio("data", "wav"), video("http://x/v.mp4"))}
+			a := stubMMFeaturesForMessages(msgs, 100)
+			b := stubMMFeaturesForMessages(msgs, 100)
+			Expect(a).To(Equal(b))
+		})
+
+		It("skips media blocks with empty identifiers", func() {
+			feats := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(
+				image(""), audio("", "wav"), video(""),
+			)}, 100)
+			Expect(feats).To(BeNil())
+		})
+
+		It("treats audio format as routing-irrelevant (same data different format collides)", func() {
+			wav := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(audio("samebytes", "wav"))}, 100)
+			mp3 := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(audio("samebytes", "mp3"))}, 100)
+			Expect(wav.MMHashes[mmModalityAudio]).To(Equal(mp3.MMHashes[mmModalityAudio]))
+		})
+	})
+
 	Describe("splitIntoTokens", func() {
 		bt := newBaseTokenizer()
 		const text = "I hear it's very cold."


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Extends `stubMMFeaturesForMessages` to emit deterministic mm_features for `input_audio` and `video_url` block types alongside the existing `image_url` path. `ChatComplContentBlock` gains `InputAudio` and `VideoURL` fields so the data is no longer dropped at JSON unmarshal. Hashes are keyed per modality (`image` / `audio` / `video`) matching the wire shape vLLM emits.

Enables cache-affinity tests in `llm-d-router/test/e2e/` to exercise audio and video paths against the sim.

Known divergences from real vLLM, called out so test authors know the limits:
- Position-dependent hash (`sim_<modality>_<index>_<fnv32(id)>`). Real vLLM is content-only. Same-content same-position requests hit; cross-position dedup does not.
- Uniform placeholder lengths (`span = totalTokens / N`). Real vLLM token counts vary per modality (image ~hundreds, audio ~50/sec, video ~thousands/clip). Cache-affinity assertions are valid; token-budget assertions are not.
- Audio identity is the base64 bytes only; the sim does not decode. The same audio in WAV vs MP3 will hash to different values.

**Which issue(s) this PR fixes**:

Fixes #413

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
sim: support `input_audio` and `video_url` content blocks with deterministic stub mm_features for cache-affinity testing.
```
