### PR TITLE
Do not build and push the dev image on a fork

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   dev-build-and-push:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.repository.fork != true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source


### PR DESCRIPTION
The builds of dev images shouldn't happen on forks when developers sync their fork with the upstream repo.