### PR TITLE
Propagate DataParallelRank and ZMQ endpoint offset in DP mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,8 +88,8 @@ For a detailed explanation of how the simulator models inference time and what e
 - `failure-types`: list of specific failure types to inject (rate_limit, invalid_api_key, context_length, server_error, invalid_request, model_not_found), optional, if empty all types are used
 
 ## Data parallel
-- `data-parallel-size`: number of ranks to run in Data Parallel deployment, from 1 to 8, default is 1. The ports will be assigned as follows: rank 0 will run on the configured `port`, rank 1 on `port`+1, etc.  
-- `data-parallel-rank`: the rank of this instance, used only when running Data Parallel ranks as separate processes. If set, data-parallel-size is ignored.
+- `data-parallel-size`: number of ranks to run in Data Parallel deployment, from 1 to 8, default is 1. Ports are assigned sequentially: rank 0 uses the configured `port`, rank 1 uses `port+1`, etc. When `--zmq-endpoint` is also set, each rank's ZMQ endpoint port is offset by the same amount — rank 0 publishes to the configured endpoint, rank 1 to `endpoint_port+1`, etc. Each rank also embeds its index in the `data_parallel_rank` field of every published event batch.
+- `data-parallel-rank`: the rank of this instance, used only when running Data Parallel ranks as separate processes. If set, `data-parallel-size` is ignored and a single simulator starts with this rank index embedded in its ZMQ event batches.
 
 ## Datasets
 - `dataset-path`: Optional local file path to the SQLite database file used for generating responses from a dataset.

--- a/docs/kv-cache.md
+++ b/docs/kv-cache.md
@@ -122,7 +122,7 @@ Each message has three ZMQ frames:
 The event batch is a msgpack array with three fields:
 1. `ts` (float64) — Unix timestamp in seconds (`nanoseconds / 1e9`)
 2. `events` (array) — list of msgpack-encoded event arrays
-3. `data_parallel_rank` (int, optional) — always `0`
+3. `data_parallel_rank` (int, optional) — the rank index of the simulator instance that published the batch; `0` for a single-instance deployment, `0`–`N-1` when running with `--data-parallel-size N`
 
 ### Event types
 

--- a/pkg/kv-cache/block_cache.go
+++ b/pkg/kv-cache/block_cache.go
@@ -87,7 +87,7 @@ func newBlockCache(ctx context.Context, config *common.Configuration, logger log
 	}
 
 	eventSender := NewKVEventSender(publisher, CreateKVEventsTopic(config.IP, config.Model),
-		eChan, config.EventBatchSize, config.TokenBlockSize, delay, config.UseVllmMapEventFormat, logger)
+		eChan, config.EventBatchSize, config.TokenBlockSize, delay, config.UseVllmMapEventFormat, config.Rank, logger)
 
 	bCache := blockCache{
 		requestToBlocks: make(map[string][]blockKey),

--- a/pkg/kv-cache/kv_cache_sender.go
+++ b/pkg/kv-cache/kv_cache_sender.go
@@ -134,10 +134,11 @@ type KVEventSender struct {
 	batch                 []batchEntry
 	logger                logr.Logger
 	useVllmMapEventFormat bool
+	dpRank                int
 }
 
 func NewKVEventSender(publisher *common.Publisher, topic string, ch common.Channel[EventData], maxBatchSize int,
-	blockSize int, delay time.Duration, useVllmMapEventFormat bool, logger logr.Logger) *KVEventSender {
+	blockSize int, delay time.Duration, useVllmMapEventFormat bool, dpRank int, logger logr.Logger) *KVEventSender {
 	return &KVEventSender{
 		publisher:             publisher,
 		topic:                 topic,
@@ -148,6 +149,7 @@ func NewKVEventSender(publisher *common.Publisher, topic string, ch common.Chann
 		batch:                 make([]batchEntry, 0, maxBatchSize),
 		logger:                logger,
 		useVllmMapEventFormat: useVllmMapEventFormat,
+		dpRank:                dpRank,
 	}
 }
 
@@ -322,7 +324,7 @@ func (s *KVEventSender) publishHelper(ctx context.Context) error {
 		events = append(events, msgpack.RawMessage(eventBytes))
 	}
 
-	dpRank := 0
+	dpRank := s.dpRank
 
 	batch := msgpackEventBatch{
 		TS:               float64(time.Now().UnixNano()) / 1e9,

--- a/pkg/kv-cache/kv_test_helper.go
+++ b/pkg/kv-cache/kv_test_helper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents/engineadapter"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 var vllmAdapter *engineadapter.VLLMAdapter = engineadapter.NewVLLMAdapter()
@@ -120,6 +121,21 @@ func CountKVEventBlocks(parts [][]byte, expectedTopic string, expectedSeq uint64
 	}
 
 	return storedCount, removedCount, allCleared
+}
+
+// ParseKVBatchRank decodes the DataParallelRank field from a raw ZMQ message.
+// The payload (frames[2]) is a positional msgpack array [TS, Events, DataParallelRank].
+func ParseKVBatchRank(frames [][]byte) int {
+	gomega.Expect(frames).To(gomega.HaveLen(3))
+	var batch struct {
+		_msgpack         struct{} `msgpack:",as_array"` //nolint:unused
+		TS               float64
+		Events           []msgpack.RawMessage
+		DataParallelRank *int `msgpack:",omitempty"`
+	}
+	gomega.Expect(msgpack.Unmarshal(frames[2], &batch)).To(gomega.Succeed())
+	gomega.Expect(batch.DataParallelRank).NotTo(gomega.BeNil())
+	return *batch.DataParallelRank
 }
 
 // verifySingleBlockEviction ensures that exactly one block from the provided list

--- a/pkg/llm-d-inference-sim/helpers.go
+++ b/pkg/llm-d-inference-sim/helpers.go
@@ -19,6 +19,8 @@ package llmdinferencesim
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/llm-d/llm-d-inference-sim/pkg/api"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
@@ -102,4 +104,19 @@ func buildECTransferParams(mmHashes map[string][]string) map[string]api.ECTransf
 		}
 	}
 	return params
