### PR TITLE
fix: send finish_reason in last tokens chunk for generate streaming, fix missing finish_reason for non-stop completions

### DIFF
--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -416,7 +416,7 @@ func (c *Communication) sendStream(ctx *fasthttp.RequestCtx, channel common.Chan
 				continue
 			}
 
-			ok, stop := c.emitResponseChunks(ctx, w, respBuilder, response, respCtx, &state)
+			ok, stop := c.emitResponseChunks(ctx, w, respBuilder, response, respCtx, &state, response.Status == vllmsim.ResponseEndOfTokens)
 			if !ok {
 				return
 			}
@@ -436,7 +436,7 @@ func (c *Communication) sendStream(ctx *fasthttp.RequestCtx, channel common.Chan
 // already reported via ctx); stop=true means the stream is complete and the main
 // loop should break out to finalize.
 func (c *Communication) emitResponseChunks(ctx *fasthttp.RequestCtx, w *bufio.Writer, respBuilder responseBuilder,
-	response *vllmsim.ResponseInfo, respCtx vllmsim.ResponseContext, state *streamState) (ok bool, stop bool) {
+	response *vllmsim.ResponseInfo, respCtx vllmsim.ResponseContext, state *streamState, lastTokensChunk bool) (ok bool, stop bool) {
 	choiceIdx := response.ChoiceIdx
 
 	if response.Tokens != nil {
@@ -461,7 +461,12 @@ func (c *Communication) emitResponseChunks(ctx *fasthttp.RequestCtx, w *bufio.Wr
 			state.lastToolCall[choiceIdx] = response.ToolCall
 			return true, false
 		}
-		return c.sendOrFail(ctx, w, respBuilder.createChunk(respCtx, response.Tokens, nil, "", nil, choiceIdx),
+
+		var finishReason *string
+		if lastTokensChunk && respBuilder.sendFinishReasonWithTokens() {
+			finishReason = respCtx.FinishReason()
+		}
+		return c.sendOrFail(ctx, w, respBuilder.createChunk(respCtx, response.Tokens, nil, "", finishReason, choiceIdx),
 			"Sending stream chunk failed, "), false
 	}
 

--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -213,8 +213,8 @@ func (respBuilder *textComplHTTPRespBuilder) createLastChunk(respCtx vllmsim.Res
 	return respBuilder.createChunk(respCtx, nil, nil, "", respCtx.FinishReason(), choiceIdx)
 }
 
-func (*textComplHTTPRespBuilder) createDoneChunk() sseChunk              { return &doneMarker{} }
-func (*textComplHTTPRespBuilder) sendFinishReasonWithTokens() bool       { return false }
+func (*textComplHTTPRespBuilder) createDoneChunk() sseChunk        { return &doneMarker{} }
+func (*textComplHTTPRespBuilder) sendFinishReasonWithTokens() bool { return false }
 
 // createRenderResponse builds the wire payload for /v1/completions/render: an
 // array with one RenderResponse per prompt, mirroring vLLM which always
@@ -333,8 +333,8 @@ func (respBuilder *chatComplHTTPRespBuilder) createLastChunk(respCtx vllmsim.Res
 	return respBuilder.createChunk(respCtx, nil, nil, "", respCtx.FinishReason(), choiceIdx)
 }
 
-func (*chatComplHTTPRespBuilder) createDoneChunk() sseChunk              { return &doneMarker{} }
-func (*chatComplHTTPRespBuilder) sendFinishReasonWithTokens() bool       { return false }
+func (*chatComplHTTPRespBuilder) createDoneChunk() sseChunk        { return &doneMarker{} }
+func (*chatComplHTTPRespBuilder) sendFinishReasonWithTokens() bool { return false }
 
 // createRenderResponse builds the wire payload for /v1/chat/completions/render:
 // a single RenderResponse object (not an array) carrying the tokens for the
@@ -611,8 +611,8 @@ func (respBuilder *responsesHTTPRespBuilder) createLastChunk(respCtx vllmsim.Res
 	}
 }
 
-func (*responsesHTTPRespBuilder) createDoneChunk() sseChunk              { return nil }
-func (*responsesHTTPRespBuilder) sendFinishReasonWithTokens() bool       { return false }
+func (*responsesHTTPRespBuilder) createDoneChunk() sseChunk        { return nil }
+func (*responsesHTTPRespBuilder) sendFinishReasonWithTokens() bool { return false }
 
 func (*responsesHTTPRespBuilder) createRenderResponse(_ [][]uint32,
 	_ *openaiserverapi.RenderMMFeatures) any {
@@ -682,8 +682,8 @@ func (respBuilder *generateHTTPRespBuilder) createLastChunk(respCtx vllmsim.Resp
 	return nil
 }
 
-func (*generateHTTPRespBuilder) createDoneChunk() sseChunk              { return &doneMarker{} }
-func (*generateHTTPRespBuilder) sendFinishReasonWithTokens() bool       { return true }
+func (*generateHTTPRespBuilder) createDoneChunk() sseChunk        { return &doneMarker{} }
+func (*generateHTTPRespBuilder) sendFinishReasonWithTokens() bool { return true }
 
 func (*generateHTTPRespBuilder) createRenderResponse(_ [][]uint32,
 	_ *openaiserverapi.RenderMMFeatures) any {

--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -83,6 +83,9 @@ type responseBuilder interface {
 	createLastChunk(respCtx vllmsim.ResponseContext, finishReason string, choiceIdx int) sseChunk
 	createDoneChunk() sseChunk
 	createRenderResponse(tokens [][]uint32, features *openaiserverapi.RenderMMFeatures) any
+	// sendFinishReasonWithTokens returns true if the builder wants the finish
+	// reason included in the last tokens chunk rather than a separate empty chunk.
+	sendFinishReasonWithTokens() bool
 }
 
 // aggregateUsage combines per-choice usages. Completion tokens are always
@@ -204,13 +207,14 @@ func (respBuilder *textComplHTTPRespBuilder) createFirstChunk(respCtx vllmsim.Re
 }
 
 func (respBuilder *textComplHTTPRespBuilder) createLastChunk(respCtx vllmsim.ResponseContext, finishReason string, choiceIdx int) sseChunk {
-	if finishReason != common.StopFinishReason {
+	if finishReason == common.CacheThresholdFinishReason {
 		return nil
 	}
 	return respBuilder.createChunk(respCtx, nil, nil, "", respCtx.FinishReason(), choiceIdx)
 }
 
-func (*textComplHTTPRespBuilder) createDoneChunk() sseChunk { return &doneMarker{} }
+func (*textComplHTTPRespBuilder) createDoneChunk() sseChunk              { return &doneMarker{} }
+func (*textComplHTTPRespBuilder) sendFinishReasonWithTokens() bool       { return false }
 
 // createRenderResponse builds the wire payload for /v1/completions/render: an
 // array with one RenderResponse per prompt, mirroring vLLM which always
@@ -323,13 +327,14 @@ func (respBuilder *chatComplHTTPRespBuilder) createFirstChunk(respCtx vllmsim.Re
 }
 
 func (respBuilder *chatComplHTTPRespBuilder) createLastChunk(respCtx vllmsim.ResponseContext, finishReason string, choiceIdx int) sseChunk {
-	if finishReason != common.StopFinishReason {
+	if finishReason == common.ToolsFinishReason || finishReason == common.CacheThresholdFinishReason {
 		return nil
 	}
 	return respBuilder.createChunk(respCtx, nil, nil, "", respCtx.FinishReason(), choiceIdx)
 }
 
-func (*chatComplHTTPRespBuilder) createDoneChunk() sseChunk { return &doneMarker{} }
+func (*chatComplHTTPRespBuilder) createDoneChunk() sseChunk              { return &doneMarker{} }
+func (*chatComplHTTPRespBuilder) sendFinishReasonWithTokens() bool       { return false }
 
 // createRenderResponse builds the wire payload for /v1/chat/completions/render:
 // a single RenderResponse object (not an array) carrying the tokens for the
@@ -606,7 +611,8 @@ func (respBuilder *responsesHTTPRespBuilder) createLastChunk(respCtx vllmsim.Res
 	}
 }
 
-func (*responsesHTTPRespBuilder) createDoneChunk() sseChunk { return nil }
+func (*responsesHTTPRespBuilder) createDoneChunk() sseChunk              { return nil }
+func (*responsesHTTPRespBuilder) sendFinishReasonWithTokens() bool       { return false }
 
 func (*responsesHTTPRespBuilder) createRenderResponse(_ [][]uint32,
 	_ *openaiserverapi.RenderMMFeatures) any {
@@ -673,13 +679,11 @@ func (respBuilder *generateHTTPRespBuilder) createFirstChunk(_ vllmsim.ResponseC
 }
 
 func (respBuilder *generateHTTPRespBuilder) createLastChunk(respCtx vllmsim.ResponseContext, finishReason string, choiceIdx int) sseChunk {
-	if finishReason != common.StopFinishReason {
-		return nil
-	}
-	return respBuilder.createChunk(respCtx, nil, nil, "", respCtx.FinishReason(), choiceIdx)
+	return nil
 }
 
-func (*generateHTTPRespBuilder) createDoneChunk() sseChunk { return &doneMarker{} }
+func (*generateHTTPRespBuilder) createDoneChunk() sseChunk              { return &doneMarker{} }
+func (*generateHTTPRespBuilder) sendFinishReasonWithTokens() bool       { return true }
 
 func (*generateHTTPRespBuilder) createRenderResponse(_ [][]uint32,
 	_ *openaiserverapi.RenderMMFeatures) any {

--- a/pkg/llm-d-inference-sim/response.go
+++ b/pkg/llm-d-inference-sim/response.go
@@ -22,7 +22,10 @@ import (
 	openaiserverapi "github.com/llm-d/llm-d-inference-sim/pkg/openai-server-api"
 )
 
-const ResponseStatusCreated = "created"
+const (
+	ResponseStatusCreated = "created"
+	ResponseEndOfTokens   = "eot"
+)
 
 type ResponseInfo struct {
 	Tokens    *openaiserverapi.Tokenized

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -434,23 +434,32 @@ func (s *VllmSimulator) simulateResponseProcessing(respCtx ResponseContext) {
 					if respCtx.responseTokens().Strings != nil {
 						tokens.Strings = append(tokens.Strings, respCtx.responseTokens().Strings[i])
 					}
-					common.WriteToChannel(reqCtx.responseChannel(),
-						&ResponseInfo{Tokens: tokens, RespCtx: respCtx, ChoiceIdx: choiceIdx},
-						s.Context.logger)
+					respInfo := ResponseInfo{Tokens: tokens, RespCtx: respCtx, ChoiceIdx: choiceIdx}
+					if i == len(respCtx.responseTokens().Tokens)-1 {
+						respInfo.Status = ResponseEndOfTokens
+					}
+					common.WriteToChannel(reqCtx.responseChannel(), &respInfo, s.Context.logger)
 				}
 			} else {
-				for _, tc := range respCtx.ToolCalls() {
+				toolCalls := respCtx.ToolCalls()
+				for tcIdx, tc := range toolCalls {
 					// Tool calls are only supported in HTTP at the moment, so we assume that we always
 					// have string tokenized arguments
-					for i, token := range tc.Function.TokenizedArguments().Tokens {
+					args := tc.Function.TokenizedArguments()
+					for i, token := range args.Tokens {
 						if i != 0 {
 							s.Context.simulateInterTokenLatency()
 						}
-						common.WriteToChannel(reqCtx.responseChannel(),
-							&ResponseInfo{Tokens: &openaiserverapi.Tokenized{
-								Tokens:  []uint32{token},
-								Strings: []string{tc.Function.TokenizedArguments().Strings[i]}},
-								RespCtx: respCtx, ToolCall: &tc, ChoiceIdx: choiceIdx}, s.Context.logger)
+						respInfo := ResponseInfo{
+							Tokens:    &openaiserverapi.Tokenized{Tokens: []uint32{token}, Strings: []string{args.Strings[i]}},
+							RespCtx:   respCtx,
+							ToolCall:  &toolCalls[tcIdx],
+							ChoiceIdx: choiceIdx,
+						}
+						if tcIdx == len(toolCalls)-1 && i == len(args.Tokens)-1 {
+							respInfo.Status = ResponseEndOfTokens
+						}
+						common.WriteToChannel(reqCtx.responseChannel(), &respInfo, s.Context.logger)
 					}
 				}
 			}

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -155,6 +155,56 @@ var _ = Describe("Simulator", func() {
 		Entry(nil, common.QwenModelName, common.ModeRandom),
 	)
 
+	It("Should send length finish_reason chunk in chat completions streaming", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient, params := getOpenAIClientAndChatParams(client, common.TestModelName, testUserMessage, true)
+		params.MaxTokens = param.NewOpt(int64(1))
+		stream := openaiclient.Chat.Completions.NewStreaming(ctx, params)
+		defer func() {
+			err := stream.Close()
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		var finishReason string
+		for stream.Next() {
+			for _, choice := range stream.Current().Choices {
+				if choice.FinishReason != "" {
+					finishReason = choice.FinishReason
+				}
+			}
+		}
+		Expect(stream.Err()).NotTo(HaveOccurred())
+		Expect(finishReason).To(Equal(common.LengthFinishReason))
+	})
+
+	It("Should send length finish_reason chunk in text completions streaming", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient, params := getOpenAIClentAndCompletionParams(client, common.TestModelName, testUserMessage, true)
+		params.MaxTokens = param.NewOpt(int64(1))
+		stream := openaiclient.Completions.NewStreaming(ctx, params)
+		defer func() {
+			err := stream.Close()
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		var finishReason string
+		for stream.Next() {
+			for _, choice := range stream.Current().Choices {
+				if choice.FinishReason != "" {
+					finishReason = string(choice.FinishReason)
+				}
+			}
+		}
+		Expect(stream.Err()).NotTo(HaveOccurred())
+		Expect(finishReason).To(Equal(common.LengthFinishReason))
+	})
+
 	DescribeTable("chat completions",
 		func(model string, mode string, maxTokens int, maxCompletionTokens int) {
 			ctx := context.TODO()
@@ -3184,10 +3234,75 @@ var _ = Describe("Simulator", func() {
 			Expect(finishChunk).NotTo(BeNil(), "should have received a chunk with finish_reason")
 			Expect(finishChunk.RequestID).NotTo(BeEmpty())
 			Expect(*finishChunk.Choices[0].FinishReason).NotTo(BeEmpty())
+			Expect(finishChunk.Choices[0].TokenIDs).NotTo(BeNil(), "finish_reason must be in the last token chunk, not a separate empty chunk")
 			Expect(finishChunk.Usage).To(BeNil(), "finish chunk should not carry usage")
 
 			Expect(usageChunk).To(BeNil(), "should not receive usage chunk without stream_options.include_usage")
 
+			Expect(gotDone).To(BeTrue(), "stream should end with [DONE]")
+		})
+
+		It("Should send length finish_reason in last token chunk for generate streaming", func() {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			// max_tokens: 1 forces length finish reason
+			reqBody := fmt.Sprintf(`{
+				"model": "%s",
+				"token_ids": [1, 2, 3, 4],
+				"sampling_params": {"max_tokens": 1},
+				"stream": true
+			}`, common.TestModelName)
+
+			resp, err := client.Post("http://localhost/inference/v1/generate", "application/json", strings.NewReader(reqBody))
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				err := resp.Body.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			reader := bufio.NewReader(resp.Body)
+			var lastTokenChunk *openaiserverapi.GenerateStreamResponse
+			gotDone := false
+
+			for {
+				line, err := reader.ReadString('\n')
+				if err == io.EOF {
+					break
+				}
+				Expect(err).NotTo(HaveOccurred())
+
+				if !strings.HasPrefix(line, "data: ") {
+					continue
+				}
+				data := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+				if data == openaiserverapi.SSEDoneMarker {
+					gotDone = true
+					break
+				}
+
+				var streamResp openaiserverapi.GenerateStreamResponse
+				Expect(json.Unmarshal([]byte(data), &streamResp)).To(Succeed(), "failed to parse SSE chunk: %s", data)
+				if len(streamResp.Choices) == 0 {
+					continue
+				}
+				choice := streamResp.Choices[0]
+				if choice.TokenIDs != nil {
+					lastTokenChunk = &streamResp
+				}
+				// finish_reason must never appear in a separate empty chunk
+				if choice.FinishReason != nil {
+					Expect(choice.TokenIDs).NotTo(BeNil(), "finish_reason must be carried by a token chunk, not a separate empty chunk")
+				}
+			}
+
+			Expect(lastTokenChunk).NotTo(BeNil(), "should have received at least one token chunk")
+			Expect(lastTokenChunk.Choices[0].FinishReason).NotTo(BeNil(), "last token chunk should carry finish_reason")
+			Expect(*lastTokenChunk.Choices[0].FinishReason).To(Equal(common.LengthFinishReason))
 			Expect(gotDone).To(BeTrue(), "stream should end with [DONE]")
 		})
 


### PR DESCRIPTION

For /inference/v1/generate streaming, the finish reason is now bundled
with the last tokens chunk rather than emitted in a separate empty chunk.

For chat and text completions streaming, createLastChunk previously only
emitted a trailing finish-reason chunk for "stop". It now does so for all
finish reasons except tool_calls (already carried by the last tool-call
token chunk via sendStreamedTools) and cache_threshold (already handled
by the dedicated branch in emitResponseChunks).

Also fixes a bug where tool-call ResponseInfo took the address of a range
variable (&tc), causing all iterations to point to the same memory.
