### PR TITLE
feat: add configurable image-generation latency for omni mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,8 @@ For a detailed explanation of how the simulator models inference time and what e
 - `inter-token-latency-std-dev`: standard deviation for time between generated tokens, optional, default is zero. Can't be more than 30% of `inter-token-latency`, will not cause the actual inter token latency to differ by more than 70% from `inter-token-latency`
 - `kv-cache-transfer-latency`: time for KV-cache "transfer" from a remote vLLM, optional, by default zero. Usually much shorter than `time-to-first-token`
 - `kv-cache-transfer-latency-std-dev`: standard deviation for time to "transfer" kv-cache from another vLLM instance in case P/D is activated, optional, default is zero. Can't be more than 30% of `kv-cache-transfer-latency`, will not cause the actual latency to differ by more than 70% from `kv-cache-transfer-latency`
+- `time-to-generate-image`: simulated time to generate an image in omni mode. When a chat completion request is going to emit an image chunk, the simulator sleeps for this duration before sending it. Optional, default is zero.
+- `time-to-generate-image-std-dev`: standard deviation for `time-to-generate-image`, optional, default is zero. Can't be more than 30% of `time-to-generate-image`, will not cause the actual image generation time to differ by more than 70% from `time-to-generate-image`.
 - `seed`: random seed for operations (if not set, current Unix time in nanoseconds is used)
 
 #### Per-token calculator parameters

--- a/docs/latency-simulation.md
+++ b/docs/latency-simulation.md
@@ -177,3 +177,19 @@ Must be `>= 1.0`. **Not** applied to KV-cache transfer parameters, which are net
 The factor scales linearly between 1.0 (one request in flight) and the configured value
 (at `max-num-seqs`). When `max-num-seqs <= 1`, the factor is forced to `1.0`.
 
+### `time-to-generate-image` / `time-to-generate-image-std-dev`
+
+Applies only in omni mode (`--omni`) when a chat completion request is going to emit an
+image chunk. After all output tokens have been produced, the simulator sleeps for a duration drawn from a
+normal distribution centered at `time-to-generate-image` with spread
+`time-to-generate-image-std-dev`. In streaming responses this delays the image chunk; in
+non-streaming responses it delays the complete response body.
+
+This models the latency of a separate image-generation step that runs concurrently with or
+after the text decode phase in real omni models. Set it to something in the range of the
+total decode time for a realistic end-to-end simulation; leave it at zero (the default) to
+emit the image without any added delay.
+
+The std-dev is capped at 30% of the mean; sampled values are clamped to ±70% of the mean.
+Not affected by `time-factor-under-load`.
+

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -117,6 +117,11 @@ type Request interface {
 	CacheThresholdFinishReason() bool
 	// SetCacheThresholdFinishReason sets cacheThresholdFinishReason
 	SetCacheThresholdFinishReason(bool)
+	// SetSendImage records whether an image will be emitted with this response.
+	// Only meaningful for chat completions in omni mode; no-op for all other request types.
+	SetSendImage(bool)
+	// SendImage reports whether an image will be emitted with this response.
+	SendImage() bool
 }
 
 // baseRequest contains base completions request related information
