### PR TITLE
fix: prevent index out-of-range panic when response Strings is an empty non-nil slice

### DIFF
--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -433,7 +433,7 @@ func (s *VllmSimulator) simulateResponseProcessing(respCtx ResponseContext) {
 						Tokens:  []uint32{token},
 						Strings: []string{},
 					}
-					if respCtx.responseTokens().Strings != nil {
+					if len(respCtx.responseTokens().Strings) != 0 {
 						tokens.Strings = append(tokens.Strings, respCtx.responseTokens().Strings[i])
 					}
 					respInfo := ResponseInfo{Tokens: tokens, RespCtx: respCtx, ChoiceIdx: choiceIdx}


### PR DESCRIPTION
`simulateResponseProcessing` checked `respCtx.responseTokens().Strings != nil`before indexing into `Strings[i]`, but a non-nil empty slice would still pass that check and panic on the index access. Changed the guard to `len(...) != 0` so it correctly reflects whether there are elements to index.

Fixes #578 