### PR TITLE
feat: add kwargs_data to multimodal render features and bump vLLM render image to v0.21.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ZMQ_IMG ?= $(IMAGE_REGISTRY)/$(ZMQ_IMAGE_NAME):$(ZMQ_IMAGE_TAG)
 CONTAINER_TOOL := $(shell { command -v docker >/dev/null 2>&1 && echo docker; } || { command -v podman >/dev/null 2>&1 && echo podman; } || echo "")
 BUILDER := $(shell command -v buildah >/dev/null 2>&1 && echo buildah || echo $(CONTAINER_TOOL))
 
-VLLM_RENDER_IMAGE ?= vllm/vllm-openai-cpu:v0.19.1
+VLLM_RENDER_IMAGE ?= vllm/vllm-openai-cpu:v0.21.0
 RENDER_PORT ?= 8082
 
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To run the vLLM simulator in a standalone test environment with a real model:
 1. Start the vLLM render server (requires a container engine, e.g. Docker or Podman):
    ```bash
    docker run --rm -p 8082:8082 --entrypoint vllm \
-     vllm/vllm-openai-cpu:v0.19.1 launch render Qwen/Qwen2.5-0.5B-Instruct --port=8082
+     vllm/vllm-openai-cpu:v0.21.0 launch render Qwen/Qwen2.5-0.5B-Instruct --port=8082
    ```
    Alternatively, use the `run-render` Makefile target, which runs the same container via your configured container engine (Docker or Podman):
    ```bash

--- a/docs/dataset_tool.md
+++ b/docs/dataset_tool.md
@@ -5,7 +5,7 @@ The `ds-tool` is used to convert conversation datasets into the format required 
 This tool requires a **vLLM render server**, which handles tokenization over HTTP. Start it with Docker before running the tool:
 
 ```bash