@@ -363,6 +368,9 @@ func (b *baseRequest) MMFeatures() *RenderMMFeatures {
 func (b *baseRequest) SetMMFeatures(mmFeatures *RenderMMFeatures) {
 	b.mmFeatures = mmFeatures
 }
+
+func (b *baseRequest) SetSendImage(bool) {}
+func (b *baseRequest) SendImage() bool   { return false }
 
 func (b *baseCompletionsRequest) IncludeUsage() bool {
 	return !b.Stream || (b.StreamOptions != nil && b.StreamOptions.IncludeUsage)

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -158,6 +158,14 @@ type Configuration struct {
 	// KVCacheTransferOverheadStdDev similar to TimeToFirstTokenStdDev
 	KVCacheTransferTimeStdDev time.Duration `yaml:"kv-cache-transfer-time-std-dev" json:"kv-cache-transfer-time-std-dev" admin:"configurable" rebuild:"latency"`
 
+	// TimeToGenerateImage is the simulated time to generate an image in omni mode.
+	// When an image is going to be emitted in a chat completion, the simulator
+	// sleeps for this duration before sending the image chunk.
+	TimeToGenerateImage time.Duration `yaml:"time-to-generate-image" json:"time-to-generate-image" admin:"configurable"`
+	// TimeToGenerateImageStdDev standard deviation for time to generate an image.
+	// Optional, default is 0, can't be more than 30% of TimeToGenerateImage.
+	TimeToGenerateImageStdDev time.Duration `yaml:"time-to-generate-image-std-dev" json:"time-to-generate-image-std-dev" admin:"configurable"`
+
 	// TimeFactorUnderLoad is a multiplicative factor that affects the overall time taken for requests when parallel
 	// requests are being processed.
 	// The value of this factor must be >= 1.0, with a default of 1.0.
@@ -418,6 +426,16 @@ func (c *Configuration) validate() error {
 	}
 	if float32(c.TimeToFirstTokenStdDev) > 0.3*float32(c.TimeToFirstToken) {
 		return errors.New("time to first token standard deviation cannot be more than 30% of time to first token")
+	}
+
+	if c.TimeToGenerateImage < 0 {
+		return errors.New("time to generate image cannot be negative")
+	}
+	if c.TimeToGenerateImageStdDev < 0 {
+		return errors.New("time to generate image standard deviation cannot be negative")
+	}
+	if float32(c.TimeToGenerateImageStdDev) > 0.3*float32(c.TimeToGenerateImage) {
+		return errors.New("time to generate image standard deviation cannot be more than 30% of time to generate image")
 	}
 
 	if c.PrefillOverhead < 0 {

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -206,6 +206,23 @@ var _ = Describe("Simulator configuration", func() {
 	}
 	tests = append(tests, test)
 
+	// Config with image generation latencies
+	c = createDefaultConfig(QwenModelName, nil)
+	c.Port = 8001
+	c.MaxLoras = 1
+	c.MaxCPULoras = 1
+	c.TimeToGenerateImage = 500 * time.Millisecond
+	c.TimeToGenerateImageStdDev = 50 * time.Millisecond
+	test = testCase{
+		name: "basic config file with image generation latencies",
+		args: []string{"cmd", "--config", "../../manifests/basic-config.yaml",
+			"--time-to-generate-image", "500ms",
+			"--time-to-generate-image-std-dev", "50ms",
+		},
+		expectedConfig: c,
+	}
+	tests = append(tests, test)
+
 	// Config from config_with_fake.yaml file
 	c = createDefaultConfig(QwenModelName, nil)
 	c.FakeMetrics = &FakeMetrics{
@@ -539,6 +556,24 @@ var _ = Describe("Simulator configuration", func() {
 			expectedError: "kv-cache transfer time standard deviation cannot be negative",
 		},
 		{
+			name: "invalid (negative) time-to-generate-image",
+			args: []string{"cmd", "--time-to-generate-image", "-1ms",
+				"--config", "../../manifests/config.yaml"},
+			expectedError: "time to generate image cannot be negative",
+		},
+		{
+			name: "invalid (negative) time-to-generate-image-std-dev",
+			args: []string{"cmd", "--time-to-generate-image-std-dev", "-1ms",
+				"--config", "../../manifests/config.yaml"},
+			expectedError: "time to generate image standard deviation cannot be negative",
+		},
+		{
+			name: "invalid time-to-generate-image-std-dev exceeds 30%",
+			args: []string{"cmd", "--time-to-generate-image", "500ms", "--time-to-generate-image-std-dev", "200ms",
+				"--config", "../../manifests/config.yaml"},
+			expectedError: "time to generate image standard deviation cannot be more than 30% of time to generate image",
+		},
+		{
 			name: "invalid data-parallel-size",
 			args: []string{"cmd", "--data-parallel-size", "15",
 				"--config", "../../manifests/config.yaml"},
@@ -730,6 +765,10 @@ var _ = Describe("ApplyAdminUpdate", func() {
 			`{"time-to-first-token": "1s", "time-to-first-token-std-dev": "100ms"}`, true),
 		Entry("mixed latency + non-latency -> true",
 			`{"failure-injection-rate": 0, "prefill-overhead": "1ms"}`, true),
+		Entry("time-to-generate-image -> false",
+			`{"time-to-generate-image": "500ms"}`, false),
+		Entry("time-to-generate-image-std-dev -> false",
+			`{"time-to-generate-image": "500ms", "time-to-generate-image-std-dev": "50ms"}`, false),
 	)
 
 	It("returns latencyChanged=false when validation fails on a latency body", func() {
@@ -917,6 +956,8 @@ var _ = Describe("admin struct tags", func() {
 			"failure-types":                     "",
 			"fake-metrics":                      "",
 			"image-emission-rate":               "",
+			"time-to-generate-image":            "",
+			"time-to-generate-image-std-dev":    "",
 		}))
 	})
 

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -204,6 +204,8 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	addToggle(f, &config.Omni,
 		"omni", "Enable omni mode: emit an image chunk when X-Send-Image header is present", "Disable omni mode")
 	f.IntVar(&config.ImageEmissionRate, "image-emission-rate", config.ImageEmissionRate, "Probability (0-100) of emitting a synthetic image chunk per chat completion request in omni mode")
+	f.DurationVar(&config.TimeToGenerateImage, "time-to-generate-image", config.TimeToGenerateImage, "Simulated time to generate an image in omni mode, e.g. 500ms")
+	f.DurationVar(&config.TimeToGenerateImageStdDev, "time-to-generate-image-std-dev", config.TimeToGenerateImageStdDev, "Standard deviation for time to generate an image in omni mode, e.g. 50ms")
 	f.StringVar(&config.MMProcessorKWArgs, "mm-processor-kwargs", config.MMProcessorKWArgs, "Arguments to be forwarded to the model's processor for multi-modal data, ignored")
 	f.StringVar(&config.ECTransferConfig, "ec-transfer-config", config.ECTransferConfig, "Configuration for distributed EC cache transfer, ignored")
 	addToggle(f, &config.EnforceEager,

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -268,7 +268,7 @@ func (c *Communication) handleHTTP(req vllmsim.Request, respBuilder responseBuil
 		if !sendImg && cfg.ImageEmissionRate > 0 {
 			sendImg = c.simulator.Context.Random.RandomInt(1, 100) <= cfg.ImageEmissionRate
 		}
-		respBuilder.setSendImage(sendImg)
+		req.SetSendImage(sendImg)
 	}
 
 	numChoices, isStream, channel, err, errInjected := c.simulator.HandleRequest(req)
@@ -444,7 +444,7 @@ func (c *Communication) sendStream(ctx *fasthttp.RequestCtx, channel common.Chan
 			}
 		}
 
-		if respBuilder.shouldSendImage() {
+		if respCtx.SendImage() {
 			for i := range state.respCtxPerChoice {
 				if !c.sendOrFail(ctx, w, respBuilder.createImageChunk(respCtx, i), "Sending image chunk failed, ") {
 					return

--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -94,12 +94,6 @@ type responseBuilder interface {
 	// to be emitted after the token stream, or nil if this builder does not
 	// support image chunks.
 	createImageChunk(respCtx vllmsim.ResponseContext, choiceIdx int) sseChunk
-	// setSendImage tells the builder whether to include a synthetic image in
-	// non-streaming responses. No-op for builders that do not support images.
-	setSendImage(bool)
-	// shouldSendImage reports whether the builder has been asked to emit an
-	// image. Always false for builders that do not support images.
-	shouldSendImage() bool
 }
 
 // aggregateUsage combines per-choice usages. Completion tokens are always
@@ -148,8 +142,6 @@ func (*baseRespBuilder) createFirstChunk(_ vllmsim.ResponseContext, _ int) sseCh
 func (*baseRespBuilder) createDoneChunk() sseChunk                                  { return &doneMarker{} }
 func (*baseRespBuilder) sendFinishReasonWithTokens() bool                           { return false }
 func (*baseRespBuilder) createImageChunk(_ vllmsim.ResponseContext, _ int) sseChunk { return nil }
-func (*baseRespBuilder) setSendImage(bool)                                          {}
-func (*baseRespBuilder) shouldSendImage() bool                                      { return false }
 func (*baseRespBuilder) createRenderResponse(_ [][]uint32, _ *api.RenderMMFeatures) any {
 	panic("createRenderResponse not supported for this response builder")
 }
@@ -250,10 +242,7 @@ func (*textComplHTTPRespBuilder) createRenderResponse(tokens [][]uint32,
 
 var _ responseBuilder = (*textComplHTTPRespBuilder)(nil)
 
-type chatComplHTTPRespBuilder struct {
-	baseRespBuilder
-	sendImage bool
-}
+type chatComplHTTPRespBuilder struct{ baseRespBuilder }
 
 func (respBuilder *chatComplHTTPRespBuilder) createResponse(respCtxPerChoice []vllmsim.ResponseContext,
 	tokens []api.Tokenized) any {
@@ -268,16 +257,17 @@ func (respBuilder *chatComplHTTPRespBuilder) createResponse(respCtxPerChoice []v
 		baseChoice := api.CreateBaseResponseChoice(i, choiceCtx.FinishReason())
 
 		message := api.Message{Role: api.RoleAssistant}
+		sendImage := choiceCtx.SendImage()
 		if choiceCtx.ToolCalls() != nil {
 			message.ToolCalls = choiceCtx.ToolCalls()
-			if respBuilder.sendImage {
+			if sendImage {
 				message.Content = api.ChatComplContent{Structured: []api.ChatComplContentBlock{
 					{Type: "image_url", ImageURL: &api.ChatComplImageBlock{Url: "data:image/png;base64," + syntheticImageData}},
 				}}
 			}
 		} else {
 			respText := strings.Join(t.Strings, "")
-			if respBuilder.sendImage {
+			if sendImage {
 				message.Content = api.ChatComplContent{Structured: []api.ChatComplContentBlock{
 					{Type: "text", Text: respText},
 					{Type: "image_url", ImageURL: &api.ChatComplImageBlock{Url: "data:image/png;base64," + syntheticImageData}},
@@ -334,7 +324,7 @@ func (respBuilder *chatComplHTTPRespBuilder) createChunk(respCtx vllmsim.Respons
 		chunk.Choices[0].Delta.ToolCalls = []api.ToolCall{*tool}
 	} else if tokens != nil && len(tokens.Strings) > 0 {
 		tokensStr := strings.Join(tokens.Strings, "")
-		if respBuilder.sendImage {
+		if respCtx.SendImage() {
 			chunk.Choices[0].Delta.Content = api.ChatComplContent{Structured: []api.ChatComplContentBlock{
 				{Type: "text", Text: tokensStr},
 			}}
@@ -369,8 +359,6 @@ func (respBuilder *chatComplHTTPRespBuilder) createLastChunk(respCtx vllmsim.Res
 	return respBuilder.createChunk(respCtx, nil, nil, "", respCtx.FinishReason(), choiceIdx)
 }
 
-func (b *chatComplHTTPRespBuilder) setSendImage(v bool)   { b.sendImage = v }
-func (b *chatComplHTTPRespBuilder) shouldSendImage() bool { return b.sendImage }
 func (b *chatComplHTTPRespBuilder) createImageChunk(respCtx vllmsim.ResponseContext, choiceIdx int) sseChunk {
 	if respCtx == nil {
 		return nil

--- a/pkg/llm-d-inference-sim/chat_completion.go
+++ b/pkg/llm-d-inference-sim/chat_completion.go
@@ -29,7 +29,11 @@ import (
 // Implementation of request for /chat/completions requests
 type ChatCompletionsRequest struct {
 	api.ChatCompletionsRequest
+	willSendImage bool
 }
+
+func (c *ChatCompletionsRequest) SetSendImage(v bool) { c.willSendImage = v }
+func (c *ChatCompletionsRequest) SendImage() bool     { return c.willSendImage }
 
 // reads and parses data from the body of the given request
 func (c *ChatCompletionsRequest) Unmarshal(data []byte) error {

--- a/pkg/llm-d-inference-sim/context.go
+++ b/pkg/llm-d-inference-sim/context.go
@@ -268,6 +268,13 @@ func (s *SimContext) simulateTTFT(respCtx ResponseContext) {
 	common.WriteToChannel(s.metrics.reqPrefillTimeChan, time.Since(startPrefill).Seconds(), s.logger)
 }
 
+func (s *SimContext) simulateImageGenerationLatency() {
+	cfg := s.Config()
+	if cfg.TimeToGenerateImage > 0 {
+		time.Sleep(s.Random.RandomNormDuration(cfg.TimeToGenerateImage, cfg.TimeToGenerateImageStdDev))
+	}
+}
+
 func (s *SimContext) simulateInterTokenLatency() {
 	perTokenLatency := s.latencyCalc().GetInterTokenLatency(&InterTokenParams{
 		RunningReqs: s.metrics.nRunningReqs})

--- a/pkg/llm-d-inference-sim/response.go
+++ b/pkg/llm-d-inference-sim/response.go
@@ -53,6 +53,7 @@ type ResponseContext interface {
 	SetCreationTime(int64)
 	TopLogprobs() *int
 	ECTransferParams() map[string]api.ECTransferParams
+	SendImage() bool
 	setWG(*sync.WaitGroup)
 	Done()
 }
@@ -158,6 +159,9 @@ func (b *baseResponseContext) Done() {
 }
 func (b *baseResponseContext) setWG(wg *sync.WaitGroup) {
 	b.wg = wg
+}
+func (b *baseResponseContext) SendImage() bool {
+	return b.reqCtx.request().SendImage()
 }
 
 func respIsEmpty(respCtx ResponseContext) bool {

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -467,6 +467,10 @@ func (s *VllmSimulator) simulateResponseProcessing(respCtx ResponseContext) {
 			}
 		}
 		common.WriteToChannel(s.Context.metrics.reqDecodeTimeChan, time.Since(startDecode).Seconds(), s.Context.logger)
+
+		if reqCtx.request().SendImage() {
+			s.Context.simulateImageGenerationLatency()
+		}
 	}
 }
 

--- a/pkg/tests/latencies_test.go
+++ b/pkg/tests/latencies_test.go
@@ -21,10 +21,15 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	"github.com/llm-d/llm-d-inference-sim/pkg/communication"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
 )
 
 var _ = Describe("Check latency calculator", Ordered, func() {
@@ -256,6 +261,96 @@ var _ = Describe("Latency admin config", func() {
 			ttft, _ := sendCompletionsRequestForLatencyTest(
 				client, common.TestModelName, testUserMessage, false, false)
 			Expect(ttft.Milliseconds()).To(BeNumerically(">=", 1000))
+		})
+	})
+
+	Context("image generation latency", func() {
+		BeforeEach(func() {
+			ctx = context.Background()
+			var err error
+			client, err = startServerWithArgs(ctx, []string{
+				"cmd", "--model", common.TestModelName,
+				"--mode", common.ModeEcho,
+				"--omni",
+				"--latency-calculator", common.ConstantLatencyCalculator,
+				"--time-to-first-token", "0ms",
+				"--inter-token-latency", "0ms",
+				"--time-to-generate-image", "500ms",
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("adds image generation delay after the token stream when X-Send-Image is set", func() {
+			openaiclient := openai.NewClient(
+				option.WithBaseURL(baseURL),
+				option.WithHTTPClient(client),
+				option.WithMaxRetries(0))
+			params := openai.ChatCompletionNewParams{
+				Messages:  []openai.ChatCompletionMessageParamUnion{openai.UserMessage(testUserMessage)},
+				Model:     common.TestModelName,
+				MaxTokens: param.NewOpt(int64(5)),
+			}
+
+			// Without X-Send-Image: no image delay, should complete quickly.
+			start := time.Now()
+			_, err := openaiclient.Chat.Completions.New(ctx, params)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(time.Since(start).Milliseconds()).To(BeNumerically("<", 200))
+
+			// With X-Send-Image: true, total time must include the 500ms image generation delay.
+			start = time.Now()
+			_, err = openaiclient.Chat.Completions.New(ctx, params,
+				option.WithHeader(communication.XSendImageHeader, "true"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(time.Since(start).Milliseconds()).To(BeNumerically(">=", 500))
+		})
+	})
+
+	Context("update of image generation latency", func() {
+		BeforeEach(func() {
+			ctx = context.Background()
+			var err error
+			client, err = startServerWithArgs(ctx, []string{
+				"cmd", "--model", common.TestModelName,
+				"--mode", common.ModeEcho,
+				"--omni",
+				"--latency-calculator", common.ConstantLatencyCalculator,
+				"--time-to-first-token", "0ms",
+				"--inter-token-latency", "0ms",
+				"--time-to-generate-image", "0ms",
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("applies a new time-to-generate-image to subsequent requests", func() {
+			openaiclient := openai.NewClient(
+				option.WithBaseURL(baseURL),
+				option.WithHTTPClient(client),
+				option.WithMaxRetries(0))
+			params := openai.ChatCompletionNewParams{
+				Messages:  []openai.ChatCompletionMessageParamUnion{openai.UserMessage(testUserMessage)},
+				Model:     common.TestModelName,
+				MaxTokens: param.NewOpt(int64(5)),
+			}
+
+			// Before: time-to-generate-image=0ms, should complete quickly.
+			start := time.Now()
+			_, err := openaiclient.Chat.Completions.New(ctx, params,
+				option.WithHeader(communication.XSendImageHeader, "true"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(time.Since(start).Milliseconds()).To(BeNumerically("<", 200))
+
+			// Bump time-to-generate-image to 500ms.
+			resp := postAdminConfig(client, `{"time-to-generate-image":"500ms"}`)
+			Expect(resp.Body.Close()).To(Succeed())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			// After: total time must include the 500ms image generation delay.
+			start = time.Now()
+			_, err = openaiclient.Chat.Completions.New(ctx, params,
+				option.WithHeader(communication.XSendImageHeader, "true"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(time.Since(start).Milliseconds()).To(BeNumerically(">=", 500))
 		})
 	})
 


### PR DESCRIPTION
Adds `--time-to-generate-image` and `--time-to-generate-image-std-dev` config options. When the simulator (in omni mode) emits an image, it now sleeps for the configured duration after the token stream, which delays the image chunk in streaming responses and the full response body in non-streaming responses. This models the separate image-decoding step in real omni models.