### PR TITLE
fix: ensure all metrics are written before signaling request completion

### DIFF
--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -457,7 +457,6 @@ func (s *VllmSimulator) simulateResponseProcessing(respCtx ResponseContext) {
 		}
 		common.WriteToChannel(s.Context.metrics.reqDecodeTimeChan, time.Since(startDecode).Seconds(), s.Context.logger)
 	}
-	reqCtx.signalDone()
 }
 
 // request processing finished

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -472,6 +472,7 @@ func (s *VllmSimulator) onResponseProcessingFinished(reqCtx requestContext) {
 	}
 
 	reqCtx.kvCacheOnRequestEnd()
+	reqCtx.signalDone()
 }
 
 // OpenRequests returns the number of requests currently in the system

--- a/pkg/llm-d-inference-sim/worker.go
+++ b/pkg/llm-d-inference-sim/worker.go
@@ -58,6 +58,11 @@ type requestProcessor interface {
 }
 
 func (s *VllmSimulator) processRequest(reqCtx requestContext) {
+	defer func() {
+		s.onResponseProcessingFinished(reqCtx)
+		reqCtx.signalDone()
+	}()
+
 	startTime := time.Now()
 	req := reqCtx.request()
 	respCtx, err := reqCtx.handleRequest()
@@ -65,8 +70,6 @@ func (s *VllmSimulator) processRequest(reqCtx requestContext) {
 		common.WriteToChannel(reqCtx.responseChannel(),
 			&ResponseInfo{RespCtx: respCtx, Err: err, ChoiceIdx: reqCtx.choiceIndex()},
 			s.Context.logger)
-		s.onResponseProcessingFinished(reqCtx)
-		reqCtx.signalDone()
 		return
 	}
 
@@ -85,8 +88,6 @@ func (s *VllmSimulator) processRequest(reqCtx requestContext) {
 
 	common.WriteToChannel(s.Context.metrics.e2eReqLatencyChan, time.Since(reqCtx.startProcessingTime()).Seconds(), s.Context.logger)
 	common.WriteToChannel(s.Context.metrics.reqInferenceTimeChan, time.Since(startTime).Seconds(), s.Context.logger)
-	s.onResponseProcessingFinished(reqCtx)
-	reqCtx.signalDone()
 }
 
 // getFreeWorker returns a free worker or nil if none are available (non-blocking)

--- a/pkg/llm-d-inference-sim/worker.go
+++ b/pkg/llm-d-inference-sim/worker.go
@@ -58,10 +58,7 @@ type requestProcessor interface {
 }
 
 func (s *VllmSimulator) processRequest(reqCtx requestContext) {
-	defer func() {
-		s.onResponseProcessingFinished(reqCtx)
-		reqCtx.signalDone()
-	}()
+	defer s.onResponseProcessingFinished(reqCtx)
 
 	startTime := time.Now()
 	req := reqCtx.request()

--- a/pkg/llm-d-inference-sim/worker.go
+++ b/pkg/llm-d-inference-sim/worker.go
@@ -58,8 +58,6 @@ type requestProcessor interface {
 }
 
 func (s *VllmSimulator) processRequest(reqCtx requestContext) {
-	defer s.onResponseProcessingFinished(reqCtx)
-
 	startTime := time.Now()
 	req := reqCtx.request()
 	respCtx, err := reqCtx.handleRequest()
@@ -67,6 +65,7 @@ func (s *VllmSimulator) processRequest(reqCtx requestContext) {
 		common.WriteToChannel(reqCtx.responseChannel(),
 			&ResponseInfo{RespCtx: respCtx, Err: err, ChoiceIdx: reqCtx.choiceIndex()},
 			s.Context.logger)
+		s.onResponseProcessingFinished(reqCtx)
 		reqCtx.signalDone()
 		return
 	}
@@ -86,6 +85,8 @@ func (s *VllmSimulator) processRequest(reqCtx requestContext) {
 
 	common.WriteToChannel(s.Context.metrics.e2eReqLatencyChan, time.Since(reqCtx.startProcessingTime()).Seconds(), s.Context.logger)
 	common.WriteToChannel(s.Context.metrics.reqInferenceTimeChan, time.Since(startTime).Seconds(), s.Context.logger)
+	s.onResponseProcessingFinished(reqCtx)
+	reqCtx.signalDone()
 }
 
 // getFreeWorker returns a free worker or nil if none are available (non-blocking)


### PR DESCRIPTION
Fix race condition: move signalDone() to after all metrics writes in processRequest, so teardown cannot race with the worker's post-request cleanup. Without this, some metrics updates could be skipped if the simulator was stopped immediately after the response completed.