-docker run --rm -p 8082:8082 vllm/vllm-openai-cpu:v0.19.1 \
+docker run --rm -p 8082:8082 vllm/vllm-openai-cpu:v0.21.0 \
   vllm launch render <model> --port=8082
 ```
 

--- a/helm/llm-d-inference-sim/values.yaml
+++ b/helm/llm-d-inference-sim/values.yaml
@@ -93,7 +93,7 @@ tolerations: []
 affinity: {}
 
 vllmRender:
-  image: vllm/vllm-openai-cpu:v0.19.1
+  image: vllm/vllm-openai-cpu:v0.21.0
   imagePullPolicy: IfNotPresent
   port: 8082
 

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
       # the simulator will not start until this container's readinessProbe passes
       - name: vllm-render
-        image: vllm/vllm-openai-cpu:v0.19.1
+        image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]

--- a/manifests/deployment_kvcache.yaml
+++ b/manifests/deployment_kvcache.yaml
@@ -17,7 +17,7 @@ spec:
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
       # vllm-sim will not start until this container's readinessProbe passes
       - name: vllm-render
-        image: vllm/vllm-openai-cpu:v0.19.1
+        image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]

--- a/manifests/disaggregation/vllm-sim-pd.yaml
+++ b/manifests/disaggregation/vllm-sim-pd.yaml
@@ -19,7 +19,7 @@ spec:
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
       # vllm-prefill will not start until this container's readinessProbe passes
       - name: vllm-render
-        image: vllm/vllm-openai-cpu:v0.19.1
+        image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]
@@ -74,7 +74,7 @@ spec:
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
       # vllm-decode will not start until this container's readinessProbe passes
       - name: vllm-render
-        image: vllm/vllm-openai-cpu:v0.19.1
+        image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]

--- a/manifests/zmq-listener/deploy_simulator.yaml
+++ b/manifests/zmq-listener/deploy_simulator.yaml
@@ -19,7 +19,7 @@ spec:
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
       # sim will not start until this container's readinessProbe passes
       - name: vllm-render
-        image: vllm/vllm-openai-cpu:v0.19.1
+        image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
         restartPolicy: Always
         command: ["vllm"]

--- a/pkg/kv-cache/kv_cache.go
+++ b/pkg/kv-cache/kv_cache.go
@@ -98,11 +98,11 @@ func (h *KVCacheHelper) OnRequestStart(req openaiserverapi.Request) (PrefixCache
 
 	// compute per-block extra features from multimodal metadata (if present).
 	var extraFeatures []*kvblock.BlockExtraFeatures
-	mmFeatres := req.MMFeatures()
+	mmFeatures := req.MMFeatures()
 
-	if mmFeatres != nil {
+	if mmFeatures != nil {
 		extraFeatures = kvblock.ComputeBlockExtraFeatures(
-			mmFeatres.MMHashes, h.convertMMPlaceholders(mmFeatres.MMPlaceholders),
+			mmFeatures.MMHashes, h.convertMMPlaceholders(mmFeatures.MMPlaceholders),
 			h.blockSize, len(tokens))
 	}
 

--- a/pkg/openai-server-api/render.go
+++ b/pkg/openai-server-api/render.go
@@ -95,6 +95,7 @@ type RenderResponse struct {
 type RenderMMFeatures struct {
 	MMHashes       map[string][]string            `json:"mm_hashes"`
 	MMPlaceholders map[string][]RenderPlaceholder `json:"mm_placeholders"`
+	KwargsData     map[string][]string            `json:"kwargs_data,omitempty"`
 }
 
 type RenderPlaceholder struct {

--- a/pkg/tests/http_server_test.go
+++ b/pkg/tests/http_server_test.go
@@ -223,7 +223,8 @@ var _ = Describe("Server", func() {
 			common.TestModelName, "/v1/chat/completions/render",
 			fmt.Sprintf(`{"model":"%s","messages":[{"role":"user","content":[`+
 				`{"type":"text","text":"describe this"},`+
-				`{"type":"image_url","image_url":{"url":"http://example.com/a.png"}}`+
+				`{"type":"image_url","image_url":{"url":"http://example.com/a.png"}},`+
+				`{"type":"image_url","image_url":{"url":"http://example.com/b.png"}}`+
 				`]}]}`, common.TestModelName),
 			func(body []byte) {
 				var resp openaiserverapi.RenderResponse
@@ -231,9 +232,11 @@ var _ = Describe("Server", func() {
 				Expect(resp.TokenIDs).NotTo(BeEmpty())
 				Expect(resp.Features).NotTo(BeNil())
 				Expect(resp.Features.MMHashes).To(HaveKey("image"))
-				Expect(resp.Features.MMHashes["image"]).To(HaveLen(1))
+				Expect(resp.Features.MMHashes["image"]).To(HaveLen(2))
 				Expect(resp.Features.MMPlaceholders).To(HaveKey("image"))
-				Expect(resp.Features.MMPlaceholders["image"]).To(HaveLen(1))
+				Expect(resp.Features.MMPlaceholders["image"]).To(HaveLen(2))
+				Expect(resp.Features.KwargsData).To(HaveKey("image"))
+				Expect(resp.Features.KwargsData["image"]).To(HaveLen(2))
 			}),
 		Entry("proxy /v1/completions/render to the upstream renderer (HF model)",
 			common.QwenModelName, "/v1/completions/render",
@@ -256,19 +259,25 @@ var _ = Describe("Server", func() {
 			}),
 		Entry("proxy /v1/chat/completions/render with image_url returns mm features (HF model)",
 			common.QwenModelName, "/v1/chat/completions/render",
-			// 1x1 transparent PNG inlined as a data URL — keeps the test
+			// Two minimal 1x1 RGB PNGs inlined as data URLs — keeps the test
 			// hermetic (no outbound fetch) and small enough to embed.
+			// Pixel values: [0,255,0,0] (red) and [0,0,0,255] (blue).
 			fmt.Sprintf(`{"model":"%s","messages":[{"role":"user","content":[`+
 				`{"type":"text","text":"describe this"},`+
-				`{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="}}`+
+				`{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"}},`+
+				`{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC"}}`+
 				`]}]}`, common.QwenModelName),
 			func(body []byte) {
 				var resp openaiserverapi.RenderResponse
 				Expect(json.Unmarshal(body, &resp)).To(Succeed())
 				Expect(resp.TokenIDs).NotTo(BeEmpty())
 				Expect(resp.Features).NotTo(BeNil())
-				Expect(resp.Features.MMHashes).NotTo(BeEmpty())
-				Expect(resp.Features.MMPlaceholders).NotTo(BeEmpty())
+				Expect(resp.Features.MMHashes).To(HaveKey("image"))
+				Expect(resp.Features.MMHashes["image"]).To(HaveLen(2))
+				Expect(resp.Features.MMPlaceholders).To(HaveKey("image"))
+				Expect(resp.Features.MMPlaceholders["image"]).To(HaveLen(2))
+				Expect(resp.Features.KwargsData).To(HaveKey("image"))
+				Expect(resp.Features.KwargsData["image"]).To(HaveLen(2))
 			}),
 	)
 

--- a/pkg/tests/test_utils_test.go
+++ b/pkg/tests/test_utils_test.go
@@ -142,7 +142,7 @@ func startServerHelper(ctx context.Context, mode string, args []string, envs map
 		}
 	} else {
 		// Use test tokenizers for normal test cases
-		gomega.Expect(config.Model).To(gomega.BeElementOf(common.TestModelName, common.QwenModelName, common.QwenModelName))
+		gomega.Expect(config.Model).To(gomega.BeElementOf(common.TestModelName, common.QwenModelName))
 		switch config.Model {
 		case common.TestModelName:
 			s.Context.Tokenizer = tokenizerMngr.TestTokenizer()

--- a/pkg/tokenizer/test_utils.go
+++ b/pkg/tokenizer/test_utils.go
@@ -101,7 +101,7 @@ func (tm *TokenizerManager) Clean() {
 // returns the HTTP base URL (http://host:port), cleanup function and error
 func (tm *TokenizerManager) startRenderContainer(ctx context.Context, model string) (string, func(), error) {
 	container, err := testcontainers.Run(ctx,
-		"vllm/vllm-openai-cpu:v0.19.1",
+		"vllm/vllm-openai-cpu:v0.21.0",
 		testcontainers.WithExposedPorts("8000/tcp"),
 		testcontainers.WithEntrypoint("vllm"),
 		testcontainers.WithCmd("launch", "render", model, "--port=8000"),

--- a/pkg/tokenizer/tokenizer.go
+++ b/pkg/tokenizer/tokenizer.go
@@ -18,6 +18,7 @@ package tokenizer
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"hash/fnv"
 	"regexp"
@@ -164,11 +165,15 @@ func stubMMFeaturesForMessages(messages []openaiserverapi.Message, totalTokens i
 	span := max(totalTokens/len(items), 1)
 	mmHashes := map[string][]string{}
 	mmPlaceholders := map[string][]openaiserverapi.RenderPlaceholder{}
+	mmKwargsData := map[string][]string{}
 
 	for i, it := range items {
 		// Deterministic so repeats hit cache.
 		hash := fmt.Sprintf("sim_%s_%d_%x", it.prefix, it.modalIndex, fnv32(it.identifier))
 		mmHashes[it.modality] = append(mmHashes[it.modality], hash)
+
+		kwarg := base64.StdEncoding.EncodeToString([]byte(hash))
+		mmKwargsData[it.modality] = append(mmKwargsData[it.modality], kwarg)
 
 		offset := i * span
 		if offset >= totalTokens {
@@ -190,6 +195,7 @@ func stubMMFeaturesForMessages(messages []openaiserverapi.Message, totalTokens i
 	return &openaiserverapi.RenderMMFeatures{
 		MMHashes:       mmHashes,
 		MMPlaceholders: mmPlaceholders,
+		KwargsData:     mmKwargsData,
 	}
 }
 

--- a/pkg/tokenizer/tokenizer_test.go
+++ b/pkg/tokenizer/tokenizer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tokenizer
 
 import (
+	"encoding/base64"
 	"strings"
 
 	openaiserverapi "github.com/llm-d/llm-d-inference-sim/pkg/openai-server-api"
@@ -70,6 +71,33 @@ var _ = Describe("tokenizer", func() {
 		tokens, _, _, err := tokenizerMngr.RealTokenizer().RenderMessages(messages)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(tokens).NotTo(BeEmpty())
+	})
+
+	It("should return kwargs_data for multimodal messages via test tokenizer", func() {
+		mmMessages := []openaiserverapi.Message{
+			{Role: openaiserverapi.RoleUser, Content: openaiserverapi.ChatComplContent{
+				Structured: []openaiserverapi.ChatComplContentBlock{
+					{Type: "image_url", ImageURL: openaiserverapi.ChatComplImageBlock{Url: "http://x/a.jpg"}},
+				},
+			}},
+		}
+		_, _, features, err := tokenizerMngr.TestTokenizer().RenderMessages(mmMessages)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(features).NotTo(BeNil())
+		Expect(features.KwargsData).To(HaveKey(mmModalityImage))
+		Expect(features.KwargsData[mmModalityImage]).To(HaveLen(1))
+		_, decodeErr := base64.StdEncoding.DecodeString(features.KwargsData[mmModalityImage][0])
+		Expect(decodeErr).NotTo(HaveOccurred())
+	})
+
+	It("should return nil kwargs_data for text-only messages via real tokenizer", func() {
+		tokens, _, features, err := tokenizerMngr.RealTokenizer().RenderMessages(messages)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tokens).NotTo(BeEmpty())
+		// text-only messages carry no MM features
+		if features != nil {
+			Expect(features.KwargsData).To(BeEmpty())
+		}
 	})
 
 	Describe("stubMMFeaturesForMessages", func() {
@@ -157,6 +185,36 @@ var _ = Describe("tokenizer", func() {
 			wav := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(audio("samebytes", "wav"))}, 100)
 			mp3 := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(audio("samebytes", "mp3"))}, 100)
 			Expect(wav.MMHashes[mmModalityAudio]).To(Equal(mp3.MMHashes[mmModalityAudio]))
+		})
+
+		It("emits kwargs_data as valid base64 per modality for a single image", func() {
+			feats := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(image("http://x/a.jpg"))}, 100)
+			Expect(feats).NotTo(BeNil())
+			Expect(feats.KwargsData).To(HaveKey(mmModalityImage))
+			Expect(feats.KwargsData[mmModalityImage]).To(HaveLen(1))
+			_, err := base64.StdEncoding.DecodeString(feats.KwargsData[mmModalityImage][0])
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("emits kwargs_data for all modalities in mixed content, each entry valid base64", func() {
+			feats := stubMMFeaturesForMessages([]openaiserverapi.Message{mkMsg(
+				image("http://x/a.jpg"), audio("data", "wav"), video("http://x/v.mp4"),
+			)}, 120)
+			Expect(feats).NotTo(BeNil())
+			for _, mod := range []string{mmModalityImage, mmModalityAudio, mmModalityVideo} {
+				Expect(feats.KwargsData).To(HaveKey(mod))
+				for _, s := range feats.KwargsData[mod] {
+					_, err := base64.StdEncoding.DecodeString(s)
+					Expect(err).NotTo(HaveOccurred(), "kwargs_data[%s] entry is not valid base64", mod)
+				}
+			}
+		})
+
+		It("produces deterministic kwargs_data for identical input", func() {
+			msgs := []openaiserverapi.Message{mkMsg(image("http://x/a.jpg"), audio("data", "wav"))}
+			a := stubMMFeaturesForMessages(msgs, 100)
+			b := stubMMFeaturesForMessages(msgs, 100)
+			Expect(a.KwargsData).To(Equal(b.KwargsData))
 		})
 	})
 


### PR DESCRIPTION
- Added kwargs_data field to RenderMMFeatures, surfacing the kwargs_data vLLM returns for multimodal inputs.

- SimpleTokenizer  populates kwargs_data with deterministic base64-encoded stub values per modality, keeping it consistent with MMHashes and MMPlaceholders

- Bumped the vLLM render sidecar image from v0.19.1 → v0.21.0 everywhere (Makefile, manifests, Helm values, README, test container)