+}
+
+// offsetZMQEndpointPort adds the given offset to the port in a ZMQ endpoint
+// string (e.g. "tcp://127.0.0.1:5557"). Returns the original endpoint unchanged
+// if parsing fails.
+func offsetZMQEndpointPort(endpoint string, offset int) string {
+	lastColon := strings.LastIndex(endpoint, ":")
+	if lastColon < 0 {
+		return endpoint
+	}
+	basePort, err := strconv.Atoi(endpoint[lastColon+1:])
+	if err != nil {
+		return endpoint
+	}
+	return endpoint[:lastColon+1] + strconv.Itoa(basePort+offset)
 }

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -119,13 +119,20 @@ func Start(ctx context.Context, config *common.Configuration, logger logr.Logger
 	sims := make([]*VllmSimulator, dpSize)
 
 	for dpRank := 0; dpRank < dpSize; dpRank++ {
-		rankConfig := config
+		rankConfig, err := config.Copy()
+		if err != nil {
+			return nil, err
+		}
 		if dpRank > 0 {
-			rankConfig, err = config.Copy()
-			if err != nil {
-				return nil, err
-			}
 			rankConfig.Port = config.Port + dpRank
+			if config.ZMQEndpoint != "" {
+				rankConfig.ZMQEndpoint = offsetZMQEndpointPort(config.ZMQEndpoint, dpRank)
+			}
+		}
+		// Store the effective rank in the per-rank config so downstream
+		// components (e.g. KV event sender) can embed it in published batches.
+		if config.Rank < 0 {
+			rankConfig.Rank = dpRank
 		}
 
 		// Add the rank to the logger if dpSize > 1 or the rank was set,

--- a/pkg/tests/data_parallel_test.go
+++ b/pkg/tests/data_parallel_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	zmq4 "github.com/go-zeromq/zmq4"
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	kvcache "github.com/llm-d/llm-d-inference-sim/pkg/kv-cache"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+var _ = Describe("Data Parallel", func() {
+	It("Start with data-parallel-size=3 serves requests on all ranks", func() {
+		ctx := context.TODO()
+
+		clients, err := startDataParallelServers(ctx, []string{
+			"cmd",
+			"--model", common.TestModelName,
+			"--mode", common.ModeRandom,
+			"--data-parallel-size", "3",
+			"--force-dummy-tokenizer",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clients).To(HaveLen(3))
+
+		for rank, httpClient := range clients {
+			c := openai.NewClient(
+				option.WithBaseURL(baseURL),
+				option.WithHTTPClient(httpClient),
+				option.WithMaxRetries(0))
+			resp, err := c.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage("hello from rank"),
+				},
+				Model: common.TestModelName,
+			})
+			Expect(err).NotTo(HaveOccurred(), "rank %d request failed", rank)
+			Expect(resp.Choices).ShouldNot(BeEmpty(), "rank %d got empty choices", rank)
+		}
+	})
+
+	It("ZMQ kv-events are published for every rank with data-parallel-size=3", func() {
+		ctx := context.TODO()
+		model := common.QwenModelName
+		longPrompt := "This is a test message for kv cache events, has to be long enough to be tokenized into multiple blocks."
+
+		// Rank 0 gets a random port; ranks 1 and 2 get port+1 and port+2 respectively
+		// (the simulator calls offsetZMQEndpointPort(base, rank) for ranks > 0).
+		topic := kvcache.CreateKVEventsTopic("localhost", model)
+		sub0, zmqEndpoint := common.CreateSub(ctx, topic)
+		defer sub0.Close() //nolint:errcheck
+
+		// Derive fixed endpoints for rank 1 and rank 2 from rank 0's port.
+		lastColon := strings.LastIndex(zmqEndpoint, ":")
+		Expect(lastColon).To(BeNumerically(">", 0))
+		basePort, err := strconv.Atoi(zmqEndpoint[lastColon+1:])
+		Expect(err).NotTo(HaveOccurred())
+
+		sub1 := common.NewSub(ctx)
+		common.StartSub(sub1, fmt.Sprintf("tcp://*:%d", basePort+1), topic)
+		defer sub1.Close() //nolint:errcheck
+
+		sub2 := common.NewSub(ctx)
+		common.StartSub(sub2, fmt.Sprintf("tcp://*:%d", basePort+2), topic)
+		defer sub2.Close() //nolint:errcheck
+
+		clients, err := startDataParallelServers(ctx, []string{
+			"cmd",
+			"--model", model,
+			"--mode", common.ModeRandom,
+			"--data-parallel-size", "3",
+			"--force-dummy-tokenizer",
+			"--enable-kvcache", "true", "--kv-cache-size", "16", "--block-size", "8",
+			"--event-batch-size", "1", "--zmq-endpoint", zmqEndpoint,
+		}, map[string]string{"POD_IP": "localhost"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clients).To(HaveLen(3))
+
+		// Send one request to each rank concurrently.
+		for rank, httpClient := range clients {
+			c := openai.NewClient(
+				option.WithBaseURL(baseURL),
+				option.WithHTTPClient(httpClient),
+				option.WithMaxRetries(0))
+
+			go func() {
+				time.Sleep(200 * time.Millisecond)
+				resp, err := c.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+					Messages: []openai.ChatCompletionMessageParamUnion{
+						openai.UserMessage(longPrompt),
+					},
+					Model: model,
+				})
+				Expect(err).NotTo(HaveOccurred(), "rank %d request failed", rank)
+				Expect(resp.Choices).ShouldNot(BeEmpty(), "rank %d got empty choices", rank)
+			}()
+		}
+
+		// Assert that each rank published at least one store event on its own endpoint,
+		// and that the DataParallelRank embedded in the batch matches the rank index.
+		for expectedRank, sub := range []zmq4.Socket{sub0, sub1, sub2} {
+			msg, err := sub.Recv()
+			Expect(err).NotTo(HaveOccurred())
+			storedCount, removedCount, _ := kvcache.CountKVEventBlocks(msg.Frames, topic, 1)
+			Expect(storedCount).To(BeNumerically(">", 0), "expected store events from rank %d", expectedRank)
+			Expect(removedCount).To(Equal(0))
+			Expect(kvcache.ParseKVBatchRank(msg.Frames)).To(Equal(expectedRank),
+				"DataParallelRank mismatch for rank %d", expectedRank)
+		}
+	})
+})

