### PR TITLE
fix(kind-deploy): drop -t flag from container exec for non-interactive shells

### DIFF
--- a/kind-deploy.sh
+++ b/kind-deploy.sh
@@ -81,7 +81,7 @@ set -x
 
 # Hotfix for https://github.com/kubernetes-sigs/kind/issues/3880
 CONTAINER_NAME="${CLUSTER_NAME}-control-plane"
-${CONTAINER_RUNTIME} exec -it ${CONTAINER_NAME} /bin/bash -c "sysctl net.ipv4.conf.all.arp_ignore=0"
+${CONTAINER_RUNTIME} exec ${CONTAINER_NAME} /bin/bash -c "sysctl net.ipv4.conf.all.arp_ignore=0"
 
 # Wait for all pods to be ready
 kubectl --context ${KUBE_CONTEXT} -n kube-system wait --for=condition=Ready --all pods --timeout=600s


### PR DESCRIPTION
## What

Drops the `-t` (TTY) flag from the `${CONTAINER_RUNTIME} exec -it` line at `kind-deploy.sh:84`.

```diff
- ${CONTAINER_RUNTIME} exec -it ${CONTAINER_NAME} /bin/bash -c "sysctl net.ipv4.conf.all.arp_ignore=0"
+ ${CONTAINER_RUNTIME} exec -i  ${CONTAINER_NAME} /bin/bash -c "sysctl net.ipv4.conf.all.arp_ignore=0"
```

## Why

The line is the hotfix for [kind#3880](https://github.com/kubernetes-sigs/kind/issues/3880). It runs as part of `make dev-env-kind`, which is meant to be runnable from any shell — including non-interactive ones (CI jobs, scripted invocations, or wrappers that buffer output).

When `make dev-env-kind` is called without a TTY attached, the `-t` flag makes `docker exec` (or `podman exec`) fail with:

```
the input device is not a TTY
make: *** [dev-env-kind] Error 1
```

…which aborts the deploy after the kind cluster has already come up, leaving a partially-stood-up environment behind.

## Reproduction

```bash
make dev-env-kind < /dev/null   # or run from any non-TTY parent process
```

Fails at the `arp_ignore` step every time on `main` (commit 6fb66f3).

## Why it's safe

`-i` keeps stdin attached, which is the only attachment this call needs — it's a one-shot, scripted `sysctl` invocation, not an interactive shell. `-t` was never doing anything useful here, since no terminal is being driven. Verified by re-running `make dev-env-kind` after the change: the `sysctl` runs successfully and the rest of the deploy completes through to a Ready `vllm-sim` pod responding on `localhost:30080`.

```
+ docker exec -i llm-d-sim-control-plane /bin/bash -c 'sysctl net.ipv4.conf.all.arp_ignore=0'
net.ipv4.conf.all.arp_ignore = 0
...
deployment.apps/vllm-sim condition met
```

## Scope

Only this one line in `kind-deploy.sh`. The other `exec -it` occurrences in `Makefile` (lines 133, 135) are inside `echo` statements that *suggest* interactive commands for the user to run themselves — those should keep `-t`.