### PR TITLE
feat: add Anthropic /v1/messages endpoint

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -49,6 +49,9 @@ const (
 	RemoteDecodeFinishReason   = "remote_decode"
 	CacheThresholdFinishReason = "cache_threshold"
 
+	ChatCmplToolIDPrefix = "chatcmpl-tool-"
+	MessagesToolIDPrefix = "toolu_"
+
 	podIPEnv = "POD_IP"
 
 	DefaultLatencyCalculator        = ""

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -68,6 +68,7 @@ func (c *Communication) startHTTPServer(listener net.Listener) (*fasthttp.Server
 	r.POST("/v1/chat/completions/render", c.HandleChatCompletionsRender)
 	r.POST("/v1/completions/render", c.HandleTextCompletionsRender)
 	r.POST("/v1/responses", c.HandleResponses)
+	r.POST("/v1/messages", c.HandleMessages)
 	r.POST("/inference/v1/generate", c.HandleGenerate)
 	if !c.simulator.Context.Config().MMEncoderOnly {
 		r.POST("/v1/embeddings", c.HandleEmbeddings)
@@ -146,6 +147,11 @@ func (c *Communication) HandleTextCompletions(ctx *fasthttp.RequestCtx) {
 // HandleResponses http handler for /v1/responses
 func (c *Communication) HandleResponses(ctx *fasthttp.RequestCtx) {
 	c.handleHTTP(&vllmsim.ResponsesRequest{}, &responsesHTTPRespBuilder{}, ctx)
+}
+
+// HandleMessages http handler for /v1/messages (Anthropic Messages API)
+func (c *Communication) HandleMessages(ctx *fasthttp.RequestCtx) {
+	c.handleHTTP(&vllmsim.MessagesRequest{}, &messagesHTTPRespBuilder{}, ctx)
 }
 
 // HandleGenerate http handler for /inference/v1/generate

--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -691,3 +691,201 @@ func (*generateHTTPRespBuilder) createRenderResponse(_ [][]uint32,
 }
 
 var _ responseBuilder = (*generateHTTPRespBuilder)(nil)
+
+// messagesHTTPRespBuilder implements responseBuilder for /v1/messages (Anthropic Messages API).
+type messagesHTTPRespBuilder struct {
+	contentBlockIndex int  // tracks which content block index we are on for streaming
+	inToolMode        bool // true when streaming tool call arguments
+}
+
+func (b *messagesHTTPRespBuilder) stopReason(finishReason string) string {
+	switch finishReason {
+	case common.ToolsFinishReason:
+		return openaiserverapi.MessagesStopReasonToolUse
+	case common.LengthFinishReason, common.CacheThresholdFinishReason:
+		return openaiserverapi.MessagesStopReasonMaxTokens
+	default:
+		return openaiserverapi.MessagesStopReasonEndTurn
+	}
+}
+
+func (b *messagesHTTPRespBuilder) createResponse(respCtxPerChoice []vllmsim.ResponseContext,
+	tokens []openaiserverapi.Tokenized) any {
+	respCtx := respCtxPerChoice[0]
+	usage := respCtx.UsageData()
+	finishReason := ""
+	if respCtx.FinishReason() != nil {
+		finishReason = *respCtx.FinishReason()
+	}
+
+	var content []openaiserverapi.MessagesContentBlock
+	if toolCalls := respCtx.ToolCalls(); len(toolCalls) > 0 {
+		for _, tc := range toolCalls {
+			var input map[string]any
+			if tc.Function.Arguments != "" {
+				_ = json.Unmarshal([]byte(tc.Function.Arguments), &input)
+			}
+			if input == nil {
+				input = map[string]any{}
+			}
+			name := ""
+			if tc.Function.Name != nil {
+				name = *tc.Function.Name
+			}
+			content = append(content, openaiserverapi.MessagesContentBlock{
+				Type:  "tool_use",
+				ID:    tc.ID,
+				Name:  name,
+				Input: input,
+			})
+		}
+	} else {
+		text := strings.Join(tokens[0].Strings, "")
+		content = []openaiserverapi.MessagesContentBlock{{Type: "text", Text: text}}
+	}
+
+	return openaiserverapi.CreateMessagesResponse(
+		respCtx.DisplayModel(),
+		respCtx.RequestID(),
+		b.stopReason(finishReason),
+		content,
+		openaiserverapi.MessagesUsage{
+			InputTokens:  usage.PromptTokens,
+			OutputTokens: usage.CompletionTokens,
+		},
+	)
+}
+
+func (b *messagesHTTPRespBuilder) createUsageChunk(_ []vllmsim.ResponseContext) sseChunk {
+	return nil // usage is delivered in the message_delta streaming event
+}
+
+func (b *messagesHTTPRespBuilder) createInitialChunk(respCtx vllmsim.ResponseContext) sseChunk {
+	msg := openaiserverapi.CreateMessagesStreamStartMessage(
+		respCtx.DisplayModel(),
+		respCtx.RequestID(),
+		respCtx.UsageData().PromptTokens,
+	)
+	return &namedEventChunk{
+		names: []string{openaiserverapi.MessagesEventMessageStart},
+		data:  []any{openaiserverapi.MessagesMessageStartEvent{Type: openaiserverapi.MessagesEventMessageStart, Message: msg}},
+	}
+}
+
+func (b *messagesHTTPRespBuilder) createFirstChunk(respCtx vllmsim.ResponseContext, _ int) sseChunk {
+	b.inToolMode = len(respCtx.ToolCalls()) > 0
+	ping := openaiserverapi.MessagesPingEvent{Type: openaiserverapi.MessagesEventPing}
+
+	if b.inToolMode {
+		// content_block_start for tool blocks is emitted in createChunk when the
+		// first argument token arrives (signalled by tool.Function.Name != nil).
+		return &namedEventChunk{
+			names: []string{openaiserverapi.MessagesEventPing},
+			data:  []any{ping},
+		}
+	}
+
+	blockStart := openaiserverapi.MessagesContentBlockStartEvent{
+		Type:         openaiserverapi.MessagesEventContentBlockStart,
+		Index:        0,
+		ContentBlock: openaiserverapi.MessagesContentBlock{Type: "text", Text: ""},
+	}
+	return &namedEventChunk{
+		names: []string{openaiserverapi.MessagesEventContentBlockStart, openaiserverapi.MessagesEventPing},
+		data:  []any{blockStart, ping},
+	}
+}
+
+func (b *messagesHTTPRespBuilder) createChunk(_ vllmsim.ResponseContext, tokens *openaiserverapi.Tokenized,
+	tool *openaiserverapi.ToolCall, _ string, _ *string, _ int) sseChunk {
+
+	if tool != nil {
+		var names []string
+		var data []any
+
+		// tool.Function.Name != nil on the first argument token of a new tool call.
+		if tool.Function.Name != nil {
+			// Stop the previous block if this is not the first tool call.
+			if b.contentBlockIndex > 0 {
+				stop := openaiserverapi.MessagesContentBlockStopEvent{
+					Type:  openaiserverapi.MessagesEventContentBlockStop,
+					Index: b.contentBlockIndex - 1,
+				}
+				names = append(names, stop.Type)
+				data = append(data, stop)
+			}
+			blockStart := openaiserverapi.MessagesContentBlockStartEvent{
+				Type:  openaiserverapi.MessagesEventContentBlockStart,
+				Index: b.contentBlockIndex,
+				ContentBlock: openaiserverapi.MessagesContentBlock{
+					Type:  "tool_use",
+					ID:    tool.ID,
+					Name:  *tool.Function.Name,
+					Input: map[string]any{},
+				},
+			}
+			names = append(names, blockStart.Type)
+			data = append(data, blockStart)
+			b.contentBlockIndex++
+		}
+
+		delta := openaiserverapi.MessagesContentBlockDeltaEvent{
+			Type:  openaiserverapi.MessagesEventContentBlockDelta,
+			Index: b.contentBlockIndex - 1,
+			Delta: openaiserverapi.MessagesContentBlockDelta{
+				Type:        "input_json_delta",
+				PartialJSON: tool.Function.Arguments,
+			},
+		}
+		names = append(names, delta.Type)
+		data = append(data, delta)
+		return &namedEventChunk{names: names, data: data}
+	}
+
+	if tokens == nil || len(tokens.Strings) == 0 {
+		return nil
+	}
+	text := strings.Join(tokens.Strings, "")
+	delta := openaiserverapi.MessagesContentBlockDeltaEvent{
+		Type:  openaiserverapi.MessagesEventContentBlockDelta,
+		Index: 0,
+		Delta: openaiserverapi.MessagesContentBlockDelta{Type: "text_delta", Text: text},
+	}
+	return &namedEventChunk{
+		names: []string{openaiserverapi.MessagesEventContentBlockDelta},
+		data:  []any{delta},
+	}
+}
+
+func (b *messagesHTTPRespBuilder) createLastChunk(respCtx vllmsim.ResponseContext, finishReason string, _ int) sseChunk {
+	blockIdx := 0
+	if b.inToolMode && b.contentBlockIndex > 0 {
+		blockIdx = b.contentBlockIndex - 1
+	}
+	sr := b.stopReason(finishReason)
+
+	blockStop := openaiserverapi.MessagesContentBlockStopEvent{
+		Type:  openaiserverapi.MessagesEventContentBlockStop,
+		Index: blockIdx,
+	}
+	msgDelta := openaiserverapi.MessagesMessageDeltaEvent{
+		Type:  openaiserverapi.MessagesEventMessageDelta,
+		Delta: openaiserverapi.MessagesMessageDeltaPayload{StopReason: &sr, StopSequence: nil},
+		Usage: openaiserverapi.MessagesStreamUsage{OutputTokens: respCtx.UsageData().CompletionTokens},
+	}
+	msgStop := openaiserverapi.MessagesMessageStopEvent{Type: openaiserverapi.MessagesEventMessageStop}
+
+	return &namedEventChunk{
+		names: []string{blockStop.Type, msgDelta.Type, msgStop.Type},
+		data:  []any{blockStop, msgDelta, msgStop},
+	}
+}
+
+func (*messagesHTTPRespBuilder) createDoneChunk() sseChunk        { return nil }
+func (*messagesHTTPRespBuilder) sendFinishReasonWithTokens() bool { return false }
+
+func (*messagesHTTPRespBuilder) createRenderResponse(_ [][]uint32, _ *openaiserverapi.RenderMMFeatures) any {
+	panic("messagesHTTPRespBuilder: /v1/messages has no /render endpoint")
+}
+
+var _ responseBuilder = (*messagesHTTPRespBuilder)(nil)

--- a/pkg/llm-d-inference-sim/chat_completion.go
+++ b/pkg/llm-d-inference-sim/chat_completion.go
@@ -83,6 +83,7 @@ func (c *ChatCompletionsRequest) buildRequestContext(simCtx *SimContext, channel
 	reqCtx := &chatCompletionReqCtx{
 		baseRequestContext: newBaseRequestContext(simCtx, channel, choiceIdx, doneFn),
 		req:                c,
+		toolIDPrefix:       common.ChatCmplToolIDPrefix,
 	}
 	// wire chatCompletionReqCtx into embedded requestContext interface
 	reqCtx.requestContext = reqCtx
@@ -145,7 +146,8 @@ var _ Request = (*ChatCompletionsRequest)(nil)
 // Implementation of requestContext for /chat/completions requests
 type chatCompletionReqCtx struct {
 	baseRequestContext
-	req *ChatCompletionsRequest
+	req          *ChatCompletionsRequest
+	toolIDPrefix string
 }
 
 func (c *chatCompletionReqCtx) request() Request {
@@ -161,7 +163,7 @@ func (c *chatCompletionReqCtx) createToolCalls() ([]openaiserverapi.ToolCall, in
 	if !isToolChoiceNone(req.GetToolChoice()) &&
 		req.GetTools() != nil {
 		toolCalls, completionTokens, err :=
-			createToolCalls(req.GetTools(), req.GetToolChoice(), c.sim.Config(), c.sim.Random, c.sim.Tokenizer)
+			createToolCalls(req.GetTools(), req.GetToolChoice(), c.sim.Config(), c.sim.Random, c.sim.Tokenizer, c.toolIDPrefix)
 		finishReason := common.ToolsFinishReason
 		return toolCalls, completionTokens, finishReason, err
 	}

--- a/pkg/llm-d-inference-sim/messages.go
+++ b/pkg/llm-d-inference-sim/messages.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmdinferencesim
+
+import (
+	"encoding/json"
+
+	"github.com/valyala/fasthttp"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	openaiserverapi "github.com/llm-d/llm-d-inference-sim/pkg/openai-server-api"
+)
+
+// MessagesRequest handles /v1/messages (Anthropic Messages API).
+// Unmarshal parses the Anthropic wire format and converts it to the OpenAI
+// chat completions format; all processing is then delegated to the embedded
+// ChatCompletionsRequest via the existing chat completions pipeline.
+type MessagesRequest struct {
+	ChatCompletionsRequest
+	orig openaiserverapi.MessagesRequest // retains original Anthropic fields for validation
+}
+
+// Unmarshal parses the Anthropic Messages API body and converts it to a
+// ChatCompletionsRequest for the existing processing pipeline.
+func (m *MessagesRequest) Unmarshal(data []byte) error {
+	if err := json.Unmarshal(data, &m.orig); err != nil {
+		return err
+	}
+	m.ChatCompletionsRequest.ChatCompletionsRequest = *m.orig.ToChatCompletionsRequest()
+	return nil
+}
+
+// validateBlocks checks Anthropic-specific constraints that are lost after conversion:
+// image blocks require a source, and tool_choice of type "tool" requires a name.
+func (m *MessagesRequest) validateBlocks() *openaiserverapi.Error {
+	for _, msg := range m.orig.Messages {
+		for _, block := range msg.Content.Blocks {
+			if block.Type == "image" && block.Source == nil {
+				err := openaiserverapi.NewError("image content block is missing required 'source' field",
+					fasthttp.StatusBadRequest, nil)
+				return &err
+			}
+		}
+	}
+	if m.orig.ToolChoice != nil && m.orig.ToolChoice.Type == "tool" && m.orig.ToolChoice.Name == "" {
+		err := openaiserverapi.NewError("tool_choice of type 'tool' requires a non-empty 'name'",
+			fasthttp.StatusBadRequest, nil)
+		return &err
+	}
+	return nil
+}
+
+func (m *MessagesRequest) validate(tv *toolsValidator) *openaiserverapi.Error {
+	if err := m.validateBlocks(); err != nil {
+		return err
+	}
+	if len(m.Messages) == 0 {
+		err := openaiserverapi.NewError("messages must not be empty", fasthttp.StatusBadRequest, nil)
+		return &err
+	}
+	if m.GetMaxCompletionTokens() == nil {
+		err := openaiserverapi.NewError("max_tokens is required", fasthttp.StatusBadRequest, nil)
+		return &err
+	}
+	return m.ChatCompletionsRequest.validate(tv)
+}
+
+func (m *MessagesRequest) AsString() string {
+	return "messages request (req id " + m.RequestID + ")"
+}
+
+func (m *MessagesRequest) split() []Request {
+	n := m.GetN()
+	out := make([]Request, n)
+	for i := range n {
+		cp := *m
+		out[i] = &cp
+	}
+	return out
+}
+
+func (m *MessagesRequest) buildRequestContext(simCtx *SimContext, channel common.Channel[*ResponseInfo],
+	choiceIdx int, doneFn func()) requestContext {
+	reqCtx := &chatCompletionReqCtx{
+		baseRequestContext: newBaseRequestContext(simCtx, channel, choiceIdx, doneFn),
+		req:                &m.ChatCompletionsRequest,
+		toolIDPrefix:       common.MessagesToolIDPrefix,
+	}
+	reqCtx.requestContext = reqCtx
+	return reqCtx
+}
+
+var _ Request = (*MessagesRequest)(nil)

--- a/pkg/llm-d-inference-sim/tools_utils.go
+++ b/pkg/llm-d-inference-sim/tools_utils.go
@@ -117,6 +117,7 @@ func createToolCalls(
 	config *common.Configuration,
 	random *common.Random,
 	tokenizer tokenizer.Tokenizer,
+	idPrefix string,
 ) ([]openaiserverapi.ToolCall, int, error) {
 	generateCalls := func(availableTools []openaiserverapi.Tool, minCalls int) ([]openaiserverapi.ToolCall, int, error) {
 		if len(availableTools) == 0 {
@@ -163,7 +164,7 @@ func createToolCalls(
 					Arguments: string(argsJson),
 					Name:      &chosenTool.Function.Name,
 				},
-				ID:    "chatcmpl-tool-" + random.RandomNumericString(10),
+				ID:    idPrefix + random.RandomNumericString(10),
 				Type:  "function",
 				Index: i,
 			}

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -978,3 +978,322 @@ func (g *GenerateRequest) ExtractMaxTokens() *int64 {
 func (g *GenerateRequest) GetLogprobs() *int {
 	return nil
 }
+
+// Anthropic Messages API
+
+// AnthropicImageSource is the source payload for an "image" content block.
+type AnthropicImageSource struct {
+	Type      string `json:"type"`                 // "base64" or "url"
+	MediaType string `json:"media_type,omitempty"` // e.g. "image/jpeg", present for base64 sources
+	Data      string `json:"data,omitempty"`       // base64-encoded bytes, present for base64 sources
+	URL       string `json:"url,omitempty"`        // present for url sources
+}
+
+// AnthropicToolResultContent is the content field inside a "tool_result" block.
+// It can be a plain string or an array of text blocks.
+type AnthropicToolResultContent struct {
+	Raw    string
+	Blocks []AnthropicContentBlock
+}
+
+func (c *AnthropicToolResultContent) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		c.Raw = str
+		return nil
+	}
+	var blocks []AnthropicContentBlock
+	if err := json.Unmarshal(data, &blocks); err == nil {
+		c.Blocks = blocks
+		return nil
+	}
+	return errors.New("tool_result content format not supported")
+}
+
+// PlainText returns the concatenated plain text from the tool result.
+func (c *AnthropicToolResultContent) PlainText() string {
+	if c.Raw != "" {
+		return c.Raw
+	}
+	var parts []string
+	for _, b := range c.Blocks {
+		if b.Type == "text" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// AnthropicContentBlock is a single content block in an Anthropic message.
+// Fields are populated according to Type:
+//   - "text":        Text
+//   - "image":       Source
+//   - "tool_use":    ID, Name, Input
+//   - "tool_result": ToolUseID, Content
+type AnthropicContentBlock struct {
+	Type string `json:"type"`
+	// text block
+	Text string `json:"text,omitempty"`
+	// image block
+	Source *AnthropicImageSource `json:"source,omitempty"`
+	// tool_use block
+	ID    string         `json:"id,omitempty"`
+	Name  string         `json:"name,omitempty"`
+	Input map[string]any `json:"input,omitempty"`
+	// tool_result block
+	ToolUseID string                      `json:"tool_use_id,omitempty"`
+	Content   *AnthropicToolResultContent `json:"content,omitempty"`
+}
+
+// AnthropicMessageContent holds the content of an Anthropic message.
+// It can be a plain string or an array of content blocks.
+type AnthropicMessageContent struct {
+	Raw    string
+	Blocks []AnthropicContentBlock
+}
+
+func (c *AnthropicMessageContent) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		c.Raw = str
+		return nil
+	}
+	var blocks []AnthropicContentBlock
+	if err := json.Unmarshal(data, &blocks); err == nil {
+		c.Blocks = blocks
+		return nil
+	}
+	return errors.New("content format not supported")
+}
+
+func (c AnthropicMessageContent) MarshalJSON() ([]byte, error) {
+	if c.Raw != "" {
+		return json.Marshal(c.Raw)
+	}
+	if c.Blocks != nil {
+		return json.Marshal(c.Blocks)
+	}
+	return json.Marshal("")
+}
+
+// PlainText returns the concatenated text from all text blocks.
+func (c *AnthropicMessageContent) PlainText() string {
+	if c.Raw != "" {
+		return c.Raw
+	}
+	var parts []string
+	for _, block := range c.Blocks {
+		if block.Type == "text" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// AnthropicMessage is a single message in the Anthropic Messages API.
+type AnthropicMessage struct {
+	// Role is "user" or "assistant"
+	Role    string                  `json:"role"`
+	Content AnthropicMessageContent `json:"content"`
+}
+
+// PlainText returns the plain text representation of the message.
+func (m *AnthropicMessage) PlainText(includeRole bool) string {
+	var builder strings.Builder
+	if includeRole {
+		builder.WriteString(m.Role)
+		builder.WriteString(": ")
+	}
+	builder.WriteString(m.Content.PlainText())
+	return builder.String()
+}
+
+// AnthropicTool defines a tool in the Anthropic Messages API format.
+type AnthropicTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"input_schema"`
+}
+
+// AnthropicToolChoice controls which tool the model calls.
+// Type is "auto" (default), "any" (force a tool call), or "tool" (specific tool via Name).
+type AnthropicToolChoice struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"` // only for type "tool"
+}
+
+// MessagesRequest defines the structure of an Anthropic /v1/messages request.
+type MessagesRequest struct {
+	baseRequest
+	// Messages is the list of input messages (required)
+	Messages []AnthropicMessage `json:"messages"`
+	// System is the optional system prompt
+	System string `json:"system,omitempty"`
+	// MaxTokens is the maximum number of output tokens (required by the API)
+	MaxTokens *int64 `json:"max_tokens"`
+	// Tools is the list of tools available to the model
+	Tools []AnthropicTool `json:"tools,omitempty"`
+	// ToolChoice controls which tool (if any) is called
+	ToolChoice *AnthropicToolChoice `json:"tool_choice,omitempty"`
+}
+
+var _ Request = (*MessagesRequest)(nil)
+
+func (m *MessagesRequest) GetTools() []Tool {
+	return nil
+}
+
+func (m *MessagesRequest) GetToolChoice() ToolChoice {
+	return ToolChoice{}
+}
+
+func (m *MessagesRequest) GetMaxCompletionTokens() *int64 {
+	return m.MaxTokens
+}
+
+func (m *MessagesRequest) ExtractMaxTokens() *int64 {
+	return m.MaxTokens
+}
+
+func (m *MessagesRequest) GetLogprobs() *int {
+	return nil
+}
+
+// ToChatCompletionsRequest converts this Anthropic Messages request to an
+// equivalent ChatCompletionsRequest for processing by the existing pipeline.
+//
+// Mapping rules:
+//   - system prompt → leading Message{Role: "system"}
+//   - "text" block  → ChatComplContentBlock{Type: "text"}
+//   - "image" block → ChatComplContentBlock{Type: "image_url"} (base64 sources become data URLs)
+//   - "tool_use" block (assistant) → Message.ToolCalls entry
+//   - "tool_result" block (user) → separate Message{Role: "tool", ToolCallID: …}
+//   - AnthropicTool → Tool with function.parameters = input_schema
+func (m *MessagesRequest) ToChatCompletionsRequest() *ChatCompletionsRequest {
+	msgs := make([]Message, 0, len(m.Messages)+1)
+	if m.System != "" {
+		msgs = append(msgs, Message{
+			Role:    "system",
+			Content: ChatComplContent{Raw: m.System},
+		})
+	}
+
+	for _, am := range m.Messages {
+		// String-form content: emit directly.
+		if am.Content.Raw != "" {
+			msgs = append(msgs, Message{
+				Role:    am.Role,
+				Content: ChatComplContent{Raw: am.Content.Raw},
+			})
+			continue
+		}
+
+		var contentBlocks []ChatComplContentBlock
+		var toolCalls []ToolCall
+		var toolResults []AnthropicContentBlock
+
+		for _, b := range am.Content.Blocks {
+			switch b.Type {
+			case "text":
+				contentBlocks = append(contentBlocks, ChatComplContentBlock{
+					Type: "text",
+					Text: b.Text,
+				})
+			case "image":
+				if b.Source != nil {
+					var url string
+					if b.Source.Type == "base64" {
+						url = "data:" + b.Source.MediaType + ";base64," + b.Source.Data
+					} else {
+						url = b.Source.URL
+					}
+					contentBlocks = append(contentBlocks, ChatComplContentBlock{
+						Type:     "image_url",
+						ImageURL: ChatComplImageBlock{Url: url},
+					})
+				}
+			case "tool_use":
+				var args []byte
+				if b.Input != nil {
+					args, _ = json.Marshal(b.Input)
+				}
+				if len(args) == 0 {
+					args = []byte("{}")
+				}
+				name := b.Name
+				toolCalls = append(toolCalls, ToolCall{
+					ID:   b.ID,
+					Type: "function",
+					Function: FunctionCall{
+						Name:      &name,
+						Arguments: string(args),
+					},
+				})
+			case "tool_result":
+				toolResults = append(toolResults, b)
+			default:
+				// unknown block types (e.g. "document", "thinking") are skipped to
+				// allow forward compatibility with new Anthropic block types
+			}
+		}
+
+		// Emit the message itself when it carries content or tool calls.
+		if len(contentBlocks) > 0 || len(toolCalls) > 0 {
+			msg := Message{Role: am.Role, ToolCalls: toolCalls}
+			if len(contentBlocks) > 0 {
+				msg.Content = ChatComplContent{Structured: contentBlocks}
+			}
+			msgs = append(msgs, msg)
+		}
+
+		// Each tool_result block becomes a separate "tool" role message.
+		for _, tr := range toolResults {
+			var content string
+			if tr.Content != nil {
+				content = tr.Content.PlainText()
+			}
+			msgs = append(msgs, Message{
+				Role:       "tool",
+				Content:    ChatComplContent{Raw: content},
+				ToolCallID: tr.ToolUseID,
+			})
+		}
+	}
+
+	// Convert Anthropic tools to OpenAI format (input_schema → parameters).
+	var tools []Tool
+	for _, at := range m.Tools {
+		tools = append(tools, Tool{
+			Type: "function",
+			Function: function{
+				Name:        at.Name,
+				Description: at.Description,
+				Parameters:  at.InputSchema,
+			},
+		})
+	}
+
+	var toolChoice ToolChoice
+	if m.ToolChoice != nil {
+		switch m.ToolChoice.Type {
+		case "any":
+			toolChoice = NewToolChoiceRequired()
+		case "none":
+			toolChoice = NewToolChoiceNone()
+		case "tool":
+			if m.ToolChoice.Name != "" {
+				toolChoice = NewToolChoiceFunction(m.ToolChoice.Name)
+			}
+		}
+	}
+
+	return &ChatCompletionsRequest{
+		baseCompletionsRequest: baseCompletionsRequest{
+			baseRequest: m.baseRequest,
+		},
+		Messages:            msgs,
+		MaxCompletionTokens: m.MaxTokens,
+		Tools:               tools,
+		ToolChoice:          toolChoice,
+	}
+}

--- a/pkg/openai-server-api/request.go
+++ b/pkg/openai-server-api/request.go
@@ -1017,7 +1017,7 @@ func (c *AnthropicToolResultContent) PlainText() string {
 	}
 	var parts []string
 	for _, b := range c.Blocks {
-		if b.Type == "text" {
+		if b.Type == ContentTypeText {
 			parts = append(parts, b.Text)
 		}
 	}
@@ -1083,7 +1083,7 @@ func (c *AnthropicMessageContent) PlainText() string {
 	}
 	var parts []string
 	for _, block := range c.Blocks {
-		if block.Type == "text" {
+		if block.Type == ContentTypeText {
 			parts = append(parts, block.Text)
 		}
 	}
@@ -1194,9 +1194,9 @@ func (m *MessagesRequest) ToChatCompletionsRequest() *ChatCompletionsRequest {
 
 		for _, b := range am.Content.Blocks {
 			switch b.Type {
-			case "text":
+			case ContentTypeText:
 				contentBlocks = append(contentBlocks, ChatComplContentBlock{
-					Type: "text",
+					Type: ContentTypeText,
 					Text: b.Text,
 				})
 			case "image":
@@ -1262,6 +1262,9 @@ func (m *MessagesRequest) ToChatCompletionsRequest() *ChatCompletionsRequest {
 
 	// Convert Anthropic tools to OpenAI format (input_schema → parameters).
 	var tools []Tool
+	if len(m.Tools) > 0 {
+		tools = make([]Tool, 0, len(m.Tools))
+	}
 	for _, at := range m.Tools {
 		tools = append(tools, Tool{
 			Type: "function",

--- a/pkg/openai-server-api/request_test.go
+++ b/pkg/openai-server-api/request_test.go
@@ -104,6 +104,73 @@ var _ = Describe("GetN", func() {
 	})
 })
 
+var _ = Describe("Message PlainText", func() {
+	Context("role:tool message with ToolCallID", func() {
+		It("includes tool_call_id in the role prefix when includeRole is true", func() {
+			msg := Message{
+				Role:       "tool",
+				ToolCallID: "call_abc123",
+				Content:    ChatComplContent{Raw: "sunny"},
+			}
+			Expect(msg.PlainText(true)).To(Equal("tool(call_abc123): sunny"))
+		})
+
+		It("omits the role prefix when includeRole is false", func() {
+			msg := Message{
+				Role:       "tool",
+				ToolCallID: "call_abc123",
+				Content:    ChatComplContent{Raw: "sunny"},
+			}
+			Expect(msg.PlainText(false)).To(Equal("sunny"))
+		})
+	})
+
+	Context("assistant message with ToolCalls", func() {
+		It("appends each tool call as [name(args)] when includeRole is true", func() {
+			funcName := "get_weather"
+			msg := Message{
+				Role: RoleAssistant,
+				ToolCalls: []ToolCall{
+					{
+						ID:   "call_xyz",
+						Type: "function",
+						Function: FunctionCall{
+							Name:      &funcName,
+							Arguments: `{"location":"NYC"}`,
+						},
+					},
+				},
+			}
+			Expect(msg.PlainText(true)).To(Equal(`assistant: [get_weather({"location":"NYC"})]`))
+		})
+	})
+
+	Context("JSON roundtrip", func() {
+		It("marshals and unmarshals tool_call_id", func() {
+			msg := Message{
+				Role:       "tool",
+				ToolCallID: "call_abc123",
+				Content:    ChatComplContent{Raw: "result"},
+			}
+			data, err := json.Marshal(msg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).To(ContainSubstring(`"tool_call_id":"call_abc123"`))
+
+			var got Message
+			Expect(json.Unmarshal(data, &got)).To(Succeed())
+			Expect(got.ToolCallID).To(Equal("call_abc123"))
+		})
+
+		It("deserializes tool_call_id from a chat completions request message", func() {
+			jsonData := []byte(`{"role":"tool","tool_call_id":"call_abc123","content":"result"}`)
+			var msg Message
+			Expect(json.Unmarshal(jsonData, &msg)).To(Succeed())
+			Expect(msg.ToolCallID).To(Equal("call_abc123"))
+			Expect(msg.Content.Raw).To(Equal("result"))
+		})
+	})
+})
+
 var _ = Describe("TextCompletionsParsedRequest prompt", func() {
 	Context("UnmarshalJSON", func() {
 		It("should unmarshal a string prompt as a one-element slice", func() {

--- a/pkg/openai-server-api/response.go
+++ b/pkg/openai-server-api/response.go
@@ -168,7 +168,7 @@ func (m *Message) PlainText(includeRole bool) string {
 		var parts []string
 		for _, block := range m.Content.Structured {
 			switch block.Type {
-			case "text":
+			case ContentTypeText:
 				parts = append(parts, block.Text)
 			case "image_url":
 				parts = append(parts, "image: "+block.ImageURL.Url)
@@ -462,7 +462,7 @@ func CreateResponsesResponse(model string, requestID string, createdAt int64,
 		CreatedAt:    createdAt,
 		Status:       ResponsesStatusCompleted,
 		Instructions: instructions,
-		Text:         &TextSettings{Format: &TextFormat{Type: "text"}},
+		Text:         &TextSettings{Format: &TextFormat{Type: ContentTypeText}},
 		Output:       output,
 		Usage:        usage,
 		TopLogprobs:  topLogprobs,
@@ -625,6 +625,8 @@ const (
 	MessagesEventContentBlockStop  = "content_block_stop"
 	MessagesEventMessageDelta      = "message_delta"
 	MessagesEventMessageStop       = "message_stop"
+
+	ContentTypeText = "text"
 )
 
 // MessagesUsage contains token usage for the Anthropic Messages API.

--- a/pkg/openai-server-api/response.go
+++ b/pkg/openai-server-api/response.go
@@ -139,12 +139,14 @@ type baseResponseChoice struct {
 // v1/chat/completions
 // Message defines vLLM chat completions Message
 type Message struct {
-	// Role is the message Role, optional values are 'user', 'assistant', ...
+	// Role is the message Role, optional values are 'user', 'assistant', 'tool', ...
 	Role string `json:"role,omitempty"`
 	// Content defines text of this message
 	Content ChatComplContent `json:"content,omitempty"`
 	// ToolCalls are the tool calls created by the model
 	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
+	// ToolCallID is the ID of the tool call this message is responding to (role: "tool" only)
+	ToolCallID string `json:"tool_call_id,omitempty"`
 }
 
 func (m *Message) PlainText(includeRole bool) string {
@@ -152,6 +154,11 @@ func (m *Message) PlainText(includeRole bool) string {
 
 	if includeRole {
 		builder.WriteString(m.Role)
+		if m.ToolCallID != "" {
+			builder.WriteString("(")
+			builder.WriteString(m.ToolCallID)
+			builder.WriteString(")")
+		}
 		builder.WriteString(": ")
 	}
 
@@ -169,6 +176,16 @@ func (m *Message) PlainText(includeRole bool) string {
 		}
 
 		builder.WriteString(strings.Join(parts, "\n"))
+	}
+
+	for _, tc := range m.ToolCalls {
+		if tc.Function.Name != nil {
+			builder.WriteString("[")
+			builder.WriteString(*tc.Function.Name)
+			builder.WriteString("(")
+			builder.WriteString(tc.Function.Arguments)
+			builder.WriteString(")]")
+		}
 	}
 
 	return builder.String()
@@ -590,4 +607,147 @@ type ECTransferParams struct {
 	PeerPort      int    `json:"peer_port"`
 	SizeBytes     int    `json:"size_bytes"`
 	NixlAgentData []byte `json:"nixl_agent_metadata_b64"`
+}
+
+// Anthropic Messages API
+
+const (
+	MessagesIDPrefix            = "msg_"
+	MessagesType                = "message"
+	MessagesStopReasonEndTurn   = "end_turn"
+	MessagesStopReasonToolUse   = "tool_use"
+	MessagesStopReasonMaxTokens = "max_tokens"
+
+	MessagesEventMessageStart      = "message_start"
+	MessagesEventContentBlockStart = "content_block_start"
+	MessagesEventPing              = "ping"
+	MessagesEventContentBlockDelta = "content_block_delta"
+	MessagesEventContentBlockStop  = "content_block_stop"
+	MessagesEventMessageDelta      = "message_delta"
+	MessagesEventMessageStop       = "message_stop"
+)
+
+// MessagesUsage contains token usage for the Anthropic Messages API.
+type MessagesUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+}
+
+// MessagesStreamUsage carries only output_tokens in streaming delta events.
+type MessagesStreamUsage struct {
+	OutputTokens int `json:"output_tokens"`
+}
+
+// MessagesContentBlock is a single content block in a Messages API response.
+// Type is "text" (text field) or "tool_use" (ID, Name, Input fields).
+type MessagesContentBlock struct {
+	Type  string         `json:"type"`
+	Text  string         `json:"text,omitempty"`
+	ID    string         `json:"id,omitempty"`
+	Name  string         `json:"name,omitempty"`
+	Input map[string]any `json:"input,omitempty"`
+}
+
+// MessagesResponse is the non-streaming Anthropic /v1/messages response.
+type MessagesResponse struct {
+	ID           string                 `json:"id"`
+	Type         string                 `json:"type"`
+	Role         string                 `json:"role"`
+	Content      []MessagesContentBlock `json:"content"`
+	Model        string                 `json:"model"`
+	StopReason   *string                `json:"stop_reason"`
+	StopSequence *string                `json:"stop_sequence"`
+	Usage        MessagesUsage          `json:"usage"`
+	RequestID    string                 `json:"-"`
+}
+
+func (r *MessagesResponse) GetRequestID() string { return r.RequestID }
+
+// CreateMessagesResponse builds a complete non-streaming Messages API response.
+func CreateMessagesResponse(model, requestID, stopReason string,
+	content []MessagesContentBlock, usage MessagesUsage) *MessagesResponse {
+	sr := stopReason
+	if content == nil {
+		content = []MessagesContentBlock{}
+	}
+	return &MessagesResponse{
+		ID:           MessagesIDPrefix + requestID,
+		Type:         MessagesType,
+		Role:         RoleAssistant,
+		Content:      content,
+		Model:        model,
+		StopReason:   &sr,
+		StopSequence: nil,
+		Usage:        usage,
+		RequestID:    requestID,
+	}
+}
+
+// CreateMessagesStreamStartMessage builds the initial message object for the
+// message_start streaming event: empty content, nil stop_reason, input_tokens set.
+func CreateMessagesStreamStartMessage(model, requestID string, inputTokens int) *MessagesResponse {
+	return &MessagesResponse{
+		ID:           MessagesIDPrefix + requestID,
+		Type:         MessagesType,
+		Role:         RoleAssistant,
+		Content:      []MessagesContentBlock{},
+		Model:        model,
+		StopReason:   nil,
+		StopSequence: nil,
+		Usage:        MessagesUsage{InputTokens: inputTokens},
+		RequestID:    requestID,
+	}
+}
+
+// Streaming event structs
+
+type MessagesMessageStartEvent struct {
+	Type    string            `json:"type"`
+	Message *MessagesResponse `json:"message"`
+}
+
+type MessagesContentBlockStartEvent struct {
+	Type         string               `json:"type"`
+	Index        int                  `json:"index"`
+	ContentBlock MessagesContentBlock `json:"content_block"`
+}
+
+// MessagesContentBlockDelta is the delta payload inside a content_block_delta event.
+// Type is "text_delta" (Text field) or "input_json_delta" (PartialJSON field).
+type MessagesContentBlockDelta struct {
+	Type        string `json:"type"`
+	Text        string `json:"text,omitempty"`
+	PartialJSON string `json:"partial_json,omitempty"`
+}
+
+type MessagesContentBlockDeltaEvent struct {
+	Type  string                    `json:"type"`
+	Index int                       `json:"index"`
+	Delta MessagesContentBlockDelta `json:"delta"`
+}
+
+type MessagesContentBlockStopEvent struct {
+	Type  string `json:"type"`
+	Index int    `json:"index"`
+}
+
+type MessagesMessageDeltaPayload struct {
+	StopReason   *string `json:"stop_reason"`
+	StopSequence *string `json:"stop_sequence"`
+}
+
+type MessagesMessageDeltaEvent struct {
+	Type  string                      `json:"type"`
+	Delta MessagesMessageDeltaPayload `json:"delta"`
+	Usage MessagesStreamUsage         `json:"usage"`
+}
+
+type MessagesMessageStopEvent struct {
+	Type string `json:"type"`
+}
+
+type MessagesPingEvent struct {
+	Type string `json:"type"`
 }

--- a/pkg/openai-server-api/tool_choice.go
+++ b/pkg/openai-server-api/tool_choice.go
@@ -91,3 +91,28 @@ func (t *ToolChoice) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func NewToolChoiceRequired() ToolChoice {
+	return ToolChoice{ChatCompletionToolChoiceOptionUnionParam: openai.ChatCompletionToolChoiceOptionUnionParam{
+		OfAuto: param.NewOpt(toolChoiceRequiredValue),
+	}}
+}
+
+func NewToolChoiceNone() ToolChoice {
+	return ToolChoice{ChatCompletionToolChoiceOptionUnionParam: openai.ChatCompletionToolChoiceOptionUnionParam{
+		OfAuto: param.NewOpt(toolChoiceNoneValue),
+	}}
+}
+
+func NewToolChoiceFunction(name string) ToolChoice {
+	return ToolChoice{ChatCompletionToolChoiceOptionUnionParam: openai.ChatCompletionToolChoiceOptionUnionParam{
+		OfFunctionToolChoice: &openai.ChatCompletionNamedToolChoiceParam{
+			Function: openai.ChatCompletionNamedToolChoiceFunctionParam{Name: name},
+		},
+	}}
+}
+
+const (
+	toolChoiceRequiredValue = "required"
+	toolChoiceNoneValue     = "none"
+)

--- a/pkg/tests/messages_test.go
+++ b/pkg/tests/messages_test.go
@@ -1,0 +1,408 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	openaiserverapi "github.com/llm-d/llm-d-inference-sim/pkg/openai-server-api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// messagesSSEEvent holds a single parsed Anthropic SSE event.
+type messagesSSEEvent struct {
+	EventType string
+	Data      json.RawMessage
+}
+
+// buildMessagesBody serialises a /v1/messages request body.
+// Pass a non-empty system string for a system prompt, and tools/toolChoice when
+// you need tool-call behaviour.
+func buildMessagesBody(model string, stream bool, messages []map[string]any,
+	system string, tools []map[string]any, toolChoice map[string]any) string {
+
+	body := map[string]any{
+		"model":      model,
+		"messages":   messages,
+		"max_tokens": 100,
+		"stream":     stream,
+	}
+	if system != "" {
+		body["system"] = system
+	}
+	if len(tools) > 0 {
+		body["tools"] = tools
+	}
+	if toolChoice != nil {
+		body["tool_choice"] = toolChoice
+	}
+	b, err := json.Marshal(body)
+	Expect(err).NotTo(HaveOccurred())
+	return string(b)
+}
+
+// sendMessagesRequest sends a non-streaming POST to /v1/messages and returns the parsed response.
+func sendMessagesRequest(client *http.Client, body string) *openaiserverapi.MessagesResponse {
+	resp, err := client.Post("http://localhost/v1/messages", "application/json", strings.NewReader(body))
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close() //nolint:errcheck
+
+	data, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK), "response body: %s", string(data))
+
+	var result openaiserverapi.MessagesResponse
+	Expect(json.Unmarshal(data, &result)).To(Succeed())
+	return &result
+}
+
+// readMessagesSSEStream sends a streaming POST to /v1/messages and returns all parsed SSE events.
+func readMessagesSSEStream(client *http.Client, body string) []messagesSSEEvent {
+	resp, err := client.Post("http://localhost/v1/messages", "application/json", strings.NewReader(body))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	defer resp.Body.Close() //nolint:errcheck
+
+	var events []messagesSSEEvent
+	scanner := bufio.NewScanner(resp.Body)
+	var currentType string
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "event: "):
+			currentType = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			raw := []byte(strings.TrimPrefix(line, "data: "))
+			events = append(events, messagesSSEEvent{EventType: currentType, Data: raw})
+			currentType = ""
+		}
+	}
+	return events
+}
+
+// anthropicGetWeatherTool returns a minimal Anthropic-format tool definition.
+var anthropicGetWeatherTool = map[string]any{
+	"name":        functionNameGetWeather,
+	"description": "Get weather at the given location",
+	"input_schema": map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"location": map[string]string{"type": "string"},
+		},
+		"required": []string{"location"},
+	},
+}
+
+var anthropicGetTemperatureTool = map[string]any{
+	"name":        functionNameGetTemperature,
+	"description": "Get temperature at the given location",
+	"input_schema": map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"city": map[string]string{"type": "string"},
+			"unit": map[string]any{
+				"type": "string",
+				"enum": []string{"C", "F"},
+			},
+		},
+		"required": []string{"city", "unit"},
+	},
+}
+
+var _ = Describe("Simulator for /v1/messages (Anthropic Messages API)", func() {
+	var (
+		ctx   context.Context
+		model string
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		model = common.TestModelName
+	})
+
+	Describe("non-streaming", func() {
+		It("returns a basic text response", func() {
+			client, err := startServer(ctx, common.ModeRandom)
+			Expect(err).NotTo(HaveOccurred())
+
+			body := buildMessagesBody(model, false, []map[string]any{
+				{"role": "user", "content": testUserMessage},
+			}, "", nil, nil)
+
+			resp := sendMessagesRequest(client, body)
+
+			Expect(resp.ID).To(HavePrefix(openaiserverapi.MessagesIDPrefix))
+			Expect(resp.Type).To(Equal(openaiserverapi.MessagesType))
+			Expect(resp.Role).To(Equal(openaiserverapi.RoleAssistant))
+			Expect(resp.Model).To(Equal(model))
+
+			Expect(resp.Content).To(HaveLen(1))
+			Expect(resp.Content[0].Type).To(Equal("text"))
+			Expect(resp.Content[0].Text).NotTo(BeEmpty())
+
+			Expect(resp.StopReason).NotTo(BeNil())
+			Expect(*resp.StopReason).To(BeElementOf(
+				openaiserverapi.MessagesStopReasonEndTurn,
+				openaiserverapi.MessagesStopReasonMaxTokens,
+			))
+			Expect(resp.StopSequence).To(BeNil())
+
+			Expect(resp.Usage.InputTokens).To(BeNumerically(">", 0))
+			Expect(resp.Usage.OutputTokens).To(BeNumerically(">", 0))
+		})
+
+		It("returns a text response with a system prompt", func() {
+			client, err := startServer(ctx, common.ModeRandom)
+			Expect(err).NotTo(HaveOccurred())
+
+			body := buildMessagesBody(model, false, []map[string]any{
+				{"role": "user", "content": testUserMessage},
+			}, "You are a helpful assistant.", nil, nil)
+
+			resp := sendMessagesRequest(client, body)
+
+			Expect(resp.Type).To(Equal(openaiserverapi.MessagesType))
+			Expect(resp.Content).To(HaveLen(1))
+			Expect(resp.Content[0].Type).To(Equal("text"))
+			Expect(*resp.StopReason).To(BeElementOf(
+				openaiserverapi.MessagesStopReasonEndTurn,
+				openaiserverapi.MessagesStopReasonMaxTokens,
+			))
+			Expect(resp.Usage.InputTokens).To(BeNumerically(">", 0))
+		})
+
+		It("returns a text response with multi-turn messages", func() {
+			client, err := startServer(ctx, common.ModeRandom)
+			Expect(err).NotTo(HaveOccurred())
+
+			body := buildMessagesBody(model, false, []map[string]any{
+				{"role": "user", "content": "Hello!"},
+				{"role": "assistant", "content": "Hi there! How can I help?"},
+				{"role": "user", "content": testUserMessage},
+			}, "", nil, nil)
+
+			resp := sendMessagesRequest(client, body)
+
+			Expect(resp.Type).To(Equal(openaiserverapi.MessagesType))
+			Expect(resp.Content).To(HaveLen(1))
+			Expect(resp.Content[0].Type).To(Equal("text"))
+			Expect(*resp.StopReason).To(BeElementOf(
+				openaiserverapi.MessagesStopReasonEndTurn,
+				openaiserverapi.MessagesStopReasonMaxTokens,
+			))
+		})
+
+		It("returns tool_use content blocks when tool_choice is any", func() {
+			client, err := startServer(ctx, common.ModeRandom)
+			Expect(err).NotTo(HaveOccurred())
+
+			body := buildMessagesBody(model, false, []map[string]any{
+				{"role": "user", "content": testUserMessage},
+			}, "", []map[string]any{anthropicGetWeatherTool}, map[string]any{"type": "any"})
+
+			resp := sendMessagesRequest(client, body)
+
+			Expect(resp.Type).To(Equal(openaiserverapi.MessagesType))
+			Expect(*resp.StopReason).To(Equal(openaiserverapi.MessagesStopReasonToolUse))
+			Expect(resp.Content).NotTo(BeEmpty())
+			for _, block := range resp.Content {
+				Expect(block.Type).To(Equal("tool_use"))
+				Expect(block.ID).To(HavePrefix(common.MessagesToolIDPrefix))
+				Expect(block.Name).To(Equal(functionNameGetWeather))
+				Expect(block.Input).NotTo(BeNil())
+				Expect(block.Input).To(HaveKey("location"))
+			}
+			Expect(resp.Usage.OutputTokens).To(BeNumerically(">", 0))
+		})
+
+		It("routes to the specific tool when tool_choice is tool", func() {
+			client, err := startServer(ctx, common.ModeRandom)
+			Expect(err).NotTo(HaveOccurred())
+
+			body := buildMessagesBody(model, false, []map[string]any{
+				{"role": "user", "content": testUserMessage},
+			}, "",
+				[]map[string]any{anthropicGetWeatherTool, anthropicGetTemperatureTool},
+				map[string]any{"type": "tool", "name": functionNameGetTemperature},
+			)
+
+			resp := sendMessagesRequest(client, body)
+
+			Expect(*resp.StopReason).To(Equal(openaiserverapi.MessagesStopReasonToolUse))
+			for _, block := range resp.Content {
+				Expect(block.Name).To(Equal(functionNameGetTemperature))
+				args, ok := block.Input["city"]
+				Expect(ok).To(BeTrue(), "expected 'city' in input, got %v", block.Input)
+				_ = args
+				Expect(block.Input).To(HaveKey("unit"))
+			}
+		})
+
+		It("returns 400 for a request with no messages", func() {
+			client, err := startServer(ctx, common.ModeRandom)
+			Expect(err).NotTo(HaveOccurred())
+
+			body := `{"model":"` + model + `","max_tokens":100,"messages":[]}`
+			resp, err := client.Post("http://localhost/v1/messages", "application/json", strings.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close() //nolint:errcheck
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Describe("streaming", func() {
+		It("returns correct event sequence for a text response", func() {
+			client, err := startServer(ctx, common.ModeRandom)
+			Expect(err).NotTo(HaveOccurred())
+
+			body := buildMessagesBody(model, true, []map[string]any{
+				{"role": "user", "content": testUserMessage},
+			}, "", nil, nil)
+
+			events := readMessagesSSEStream(client, body)
+			Expect(events).NotTo(BeEmpty())
+
+			// Verify the event sequence
+			types := make([]string, len(events))
+			for i, e := range events {
+				types[i] = e.EventType
+			}
+
+			Expect(types[0]).To(Equal(openaiserverapi.MessagesEventMessageStart))
+			Expect(types).To(ContainElement(openaiserverapi.MessagesEventContentBlockStart))
+			Expect(types).To(ContainElement(openaiserverapi.MessagesEventPing))
+			Expect(types).To(ContainElement(openaiserverapi.MessagesEventContentBlockDelta))
+			Expect(types).To(ContainElement(openaiserverapi.MessagesEventContentBlockStop))
+			Expect(types).To(ContainElement(openaiserverapi.MessagesEventMessageDelta))
+			Expect(types[len(types)-1]).To(Equal(openaiserverapi.MessagesEventMessageStop))
+
+			// message_start carries the initial message object
+			var startEvent openaiserverapi.MessagesMessageStartEvent
+			Expect(json.Unmarshal(events[0].Data, &startEvent)).To(Succeed())
+			Expect(startEvent.Message).NotTo(BeNil())
+			Expect(startEvent.Message.ID).To(HavePrefix(openaiserverapi.MessagesIDPrefix))
+			Expect(startEvent.Message.Role).To(Equal(openaiserverapi.RoleAssistant))
+			Expect(startEvent.Message.Usage.InputTokens).To(BeNumerically(">", 0))
+
+			// content_block_start opens a text block
+			cbsIdx := findEventIndex(types, openaiserverapi.MessagesEventContentBlockStart)
+			var blockStart openaiserverapi.MessagesContentBlockStartEvent
+			Expect(json.Unmarshal(events[cbsIdx].Data, &blockStart)).To(Succeed())
+			Expect(blockStart.ContentBlock.Type).To(Equal("text"))
+			Expect(blockStart.Index).To(Equal(0))
+
+			// content_block_delta carries text
+			deltasText := collectTextDeltas(events)
+			Expect(strings.Join(deltasText, "")).NotTo(BeEmpty())
+
+			// message_delta carries stop_reason and output token count
+			mdIdx := findEventIndex(types, openaiserverapi.MessagesEventMessageDelta)
+			var msgDelta openaiserverapi.MessagesMessageDeltaEvent
+			Expect(json.Unmarshal(events[mdIdx].Data, &msgDelta)).To(Succeed())
+			Expect(msgDelta.Delta.StopReason).NotTo(BeNil())
+			Expect(*msgDelta.Delta.StopReason).To(BeElementOf(
+				openaiserverapi.MessagesStopReasonEndTurn,
+				openaiserverapi.MessagesStopReasonMaxTokens,
+			))
+			Expect(msgDelta.Usage.OutputTokens).To(BeNumerically(">", 0))
+		})
+
+		It("returns correct event sequence for tool_use", func() {
+			client, err := startServer(ctx, common.ModeRandom)
+			Expect(err).NotTo(HaveOccurred())
+
+			body := buildMessagesBody(model, true, []map[string]any{
+				{"role": "user", "content": testUserMessage},
+			}, "", []map[string]any{anthropicGetWeatherTool}, map[string]any{"type": "any"})
+
+			events := readMessagesSSEStream(client, body)
+			Expect(events).NotTo(BeEmpty())
+
+			types := make([]string, len(events))
+			for i, e := range events {
+				types[i] = e.EventType
+			}
+
+			Expect(types[0]).To(Equal(openaiserverapi.MessagesEventMessageStart))
+			Expect(types).To(ContainElement(openaiserverapi.MessagesEventContentBlockStart))
+			Expect(types).To(ContainElement(openaiserverapi.MessagesEventContentBlockDelta))
+			Expect(types).To(ContainElement(openaiserverapi.MessagesEventContentBlockStop))
+			Expect(types).To(ContainElement(openaiserverapi.MessagesEventMessageDelta))
+			Expect(types[len(types)-1]).To(Equal(openaiserverapi.MessagesEventMessageStop))
+
+			// content_block_start must describe a tool_use block
+			cbsIdx := findEventIndex(types, openaiserverapi.MessagesEventContentBlockStart)
+			var blockStart openaiserverapi.MessagesContentBlockStartEvent
+			Expect(json.Unmarshal(events[cbsIdx].Data, &blockStart)).To(Succeed())
+			Expect(blockStart.ContentBlock.Type).To(Equal("tool_use"))
+			Expect(blockStart.ContentBlock.ID).To(HavePrefix(common.MessagesToolIDPrefix))
+			Expect(blockStart.ContentBlock.Name).To(Equal(functionNameGetWeather))
+
+			// content_block_delta events carry input_json_delta
+			for _, e := range events {
+				if e.EventType != openaiserverapi.MessagesEventContentBlockDelta {
+					continue
+				}
+				var delta openaiserverapi.MessagesContentBlockDeltaEvent
+				Expect(json.Unmarshal(e.Data, &delta)).To(Succeed())
+				Expect(delta.Delta.Type).To(Equal("input_json_delta"))
+				Expect(delta.Delta.PartialJSON).NotTo(BeEmpty())
+			}
+
+			// message_delta carries tool_use stop_reason
+			mdIdx := findEventIndex(types, openaiserverapi.MessagesEventMessageDelta)
+			var msgDelta openaiserverapi.MessagesMessageDeltaEvent
+			Expect(json.Unmarshal(events[mdIdx].Data, &msgDelta)).To(Succeed())
+			Expect(*msgDelta.Delta.StopReason).To(Equal(openaiserverapi.MessagesStopReasonToolUse))
+		})
+	})
+})
+
+// findEventIndex returns the index of the first event with the given type.
+func findEventIndex(types []string, eventType string) int {
+	for i, t := range types {
+		if t == eventType {
+			return i
+		}
+	}
+	return -1
+}
+
+// collectTextDeltas returns the Text field from every content_block_delta event that carries a text_delta.
+func collectTextDeltas(events []messagesSSEEvent) []string {
+	var out []string
+	for _, e := range events {
+		if e.EventType != openaiserverapi.MessagesEventContentBlockDelta {
+			continue
+		}
+		var delta openaiserverapi.MessagesContentBlockDeltaEvent
+		if err := json.Unmarshal(e.Data, &delta); err != nil {
+			continue
+		}
+		if delta.Delta.Type == "text_delta" {
+			out = append(out, delta.Delta.Text)
+		}
+	}
+	return out
+}

--- a/pkg/tests/tools_test.go
+++ b/pkg/tests/tools_test.go
@@ -421,7 +421,7 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 							Expect(tc.Function.Name).To(BeEmpty())
 							args[functionName] = append(args[functionName], tc.Function.Arguments)
 						}
-						Expect(tc.ID).NotTo(BeEmpty())
+						Expect(tc.ID).To(HavePrefix(common.ChatCmplToolIDPrefix))
 						Expect(tc.Type).To(Equal("function"))
 					}
 				}
@@ -489,7 +489,7 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 			Expect(toolCalls).ToNot(BeEmpty())
 			for _, tc := range toolCalls {
 				Expect(tc.Function.Name).To(Or(Equal(functionNameGetWeather), Equal(functionNameGetTemperature)))
-				Expect(tc.ID).NotTo(BeEmpty())
+				Expect(tc.ID).To(HavePrefix(common.ChatCmplToolIDPrefix))
 				Expect(tc.Type).To(Equal("function"))
 				args := make(map[string]string)
 				err := json.Unmarshal([]byte(tc.Function.Arguments), &args)
@@ -542,7 +542,7 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 			Expect(toolCalls).ToNot(BeEmpty())
 			for _, tc := range toolCalls {
 				Expect(tc.Function.Name).To(Equal(specificTool))
-				Expect(tc.ID).NotTo(BeEmpty())
+				Expect(tc.ID).To(HavePrefix(common.ChatCmplToolIDPrefix))
 				Expect(tc.Type).To(Equal("function"))
 				args := make(map[string]string)
 				err := json.Unmarshal([]byte(tc.Function.Arguments), &args)
@@ -627,7 +627,7 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 			Expect(toolCalls).To(HaveLen(1))
 			tc := toolCalls[0]
 			Expect(tc.Function.Name).To(Equal("multiply_numbers"))
-			Expect(tc.ID).NotTo(BeEmpty())
+			Expect(tc.ID).To(HavePrefix(common.ChatCmplToolIDPrefix))
 			Expect(tc.Type).To(Equal("function"))
 			args := make(map[string][]float64)
 			err = json.Unmarshal([]byte(tc.Function.Arguments), &args)
@@ -676,7 +676,7 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 			Expect(toolCalls).To(HaveLen(1))
 			tc := toolCalls[0]
 			Expect(tc.Function.Name).To(Equal("process_tensor"))
-			Expect(tc.ID).NotTo(BeEmpty())
+			Expect(tc.ID).To(HavePrefix(common.ChatCmplToolIDPrefix))
 			Expect(tc.Type).To(Equal("function"))
 
 			args := make(map[string][][][]string)
@@ -748,7 +748,7 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 			Expect(toolCalls).To(HaveLen(1))
 			tc := toolCalls[0]
 			Expect(tc.Function.Name).To(Equal("process_order"))
-			Expect(tc.ID).NotTo(BeEmpty())
+			Expect(tc.ID).To(HavePrefix(common.ChatCmplToolIDPrefix))
 			Expect(tc.Type).To(Equal("function"))
 
 			args := make(map[string]any)
@@ -803,7 +803,7 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 			Expect(toolCalls).To(HaveLen(1))
 			tc := toolCalls[0]
 			Expect(tc.Function.Name).To(Equal("submit_survey"))
-			Expect(tc.ID).NotTo(BeEmpty())
+			Expect(tc.ID).To(HavePrefix(common.ChatCmplToolIDPrefix))
 			Expect(tc.Type).To(Equal("function"))
 
 			args := make(map[string]any)
@@ -847,7 +847,7 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 			Expect(toolCalls).To(HaveLen(1))
 			tc := toolCalls[0]
 			Expect(tc.Function.Name).To(Equal(functionNameGetTemperature))
-			Expect(tc.ID).NotTo(BeEmpty())
+			Expect(tc.ID).To(HavePrefix(common.ChatCmplToolIDPrefix))
 			Expect(tc.Type).To(Equal("function"))
 			args := make(map[string]string)
 			err = json.Unmarshal([]byte(tc.Function.Arguments), &args)
@@ -887,7 +887,7 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 			Expect(toolCalls).To(HaveLen(1))
 			tc := toolCalls[0]
 			Expect(tc.Function.Name).To(Equal("process_order"))
-			Expect(tc.ID).NotTo(BeEmpty())
+			Expect(tc.ID).To(HavePrefix(common.ChatCmplToolIDPrefix))
 			Expect(tc.Type).To(Equal("function"))
 
 			args := make(map[string]any)


### PR DESCRIPTION
Implements the Anthropic Messages API at `POST /v1/messages`. 

Requests are converted to the existing chat-completions pipeline; responses are formatted in Anthropic's SSE event format (streaming) or `MessagesResponse` (non-streaming).

**Changes:**

- New `/v1/messages` route, request handler, and response builder

- Anthropic wire-format types (`MessagesRequest`, content blocks, SSE event structs)

- Per-API tool ID prefixes (`chatcmpl-tool-` vs `toolu_`)

- `Message.ToolCallID` field for `role: "tool"` messages — needed to carry `tool_use_id` when converting Anthropic `tool_result` blocks to OpenAI `role: "tool"` messages during request conversion.

- Integration tests for the new endpoint; tightened tool ID prefix assertions in existing tests

Since `MessagesRequest` converts to `ChatCompletionsRequest` before processing, KV cache token counting and chat template application go through the same `RenderMessages` path as `/v1/chat/completions`, matching vLLM's behavior where the Messages API uses the same underlying chat template.

Fixes #542 