--- a/pkg/tests/test_utils_test.go
+++ b/pkg/tests/test_utils_test.go
@@ -198,6 +198,70 @@ func startServerHelper(ctx context.Context, mode string, args []string, envs map
 	}, nil
 }
 
+// startDataParallelServers parses the given args, calls vllmsim.Start to obtain
+// one simulator per data-parallel rank, and wires each rank to its own
+// in-memory HTTP listener. It returns one *http.Client per rank, each dialling
+// exclusively into its own server. Cleanup (listener + sim shutdown) is
+// registered via DeferCleanup.
+func startDataParallelServers(ctx context.Context, args []string, envs ...map[string]string) ([]*http.Client, error) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = args
+
+	if len(envs) > 0 && envs[0] != nil {
+		for k, v := range envs[0] {
+			if err := os.Setenv(k, v); err != nil {
+				return nil, err
+			}
+		}
+		defer func() {
+			for k := range envs[0] {
+				gomega.Expect(os.Unsetenv(k)).To(gomega.Succeed())
+			}
+		}()
+	}
+
+	config, err := common.ParseCommandParamsAndLoadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	logger := klog.Background()
+
+	sims, err := vllmsim.Start(ctx, config, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	clients := make([]*http.Client, len(sims))
+	for rank, sim := range sims {
+		listener := fasthttputil.NewInmemoryListener()
+		comm := communication.New(logger, sim)
+
+		ginkgo.DeferCleanup(func() {
+			listener.Close() //nolint:errcheck
+			sim.Stop()
+		})
+
+		go func() {
+			if err := comm.StartHTTPServer(listener); err != nil {
+				logger.Error(err, "error starting server")
+			}
+		}()
+
+		clients[rank] = &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return listener.Dial()
+				},
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			},
+		}
+	}
+
+	return clients, nil
+}
+
 // startServerForLatencyTest - starts server configured according the given latency parameters in echo modes
 func startServerForLatencyTest(modelName string, ttft int, prefillTimePerToken int, interTokenLatency int, kvcacheTransferLatency int, kvCacheTransferTimePerToken int) *http.Client {
 	ctx := context.TODO()


### PR DESCRIPTION
ZMQ endpoint offset per rank: only Port was offset for ranks > 0, while ZMQEndpoint was not, so all ranks published to the same ZMQ port. Each rank now publishes to endpoint_port + rank.

DataParallelRank in ZMQ event batches was hard-coded 0. The effective rank is now set, so consumers can identify which rank emitted each batch.

Tests:
Added startDataParallelServers test helper to directly test simulator's start with DP.
Added two data-parallel integration tests: basic request serving across all ranks, and ZMQ event verification (store events present + correct DataParallelRank per rank).
