### PR TITLE
fix: suppress expected shutdown noise in WriteToChannel and ZMQ dialer

### DIFF
--- a/pkg/common/publisher.go
+++ b/pkg/common/publisher.go
@@ -55,7 +55,10 @@ func NewPublisher(ctx context.Context, endpoint string) (*Publisher, error) {
 		// wait until the listener is ready
 		err := socket.Dial(endpoint)
 		if err != nil {
-			// This only triggers if the address format is invalid or ctx is canceled
+			// Context cancellation during shutdown is expected — don't treat it as an error.
+			if ctx.Err() != nil {
+				return
+			}
 			log.FromContext(ctx).Error(err, "ZMQ dialer exited", "endpoint", endpoint)
 		} else {
 			log.FromContext(ctx).Info("ZMQ dialer connected", "endpoint", endpoint)

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -171,14 +171,25 @@ func (r *Random) RandomNumericString(length int) string {
 type Channel[T any] struct {
 	Channel chan T
 	Name    string
+	// Done, if set, suppresses the dropped-write warning when closed (e.g. pass ctx.Done()).
+	Done <-chan struct{}
 }
 
 func WriteToChannel[T any](channel Channel[T], object T, logger logr.Logger) {
 	select {
 	case channel.Channel <- object:
+		return
 	default:
-		logger.V(logging.WARN).Info("failed to write to", "channel", channel.Name)
 	}
+	// Channel was full — only warn if we are not shutting down.
+	if channel.Done != nil {
+		select {
+		case <-channel.Done:
+			return
+		default:
+		}
+	}
+	logger.V(logging.WARN).Info("failed to write to", "channel", channel.Name)
 }
 
 // MaxIntSlice receives a slice of ints, returns the maximum value in the slice if not empty,

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -418,6 +418,7 @@ func (c *Communication) sendStream(ctx *fasthttp.RequestCtx, channel common.Chan
 
 			ok, stop := c.emitResponseChunks(ctx, w, respBuilder, response, respCtx, &state, response.Status == vllmsim.ResponseEndOfTokens)
 			if !ok {
+				go drainResponseChannel(channel)
 				return
 			}
 			if stop {

--- a/pkg/llm-d-inference-sim/context.go
+++ b/pkg/llm-d-inference-sim/context.go
@@ -162,6 +162,7 @@ func (s *SimContext) initialize(ctx context.Context) error {
 	s.loras.loraRemovable = common.Channel[int]{
 		Channel: make(chan int, s.Config().MaxNumSeqs),
 		Name:    "loraRemovable",
+		Done:    ctx.Done(),
 	}
 
 	// initialize prometheus metrics

--- a/pkg/llm-d-inference-sim/metrics.go
+++ b/pkg/llm-d-inference-sim/metrics.go
@@ -177,6 +177,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.lorasChan = common.Channel[loraUsage]{
 		Channel: make(chan loraUsage, maxNumberOfRequests),
 		Name:    "metrics.lorasChan",
+		Done:    ctx.Done(),
 	}
 	go s.lorasUpdater(ctx)
 
@@ -197,6 +198,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.runReqChan = common.Channel[common.MetricInfo]{
 		Channel: make(chan common.MetricInfo, maxNumberOfRequests),
 		Name:    "metrics.runReqChan",
+		Done:    ctx.Done(),
 	}
 	go s.runningRequestsUpdater(ctx)
 
@@ -217,6 +219,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.waitingReqChan = common.Channel[common.MetricInfo]{
 		Channel: make(chan common.MetricInfo, maxNumberOfRequests),
 		Name:    "metrics.waitingReqChan",
+		Done:    ctx.Done(),
 	}
 	go s.waitingRequestsUpdater(ctx)
 
@@ -227,6 +230,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.ttftChan = common.Channel[float64]{
 		Channel: make(chan float64, maxNumberOfRequests),
 		Name:    "metrics.ttftChan",
+		Done:    ctx.Done(),
 	}
 	go s.ttftUpdater(ctx)
 
@@ -237,6 +241,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.tpotChan = common.Channel[float64]{
 		Channel: make(chan float64, maxNumberOfRequests*s.Config().MaxModelLen),
 		Name:    "metrics.tpotChan",
+		Done:    ctx.Done(),
 	}
 	go s.tpotUpdater(ctx)
 
@@ -247,6 +252,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.e2eReqLatencyChan = common.Channel[float64]{
 		Channel: make(chan float64, maxNumberOfRequests),
 		Name:    "metrics.e2eReqLatencyChan",
+		Done:    ctx.Done(),
 	}
 	go s.e2eReqLatencyUpdater(ctx)
 
@@ -257,6 +263,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.reqQueueTimeChan = common.Channel[float64]{
 		Channel: make(chan float64, maxNumberOfRequests),
 		Name:    "metrics.reqQueueTimeChan",
+		Done:    ctx.Done(),
 	}
 	go s.reqQueueTimeUpdater(ctx)
 
@@ -267,6 +274,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.reqInferenceTimeChan = common.Channel[float64]{
 		Channel: make(chan float64, maxNumberOfRequests),
 		Name:    "metrics.reqInferenceTimeChan",
+		Done:    ctx.Done(),
 	}
 	go s.reqInferenceTimeUpdater(ctx)
 
@@ -277,6 +285,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.reqPrefillTimeChan = common.Channel[float64]{
 		Channel: make(chan float64, maxNumberOfRequests),
 		Name:    "metrics.reqPrefillTimeChan",
+		Done:    ctx.Done(),
 	}
 	go s.reqPrefillTimeUpdater(ctx)
 
@@ -287,6 +296,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.reqDecodeTimeChan = common.Channel[float64]{
 		Channel: make(chan float64, maxNumberOfRequests),
 		Name:    "metrics.reqDecodeTimeChan",
+		Done:    ctx.Done(),
 	}
 	go s.reqDecodeTimeUpdater(ctx)
 
@@ -307,6 +317,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.kvCacheUsageChan = common.Channel[common.MetricInfo]{
 		Channel: make(chan common.MetricInfo, maxNumberOfRequests),
 		Name:    "metrics.kvCacheUsageChan",
+		Done:    ctx.Done(),
 	}
 	go s.kvCacheUsageUpdater(ctx)
 
@@ -321,6 +332,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.prefixCacheStatsChan = common.Channel[kvcache.PrefixCacheStats]{
 		Channel: make(chan kvcache.PrefixCacheStats, maxNumberOfRequests),
 		Name:    "metrics.prefixCacheStatsChan",
+		Done:    ctx.Done(),
 	}
 	go s.prefixCacheStatsUpdater(ctx)
 
@@ -355,6 +367,7 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	s.metrics.requestSuccessChan = common.Channel[requestSuccessEvent]{
 		Channel: make(chan requestSuccessEvent, maxNumberOfRequests),
 		Name:    "metrics.requestSuccessChan",
+		Done:    ctx.Done(),
 	}
 	go s.recordRequestUpdater(ctx)
 

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -172,6 +172,7 @@ func (s *VllmSimulator) InitializeSim(ctx context.Context) error {
 	s.newRequests = common.Channel[requestContext]{
 		Channel: make(chan requestContext, maxNumberOfRequests),
 		Name:    "newRequests",
+		Done:    drainCtx.Done(),
 	}
 
 	// run request processing workers
@@ -186,6 +187,7 @@ func (s *VllmSimulator) InitializeSim(ctx context.Context) error {
 			reqChan: common.Channel[requestContext]{
 				Channel: make(chan requestContext, 1),
 				Name:    "worker's reqChan",
+				Done:    drainCtx.Done(),
 			},
 			processor: s,
 		}


### PR DESCRIPTION
Fixes intermittent "failed to write to <channel>" warnings and
"ZMQ dialer exited" errors that appeared during test teardown.

Both were caused by the same pattern: a goroutine racing to log an
error after the drain context was already cancelled.

- Add `Done <-chan struct{}` to `Channel[T]`. `WriteToChannel` now
  silently drops writes (no warning) when the channel is full and
  `Done` is already closed. Wire `ctx.Done()` into all 16 internal
  simulator channels (metrics, workers, loras, newRequests).
- Fix `sendStream` to launch `go drainResponseChannel` when writing
  to the client fails, so in-flight workers don't fill the response
  channel and trigger spurious warnings.
- In `NewPublisher`, return silently from the dial goroutine when
  `ctx.Err() != nil`; the "operation was canceled" error is expected
  on shutdown and should not be logged at error level.
