### PR TITLE
ci: add dev image builds on push to main

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -2,13 +2,46 @@ name: CI - Release - Docker Container Image
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'  # Runs when a tag like v0.1.0 is pushed
   release:
     types: [published]  # Also runs when a GitHub release is published
 
 jobs:
+  dev-build-and-push:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Set short SHA tag
+        id: tag
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push dev image
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          tag: ${{ steps.tag.outputs.sha_short }}
+          image-name: llm-d-inference-sim-dev
+          registry: ghcr.io/llm-d
+          github-token: ${{ secrets.GHCR_TOKEN }}
+          prerelease: "true"
+
+      - name: Build and push dev zmq listener image
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          tag: ${{ steps.tag.outputs.sha_short }}
+          image-name: zmq-listener-dev
+          registry: ghcr.io/llm-d
+          github-token: ${{ secrets.GHCR_TOKEN }}
+          prerelease: "true"
+          dockerfile: Dockerfile.zmq
+
   docker-build-and-push:
+    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source


### PR DESCRIPTION
Add a dev-build-and-push job to ci-release.yaml that builds and pushes dev images (llm-d-inference-sim-dev and zmq-listener-dev) to ghcr.io/llm-d on every push to main, tagged with the short commit SHA.

The existing release job (docker-build-and-push) is now gated to only run on tag pushes and release events, preventing it from triggering on plain main branch pushes.

We're trying to resolve an issue with the certs not reloading https://github.com/llm-d/llm-d-inference-sim/pull/568 and would be great to get a build of the simulator as soon as the other PR is merged