### PR TITLE
feat: add max-request-body-size-mb configuration flag (#571)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,7 @@ Some environment variables (for example `POD_NAME`, `POD_NAMESPACE`) are not ove
 ## General
 - `config`: the path to a yaml configuration file that can contain the simulator's command line parameters. If a parameter is defined in both the config file and the command line, the command line value overwrites the configuration file value. An example configuration file can be found at [manifests/config.yaml](../manifests/config.yaml)
 - `port`: the port the simulator listens on, default is 8000
+- `max-request-body-size-mb`: maximum allowed size of an HTTP request body in megabytes, optional, default is 4 (matching the fasthttp built-in default). Must be between 1 and 512.
 - `model`: the currently 'loaded' model, mandatory. If you omit `--model` on the command line, a non-empty `SIM_MODEL` environment variable can supply the model; see [Configuration precedence](#configuration-precedence) and [Environment variables](#environment-variables).
 - `served-model-name`: model names exposed by the API (a list of space-separated strings)
 - `lora-modules`: a list of LoRA adapters (a list of space-separated JSON strings): '{"name": "name", "path": "lora_path", "base_model_name": "id"}', optional, empty by default

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -330,6 +330,9 @@ type Configuration struct {
 	// EnablePrefixCaching defines whether to enable prefix caching.
 	// Ignored in the simulator.
 	EnablePrefixCaching bool `yaml:"enable-prefix-caching" json:"enable-prefix-caching"`
+	// MaxRequestBodySizeMB sets the maximum allowed request body size in megabytes for the HTTP server.
+	// Default is 4 (matching the fasthttp built-in default). Must be between 1 and 512.
+	MaxRequestBodySizeMB int `yaml:"max-request-body-size-mb" json:"max-request-body-size-mb"`
 }
 
 type LoraModule struct {
@@ -367,6 +370,7 @@ func newConfig() *Configuration {
 		DatasetTableName:           DefaultDSTableName,
 		DefaultEmbeddingDimensions: 384,
 		FakeMetricsRefreshInterval: 100 * time.Millisecond,
+		MaxRequestBodySizeMB:       4,
 		RenderURL:                  "http://localhost:8082",
 		RenderTimeout:              30 * time.Second,
 		MMRenderTimeout:            60 * time.Second,
@@ -613,6 +617,10 @@ func (c *Configuration) validate() error {
 
 	if c.DefaultEmbeddingDimensions < 1 {
 		return errors.New("default embedding dimensions must be at least 1")
+	}
+
+	if c.MaxRequestBodySizeMB < 1 || c.MaxRequestBodySizeMB > 512 {
+		return fmt.Errorf("max-request-body-size-mb must be between 1 MB and 512 MB, got %d", c.MaxRequestBodySizeMB)
 	}
 
 	return nil

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -322,6 +322,18 @@ var _ = Describe("Simulator configuration", func() {
 	}
 	tests = append(tests, test)
 
+	// max-request-body-size-mb set to exactly 1 MB (lower boundary)
+	c = createConfigWithModel(TestModelName, nil)
+	c.MaxCPULoras = 1
+	c.Seed = 100
+	c.MaxRequestBodySizeMB = 1
+	test = testCase{
+		name:           "valid max-request-body-size-mb (1 MB boundary)",
+		args:           []string{"cmd", "--model", TestModelName, "--seed", "100", "--max-request-body-size-mb", "1"},
+		expectedConfig: c,
+	}
+	tests = append(tests, test)
+
 	for _, test := range tests {
 		When(test.name, func() {
 			It("should create correct configuration", func() {
@@ -679,6 +691,16 @@ var _ = Describe("Simulator configuration", func() {
 			name:          "invalid latency calculator",
 			args:          []string{"cmd", "--config", "../../manifests/config.yaml", "--latency-calculator", "hello"},
 			expectedError: "unknown latency-calculator",
+		},
+		{
+			name:          "invalid max-request-body-size-mb (too small)",
+			args:          []string{"cmd", "--config", "../../manifests/config.yaml", "--max-request-body-size-mb", "-1"},
+			expectedError: "max-request-body-size-mb must be between 1 MB and 512 MB",
+		},
+		{
+			name:          "invalid max-request-body-size-mb (too large)",
+			args:          []string{"cmd", "--config", "../../manifests/config.yaml", "--max-request-body-size-mb", "513"},
+			expectedError: "max-request-body-size-mb must be between 1 MB and 512 MB",
 		},
 	}
 

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -113,6 +113,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f := pflag.NewFlagSet("llm-d-inference-sim flags", pflag.ContinueOnError)
 
 	f.IntVar(&config.Port, "port", config.Port, "Port")
+	f.IntVar(&config.MaxRequestBodySizeMB, "max-request-body-size-mb", config.MaxRequestBodySizeMB, "Maximum allowed size of an HTTP request body in megabytes, must be between 1 and 512, default is 4 (matching the fasthttp built-in default)")
 	f.StringVar(&config.Model, "model", config.Model,
 		"Currently 'loaded' model (if omitted on the command line, "+ModelEnv+" may set the model; see docs)")
 	f.IntVar(&config.MaxNumSeqs, "max-num-seqs", config.MaxNumSeqs, "Maximum number of inference requests that could be processed at the same time")

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -100,9 +100,10 @@ func (c *Communication) startHTTPServer(listener net.Listener) (*fasthttp.Server
 	}
 
 	server := &fasthttp.Server{
-		ErrorHandler: c.HandleError,
-		Handler:      handler,
-		Logger:       c,
+		ErrorHandler:        c.HandleError,
+		Handler:             handler,
+		Logger:              c,
+		MaxRequestBodySize:  c.simulator.Context.Config().MaxRequestBodySizeMB * 1024 * 1024,
 	}
 
 	if err := c.configureSSL(server); err != nil {

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -100,10 +100,10 @@ func (c *Communication) startHTTPServer(listener net.Listener) (*fasthttp.Server
 	}
 
 	server := &fasthttp.Server{
-		ErrorHandler:        c.HandleError,
-		Handler:             handler,
-		Logger:              c,
-		MaxRequestBodySize:  c.simulator.Context.Config().MaxRequestBodySizeMB * 1024 * 1024,
+		ErrorHandler:       c.HandleError,
+		Handler:            handler,
+		Logger:             c,
+		MaxRequestBodySize: c.simulator.Context.Config().MaxRequestBodySizeMB * 1024 * 1024,
 	}
 
 	if err := c.configureSSL(server); err != nil {


### PR DESCRIPTION
Adds a `--max-request-body-size-mb` flag to cap the HTTP server's maximum request body size. Default is 4 MB (matching the fasthttp built-in default), valid range is 1–512 MB. 