### PR TITLE
feat: add ZMQ replay endpoint for KV cache events

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,8 @@ For a detailed explanation of how the simulator models inference time and what e
 - `zmq-endpoint`: ZMQ address to publish events
 - `event-batch-size`: the maximum number of kv-cache events to be sent together, defaults to 16
 - `use-vllm-map-event-format`: when `true`, encodes KV cache events as msgpack maps with named fields, matching the format introduced in vLLM PR #42892. When `false` (the default), events are encoded as positional msgpack arrays (legacy format). Use `true` when the event consumer is the llm-d `VLLMAdapter` parsing the new named-field schema.
+- `kv-events-replay-endpoint`: ZMQ ROUTER address to bind for receiving KV events replay requests. Empty (default) disables the replay listener. Example: `tcp://*:5558`. A client that stops draining its socket without closing the connection stalls replay for every other connected client too, not just its own — see [KV events replay](kv-cache.md#kv-events-replay).
+- `kv-events-replay-queue-size`: the max number of event batches held in the replay queue; oldest dropped when full. Defaults to 1024.
 
 ## Failure injection
 - `failure-injection-rate`: probability (0-100) of injecting failures, optional, default is 0

--- a/docs/kv-cache.md
+++ b/docs/kv-cache.md
@@ -36,6 +36,8 @@ All KV cache parameters can be set via CLI flags or the equivalent YAML keys (na
 | `zmq-endpoint` | string | `tcp://127.0.0.1:5557` | ZMQ address to publish events (the simulator dials this address) |
 | `event-batch-size` | int | `16` | Maximum number of events bundled into a single ZMQ message |
 | `use-vllm-map-event-format` | bool | `false` | Encode events as msgpack maps with named fields (vLLM PR #42892 format) instead of positional arrays. Set to `true` when the consumer expects the named-field schema. |
+| `kv-events-replay-endpoint` | string | `""` (disabled) | ZMQ ROUTER address to bind for KV events replay requests. See [KV events replay](#kv-events-replay). |
+| `kv-events-replay-queue-size` | int | `1024` | Maximum number of published event batches retained for replay, oldest dropped when full. |
 | `global-cache-hit-threshold` | float | `0` (disabled) | Server-wide minimum cache hit rate `[0, 1]`. Requests whose hit rate falls below this threshold return immediately with finish reason `cache_threshold`. Individual requests can override this with the `cache_hit_threshold` field. |
 
 ### Example YAML config
@@ -172,6 +174,26 @@ Emitted when the cache is fully discarded (see [Sleep mode](#sleep-mode-integrat
 Events are buffered and sent together for efficiency. A batch is flushed when either:
 - The number of pending events reaches `event-batch-size`, or
 - 1 second elapses since the last flush.
+
+## KV events replay
+
+When `kv-events-replay-endpoint` is set, the simulator additionally binds a ZMQ ROUTER socket that lets a late-joining or reconnecting subscriber catch up on batches it missed on the live PUB stream, instead of waiting for new events.
+
+- The simulator keeps a sliding window of the last `kv-events-replay-queue-size` published batches (default `1024`), keyed by their sequence number. Once the window is full, the oldest batch is dropped as new ones arrive.
+
+### Request format
+
+A request is a REQ-style 3-frame message — `[identity, empty-delimiter, startSeq]` — where `startSeq` is an 8-byte big-endian `uint64` meaning "replay every batch with `seq >= startSeq`"; malformed requests are silently ignored.
+
+### Reply format
+
+The simulator replies with each matching batch as a 3-frame message — `[topic, seq (8-byte big-endian), msgpack payload]` — identical in shape to the live PUB frames, so a subscriber can decode replayed and live batches the same way. 
+
+After the last matching batch, the simulator sends an end-of-replay sentinel: empty topic, `seq = 0xFFFFFFFFFFFFFFFF`, empty payload. The client should treat this as "you are caught up".
+
+If `startSeq` is older than every batch still in the window, all retained batches are replayed — there is no error signal for "some history was already evicted"; the client has to also track this against its own expectations.
+
+Replies for one client are sent from a dedicated goroutine, but this only isolates a slow client from the ROUTER socket's *receive* loop — new incoming replay requests still get parsed while a reply is in flight. It does **not** isolate clients from each other's replies: all replies on this endpoint go out over the same ROUTER socket, and the underlying ZMQ library serializes every send on that socket behind one shared, unbounded-blocking write. A client that stops draining its own socket without closing the connection therefore stalls replay for every other client on this rank too, not just its own, until that connection is closed — there is no per-message timeout that can free it. Clients must actively read every reply until the sentinel (or close the connection promptly on error) to avoid this.
 
 ## Block eviction policy
 

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -222,6 +222,13 @@ type Configuration struct {
 	// ZMQEndpoint is the ZMQ address to publish events, the default value is tcp://localhost:5557
 	ZMQEndpoint string `yaml:"zmq-endpoint" json:"zmq-endpoint"`
 
+	// KVEventsReplayEndpoint is the ZMQ PULL address to bind for receiving KV events replay requests.
+	// Empty (default) disables the replay listener. Example: "tcp://*:5558"
+	KVEventsReplayEndpoint string `yaml:"kv-events-replay-endpoint" json:"kv-events-replay-endpoint"`
+
+	// KVEventsReplayQueueSize is the max number of event batches held in the replay queue; oldest dropped when full. Defaults to 1024.
+	KVEventsReplayQueueSize int `yaml:"kv-events-replay-queue-size" json:"kv-events-replay-queue-size"`
+
 	// EventBatchSize is the maximum number of kv-cache events to be sent together, defaults to 16
 	EventBatchSize int `yaml:"event-batch-size" json:"event-batch-size"`
 
@@ -364,6 +371,7 @@ func newConfig() *Configuration {
 		KVCacheSize:                1024,
 		TokenBlockSize:             16,
 		ZMQEndpoint:                "tcp://127.0.0.1:5557",
+		KVEventsReplayQueueSize:    1024,
 		EventBatchSize:             16,
 		DPSize:                     1,
 		Rank:                       -1,
@@ -548,6 +556,10 @@ func (c *Configuration) validate() error {
 		return errors.New("event batch size cannot less than 1")
 	}
 
+	if c.KVEventsReplayEndpoint != "" && c.KVEventsReplayQueueSize < 1 {
+		return errors.New("kv-events-replay-queue-size cannot be less than 1")
+	}
+
 	if c.FailureInjectionRate < 0 || c.FailureInjectionRate > 100 {
 		return errors.New("failure injection rate should be between 0 and 100")
 	}
@@ -589,6 +601,10 @@ func (c *Configuration) validate() error {
 		return errors.New("data parallel rank must be between 0 and 7")
 	}
 
+	if err := c.validateEndpointPortsDontCollide(); err != nil {
+		return err
+	}
+
 	if (c.SSLCertFile == "") != (c.SSLKeyFile == "") {
 		return errors.New("both ssl-certfile and ssl-keyfile must be provided together")
 	}
@@ -623,6 +639,38 @@ func (c *Configuration) validate() error {
 		return fmt.Errorf("max-request-body-size-mb must be between 1 MB and 512 MB, got %d", c.MaxRequestBodySizeMB)
 	}
 
+	return nil
+}
+
+// validateEndpointPortsDontCollide ensures the ZMQ publish endpoint and the
+// KV-events-replay endpoint don't end up bound to the same port once each
+// rank's offset is applied
+func (c *Configuration) validateEndpointPortsDontCollide() error {
+	if c.ZMQEndpoint == "" || c.KVEventsReplayEndpoint == "" {
+		return nil
+	}
+
+	_, zmqPort, ok := ParseEndpointPort(c.ZMQEndpoint)
+	if !ok {
+		return nil
+	}
+	_, replayPort, ok := ParseEndpointPort(c.KVEventsReplayEndpoint)
+	if !ok {
+		return nil
+	}
+
+	// When data-parallel-rank is set, data-parallel-size is ignored for endpoint
+	// offsetting and both endpoints are offset by the
+	// same fixed rank, so only an exact port match can collide.
+	maxRank := c.DPSize - 1
+	if c.Rank >= 0 {
+		maxRank = 0
+	}
+	// Ports occupied across ranks 0..maxRank: [port, port+maxRank].
+	if zmqPort <= replayPort+maxRank && replayPort <= zmqPort+maxRank {
+		return fmt.Errorf("zmq-endpoint (%s) and kv-events-replay-endpoint (%s) ports collide"+
+			" once offset by data-parallel rank", c.ZMQEndpoint, c.KVEventsReplayEndpoint)
+	}
 	return nil
 }
 

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -222,7 +222,7 @@ type Configuration struct {
 	// ZMQEndpoint is the ZMQ address to publish events, the default value is tcp://localhost:5557
 	ZMQEndpoint string `yaml:"zmq-endpoint" json:"zmq-endpoint"`
 
-	// KVEventsReplayEndpoint is the ZMQ PULL address to bind for receiving KV events replay requests.
+	// KVEventsReplayEndpoint is the ZMQ ROUTER address to bind for receiving KV events replay requests.
 	// Empty (default) disables the replay listener. Example: "tcp://*:5558"
 	KVEventsReplayEndpoint string `yaml:"kv-events-replay-endpoint" json:"kv-events-replay-endpoint"`
 
@@ -644,7 +644,15 @@ func (c *Configuration) validate() error {
 
 // validateEndpointPortsDontCollide ensures the ZMQ publish endpoint and the
 // KV-events-replay endpoint don't end up bound to the same port once each
-// rank's offset is applied
+// rank's offset is applied.
+//
+// This holds even when data-parallel-rank is set to a single fixed value for
+// this process: the other ranks of the same cluster are still out there,
+// each running with their own fixed rank in 0..data-parallel-size-1 and the
+// same base endpoints, so this rank's ZMQ port can still collide with some
+// other rank's replay port (or vice versa). The check therefore always
+// spans the full 0..DPSize-1 range rather than narrowing to this process's
+// own rank.
 func (c *Configuration) validateEndpointPortsDontCollide() error {
 	if c.ZMQEndpoint == "" || c.KVEventsReplayEndpoint == "" {
 		return nil
@@ -659,14 +667,8 @@ func (c *Configuration) validateEndpointPortsDontCollide() error {
 		return nil
 	}
 
-	// When data-parallel-rank is set, data-parallel-size is ignored for endpoint
-	// offsetting and both endpoints are offset by the
-	// same fixed rank, so only an exact port match can collide.
+	// Ports occupied across ranks 0..DPSize-1: [port, port+DPSize-1].
 	maxRank := c.DPSize - 1
-	if c.Rank >= 0 {
-		maxRank = 0
-	}
-	// Ports occupied across ranks 0..maxRank: [port, port+maxRank].
 	if zmqPort <= replayPort+maxRank && replayPort <= zmqPort+maxRank {
 		return fmt.Errorf("zmq-endpoint (%s) and kv-events-replay-endpoint (%s) ports collide"+
 			" once offset by data-parallel rank", c.ZMQEndpoint, c.KVEventsReplayEndpoint)

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -334,6 +334,66 @@ var _ = Describe("Simulator configuration", func() {
 	}
 	tests = append(tests, test)
 
+	// kv-events-replay-endpoint set via CLI flag
+	c = createConfigWithModel(TestModelName, nil)
+	c.MaxCPULoras = 1
+	c.Seed = 100
+	c.KVEventsReplayEndpoint = "tcp://*:5558"
+	test = testCase{
+		name:           "kv-events-replay-endpoint via CLI",
+		args:           []string{"cmd", "--model", TestModelName, "--seed", "100", "--kv-events-replay-endpoint", "tcp://*:5558"},
+		expectedConfig: c,
+	}
+	tests = append(tests, test)
+
+	// kv-events-replay-endpoint not set — defaults to empty (disabled)
+	c = createConfigWithModel(TestModelName, nil)
+	c.MaxCPULoras = 1
+	c.Seed = 100
+	test = testCase{
+		name:           "kv-events-replay-endpoint disabled by default",
+		args:           []string{"cmd", "--model", TestModelName, "--seed", "100"},
+		expectedConfig: c,
+	}
+	tests = append(tests, test)
+
+	// zmq-endpoint and kv-events-replay-endpoint ports far enough apart that
+	// they don't collide even once each rank's offset (0..data-parallel-size-1) is applied
+	c = createConfigWithModel(TestModelName, nil)
+	c.MaxCPULoras = 1
+	c.Seed = 100
+	c.DPSize = 3
+	c.ZMQEndpoint = "tcp://127.0.0.1:5557"
+	c.KVEventsReplayEndpoint = "tcp://*:5600"
+	test = testCase{
+		name: "zmq-endpoint and kv-events-replay-endpoint ports don't collide with data-parallel-size",
+		args: []string{"cmd", "--model", TestModelName, "--seed", "100", "--data-parallel-size", "3",
+			"--zmq-endpoint", "tcp://127.0.0.1:5557", "--kv-events-replay-endpoint", "tcp://*:5600"},
+		expectedConfig: c,
+	}
+	tests = append(tests, test)
+
+	// data-parallel-rank is set, so data-parallel-size is ignored for endpoint
+	// offsetting purposes: ports 5557/5559 would collide under the DPSize-based
+	// range check (DPSize=3 → range [5557,5559] vs [5559,5561] overlap at 5559),
+	// but since both endpoints get the same fixed rank offset, only an exact
+	// port match can actually collide — so this is valid.
+	c = createConfigWithModel(TestModelName, nil)
+	c.MaxCPULoras = 1
+	c.Seed = 100
+	c.DPSize = 3
+	c.Rank = 2
+	c.ZMQEndpoint = "tcp://127.0.0.1:5557"
+	c.KVEventsReplayEndpoint = "tcp://*:5559"
+	test = testCase{
+		name: "zmq-endpoint and kv-events-replay-endpoint ports don't collide when data-parallel-rank is set",
+		args: []string{"cmd", "--model", TestModelName, "--seed", "100", "--data-parallel-size", "3",
+			"--data-parallel-rank", "2",
+			"--zmq-endpoint", "tcp://127.0.0.1:5557", "--kv-events-replay-endpoint", "tcp://*:5559"},
+		expectedConfig: c,
+	}
+	tests = append(tests, test)
+
 	for _, test := range tests {
 		When(test.name, func() {
 			It("should create correct configuration", func() {
@@ -596,6 +656,36 @@ var _ = Describe("Simulator configuration", func() {
 			args: []string{"cmd", "--data-parallel-rank", "15",
 				"--config", "../../manifests/config.yaml"},
 			expectedError: "data parallel rank must be between 0 and 7",
+		},
+		{
+			name: "invalid zmq-endpoint and kv-events-replay-endpoint on the same port",
+			args: []string{"cmd", "--zmq-endpoint", "tcp://127.0.0.1:5557",
+				"--kv-events-replay-endpoint", "tcp://127.0.0.1:5557",
+				"--config", "../../manifests/config.yaml"},
+			expectedError: "zmq-endpoint (tcp://127.0.0.1:5557) and kv-events-replay-endpoint (tcp://127.0.0.1:5557) ports collide",
+		},
+		{
+			name: "invalid zmq-endpoint and kv-events-replay-endpoint colliding once offset by data-parallel-size",
+			args: []string{"cmd", "--data-parallel-size", "3",
+				"--zmq-endpoint", "tcp://127.0.0.1:5557",
+				"--kv-events-replay-endpoint", "tcp://127.0.0.1:5558",
+				"--config", "../../manifests/config.yaml"},
+			expectedError: "zmq-endpoint (tcp://127.0.0.1:5557) and kv-events-replay-endpoint (tcp://127.0.0.1:5558) ports collide",
+		},
+		{
+			name: "invalid zmq-endpoint and kv-events-replay-endpoint on the same port with data-parallel-rank set",
+			args: []string{"cmd", "--data-parallel-size", "3", "--data-parallel-rank", "2",
+				"--zmq-endpoint", "tcp://127.0.0.1:5557",
+				"--kv-events-replay-endpoint", "tcp://127.0.0.1:5557",
+				"--config", "../../manifests/config.yaml"},
+			expectedError: "zmq-endpoint (tcp://127.0.0.1:5557) and kv-events-replay-endpoint (tcp://127.0.0.1:5557) ports collide",
+		},
+		{
+			name: "invalid kv-events-replay-queue-size",
+			args: []string{"cmd", "--kv-events-replay-endpoint", "tcp://*:5558",
+				"--kv-events-replay-queue-size", "0",
+				"--config", "../../manifests/config.yaml"},
+			expectedError: "kv-events-replay-queue-size cannot be less than 1",
 		},
 		{
 			name: "invalid max-num-seqs",

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -373,23 +373,24 @@ var _ = Describe("Simulator configuration", func() {
 	}
 	tests = append(tests, test)
 
-	// data-parallel-rank is set, so data-parallel-size is ignored for endpoint
-	// offsetting purposes: ports 5557/5559 would collide under the DPSize-based
-	// range check (DPSize=3 → range [5557,5559] vs [5559,5561] overlap at 5559),
-	// but since both endpoints get the same fixed rank offset, only an exact
-	// port match can actually collide — so this is valid.
+	// data-parallel-rank is set to a single fixed value for this process, but the
+	// collision check still spans the full data-parallel-size range: the other
+	// ranks of the cluster are still out there running with their own fixed rank
+	// and the same base endpoints, so the check is unaffected by data-parallel-rank
+	// being set here. These ports (range [5557,5559] vs [5600,5602]) don't collide
+	// either way.
 	c = createConfigWithModel(TestModelName, nil)
 	c.MaxCPULoras = 1
 	c.Seed = 100
 	c.DPSize = 3
 	c.Rank = 2
 	c.ZMQEndpoint = "tcp://127.0.0.1:5557"
-	c.KVEventsReplayEndpoint = "tcp://*:5559"
+	c.KVEventsReplayEndpoint = "tcp://*:5600"
 	test = testCase{
 		name: "zmq-endpoint and kv-events-replay-endpoint ports don't collide when data-parallel-rank is set",
 		args: []string{"cmd", "--model", TestModelName, "--seed", "100", "--data-parallel-size", "3",
 			"--data-parallel-rank", "2",
-			"--zmq-endpoint", "tcp://127.0.0.1:5557", "--kv-events-replay-endpoint", "tcp://*:5559"},
+			"--zmq-endpoint", "tcp://127.0.0.1:5557", "--kv-events-replay-endpoint", "tcp://*:5600"},
 		expectedConfig: c,
 	}
 	tests = append(tests, test)
@@ -679,6 +680,19 @@ var _ = Describe("Simulator configuration", func() {
 				"--kv-events-replay-endpoint", "tcp://127.0.0.1:5557",
 				"--config", "../../manifests/config.yaml"},
 			expectedError: "zmq-endpoint (tcp://127.0.0.1:5557) and kv-events-replay-endpoint (tcp://127.0.0.1:5557) ports collide",
+		},
+		{
+			// data-parallel-rank is fixed to 2 for this process, but the check still
+			// spans the full data-parallel-size range: rank 2's zmq port (5559) would
+			// collide with rank 0's replay port (5559) elsewhere in the same cluster,
+			// even though this process's own zmq (5559) and replay (5561) ports don't
+			// collide with each other.
+			name: "invalid zmq-endpoint and kv-events-replay-endpoint colliding with another rank's port when data-parallel-rank is set",
+			args: []string{"cmd", "--data-parallel-size", "3", "--data-parallel-rank", "2",
+				"--zmq-endpoint", "tcp://127.0.0.1:5557",
+				"--kv-events-replay-endpoint", "tcp://127.0.0.1:5559",
+				"--config", "../../manifests/config.yaml"},
+			expectedError: "zmq-endpoint (tcp://127.0.0.1:5557) and kv-events-replay-endpoint (tcp://127.0.0.1:5559) ports collide",
 		},
 		{
 			name: "invalid kv-events-replay-queue-size",

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -155,6 +155,8 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.StringVar(&config.HashSeed, "hash-seed", config.HashSeed,
 		"Seed for hash generation (if omitted on the command line, "+PythonHashSeedEnv+" may set it; see docs)")
 	f.StringVar(&config.ZMQEndpoint, "zmq-endpoint", config.ZMQEndpoint, "ZMQ address to publish events")
+	f.StringVar(&config.KVEventsReplayEndpoint, "kv-events-replay-endpoint", config.KVEventsReplayEndpoint, "ZMQ PULL address to bind for receiving KV events replay requests (empty disables)")
+	f.IntVar(&config.KVEventsReplayQueueSize, "kv-events-replay-queue-size", config.KVEventsReplayQueueSize, "Max number of event batches held in the replay queue; oldest dropped when full")
 	f.IntVar(&config.EventBatchSize, "event-batch-size", config.EventBatchSize, "Maximum number of kv-cache events to be sent together")
 	f.BoolVar(&config.UseVllmMapEventFormat, "use-vllm-map-event-format", config.UseVllmMapEventFormat, "Encode KV cache events as msgpack maps with named fields (vLLM PR #42892 format) instead of positional arrays")
 	f.IntVar(&config.DPSize, "data-parallel-size", config.DPSize, "Number of ranks to run")

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -155,7 +155,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.StringVar(&config.HashSeed, "hash-seed", config.HashSeed,
 		"Seed for hash generation (if omitted on the command line, "+PythonHashSeedEnv+" may set it; see docs)")
 	f.StringVar(&config.ZMQEndpoint, "zmq-endpoint", config.ZMQEndpoint, "ZMQ address to publish events")
-	f.StringVar(&config.KVEventsReplayEndpoint, "kv-events-replay-endpoint", config.KVEventsReplayEndpoint, "ZMQ PULL address to bind for receiving KV events replay requests (empty disables)")
+	f.StringVar(&config.KVEventsReplayEndpoint, "kv-events-replay-endpoint", config.KVEventsReplayEndpoint, "ZMQ ROUTER address to bind for receiving KV events replay requests (empty disables)")
 	f.IntVar(&config.KVEventsReplayQueueSize, "kv-events-replay-queue-size", config.KVEventsReplayQueueSize, "Max number of event batches held in the replay queue; oldest dropped when full")
 	f.IntVar(&config.EventBatchSize, "event-batch-size", config.EventBatchSize, "Maximum number of kv-cache events to be sent together")
 	f.BoolVar(&config.UseVllmMapEventFormat, "use-vllm-map-event-format", config.UseVllmMapEventFormat, "Encode KV cache events as msgpack maps with named fields (vLLM PR #42892 format) instead of positional arrays")

--- a/pkg/common/publisher.go
+++ b/pkg/common/publisher.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -29,6 +31,41 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// ParseEndpointPort splits a ZMQ endpoint string (e.g. "tcp://127.0.0.1:5557")
+// into the prefix up to and including the last colon, and the trailing port
+// number. ok is false if there is no trailing ":<port>".
+func ParseEndpointPort(endpoint string) (prefix string, port int, ok bool) {
+	lastColon := strings.LastIndex(endpoint, ":")
+	if lastColon < 0 {
+		return "", 0, false
+	}
+	port, err := strconv.Atoi(endpoint[lastColon+1:])
+	if err != nil {
+		return "", 0, false
+	}
+	return endpoint[:lastColon+1], port, true
+}
+
+// OffsetEndpointPort adds the given offset to the port in a ZMQ endpoint
+// string (e.g. "tcp://127.0.0.1:5557"). Returns the original
+// endpoint unchanged if parsing fails.
+func OffsetEndpointPort(endpoint string, offset int) string {
+	prefix, port, ok := ParseEndpointPort(endpoint)
+	if !ok {
+		return endpoint
+	}
+	return prefix + strconv.Itoa(port+offset)
+}
+
+// EncodeSeq encodes a sequence number as an 8-byte big-endian slice, the
+// wire format used for the seq frame in both the live PUB stream and KV
+// events replay.
+func EncodeSeq(seq uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, seq)
+	return b
+}
 
 // Publisher sends events to a ZMQ endpoint.
 type Publisher struct {
@@ -71,30 +108,29 @@ func NewPublisher(ctx context.Context, endpoint string) (*Publisher, error) {
 	}, nil
 }
 
-// PublishEvent publishes a KV cache event batch to the ZMQ topic.
-// topic should include the pod identifier (e.g., "kv.pod1").
-func (p *Publisher) PublishEvent(ctx context.Context, topic string, batch interface{}) error {
+// PublishEvent marshals batch, assigns the next sequence number, and sends
+// [topic, seq, payload] over ZMQ. Returns the assigned sequence number and
+// the marshaled payload so callers can store it without re-encoding.
+func (p *Publisher) PublishEvent(ctx context.Context, topic string, batch interface{}) (uint64, []byte, error) {
 	logger := klog.FromContext(ctx).V(0)
 
 	payload, err := msgpack.Marshal(batch)
 	if err != nil {
-		return fmt.Errorf("failed to marshal event batch: %w", err)
+		return 0, nil, fmt.Errorf("failed to marshal event batch: %w", err)
 	}
 
 	// sequence number for ordering
 	seq := atomic.AddUint64(&p.seqNum, 1)
-	seqBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(seqBytes, seq)
 
 	// send topic, sequence, payload
-	msg := zmq4.NewMsgFrom([]byte(topic), seqBytes, payload)
+	msg := zmq4.NewMsgFrom([]byte(topic), EncodeSeq(seq), payload)
 
 	if err = p.socket.Send(msg); err != nil {
-		return fmt.Errorf("failed to send message to topic %s: %w", topic, err)
+		return 0, nil, fmt.Errorf("failed to send message to topic %s: %w", topic, err)
 	}
 
 	logger.V(logging.TRACE).Info("Published event batch", "topic", topic, "seq", seq)
-	return nil
+	return seq, payload, nil
 }
 
 // Close closes the publisher and cleans up resources.

--- a/pkg/common/publisher_test.go
+++ b/pkg/common/publisher_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Publisher", func() {
 		go func() {
 			// Make sure that sub.RecvMessageBytes is called before pub.PublishEvent
 			time.Sleep(time.Second)
-			err := pub.PublishEvent(ctx, topic, data)
+			_, _, err := pub.PublishEvent(ctx, topic, data)
 			Expect(err).NotTo(HaveOccurred())
 		}()
 

--- a/pkg/common/publisher_test.go
+++ b/pkg/common/publisher_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"net"
+	"fmt"
 
 	"time"
 
@@ -81,10 +81,9 @@ var _ = Describe("Publisher", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		freePort, err := getFreePort()
+		freePort, err := FreeTCPPort()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(freePort).ToNot(BeEmpty())
-		endpoint := "tcp://127.0.0.1:" + freePort
+		endpoint := fmt.Sprintf("tcp://127.0.0.1:%d", freePort)
 
 		// create publisher - it will try to connect to the listener, but the listener is not started yet
 		pub, err := NewPublisher(ctx, endpoint)
@@ -149,17 +148,3 @@ var _ = Describe("Publisher", func() {
 
 	})
 })
-
-func getFreePort() (string, error) {
-	var listener net.Listener
-	var err error
-	if listener, err = net.Listen("tcp", ":0"); err == nil {
-		var port string
-		_, port, err = net.SplitHostPort(listener.Addr().String())
-		defer func() {
-			_ = listener.Close()
-		}()
-		return port, err
-	}
-	return "", err
-}

--- a/pkg/common/test_utils.go
+++ b/pkg/common/test_utils.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"context"
+	"net"
 
 	zmq4 "github.com/go-zeromq/zmq4"
 	"github.com/onsi/gomega"
@@ -40,6 +41,20 @@ func CreateSub(ctx context.Context, topic string) (zmq4.Socket, string) {
 
 func NewSub(ctx context.Context) zmq4.Socket {
 	return zmq4.NewSub(ctx)
+}
+
+// FreeTCPPort asks the OS for a currently-unused TCP port by binding to port
+// 0, reading back the assigned port, and releasing it immediately. There's a
+// small window before the real bind where another process could take the
+// port, but it's negligible in practice and avoids hardcoding ports that can
+// collide with other tests or leftover processes.
+func FreeTCPPort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close() //nolint:errcheck
+	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 // starts the given sub on a random port and subscribes to the given topic. Returns the sub and the real endpoint to publish events on.

--- a/pkg/kv-cache/block_cache.go
+++ b/pkg/kv-cache/block_cache.go
@@ -86,8 +86,15 @@ func newBlockCache(ctx context.Context, config *common.Configuration, logger log
 		}
 	}
 
-	eventSender := NewKVEventSender(publisher, CreateKVEventsTopic(config.IP, config.Model),
-		eChan, config.EventBatchSize, config.TokenBlockSize, delay, config.UseVllmMapEventFormat, config.Rank, logger)
+	topic := CreateKVEventsTopic(config.IP, config.Model)
+
+	var replayer *kvEventsReplayer
+	if config.KVEventsReplayEndpoint != "" {
+		replayer = newKVEventsReplayer(config.KVEventsReplayEndpoint, topic, config.KVEventsReplayQueueSize, logger)
+	}
+
+	eventSender := NewKVEventSender(publisher, topic,
+		eChan, config.EventBatchSize, config.TokenBlockSize, delay, config.UseVllmMapEventFormat, config.Rank, logger, replayer)
 
 	bCache := blockCache{
 		requestToBlocks: make(map[string][]blockKey),

--- a/pkg/kv-cache/kv_cache.go
+++ b/pkg/kv-cache/kv_cache.go
@@ -80,6 +80,13 @@ func NewKVCacheHelper(ctx context.Context, config *common.Configuration, logger 
 
 // Run starts the helper.
 func (h *KVCacheHelper) Run(ctx context.Context) {
+	if r := h.blockCache.eventSender.replayer; r != nil {
+		go func() {
+			if err := r.run(ctx); err != nil {
+				h.logger.Error(err, "KV events replayer stopped with error")
+			}
+		}()
+	}
 	h.blockCache.start(ctx)
 }
 

--- a/pkg/kv-cache/kv_cache.go
+++ b/pkg/kv-cache/kv_cache.go
@@ -81,11 +81,15 @@ func NewKVCacheHelper(ctx context.Context, config *common.Configuration, logger 
 // Run starts the helper.
 func (h *KVCacheHelper) Run(ctx context.Context) {
 	if r := h.blockCache.eventSender.replayer; r != nil {
-		go func() {
-			if err := r.run(ctx); err != nil {
-				h.logger.Error(err, "KV events replayer stopped with error")
-			}
-		}()
+		if _, err := r.listen(ctx); err != nil {
+			h.logger.Error(err, "KV events replayer failed to bind, replay will be unavailable")
+		} else {
+			go func() {
+				if err := r.serve(ctx); err != nil {
+					h.logger.Error(err, "KV events replayer stopped with error")
+				}
+			}()
+		}
 	}
 	h.blockCache.start(ctx)
 }

--- a/pkg/kv-cache/kv_cache_sender.go
+++ b/pkg/kv-cache/kv_cache_sender.go
@@ -135,10 +135,12 @@ type KVEventSender struct {
 	logger                logr.Logger
 	useVllmMapEventFormat bool
 	dpRank                int
+	replayer              *kvEventsReplayer // nil when replay is disabled
 }
 
 func NewKVEventSender(publisher *common.Publisher, topic string, ch common.Channel[EventData], maxBatchSize int,
-	blockSize int, delay time.Duration, useVllmMapEventFormat bool, dpRank int, logger logr.Logger) *KVEventSender {
+	blockSize int, delay time.Duration, useVllmMapEventFormat bool, dpRank int, logger logr.Logger,
+	replayer *kvEventsReplayer) *KVEventSender {
 	return &KVEventSender{
 		publisher:             publisher,
 		topic:                 topic,
@@ -150,6 +152,7 @@ func NewKVEventSender(publisher *common.Publisher, topic string, ch common.Chann
 		logger:                logger,
 		useVllmMapEventFormat: useVllmMapEventFormat,
 		dpRank:                dpRank,
+		replayer:              replayer,
 	}
 }
 
@@ -332,7 +335,10 @@ func (s *KVEventSender) publishHelper(ctx context.Context) error {
 		DataParallelRank: &dpRank,
 	}
 
-	err := s.publisher.PublishEvent(ctx, s.topic, batch)
+	seq, payload, err := s.publisher.PublishEvent(ctx, s.topic, batch)
+	if err == nil && s.replayer != nil {
+		s.replayer.store(seq, payload)
+	}
 
 	// reset batch
 	s.batch = make([]batchEntry, 0, s.maxBatchSize)

--- a/pkg/kv-cache/kv_events_replayer.go
+++ b/pkg/kv-cache/kv_events_replayer.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package kvcache
+
+import (
+	"context"
+	"encoding/binary"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	zmq4 "github.com/go-zeromq/zmq4"
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
+)
+
+// replayRecvErrorBackoff bounds how fast we retry socket.Recv() after a
+// non-context error, so a persistent receive failure can't busy-spin the
+// loop or flood the log.
+const replayRecvErrorBackoff = 100 * time.Millisecond
+
+// replayEntry holds one published event batch payload together with its
+// sequence number for range-based filtering.
+type replayEntry struct {
+	seq     uint64
+	payload []byte
+}
+
+// replaySentinel is the sequence value used in the vLLM end-of-replay sentinel frame.
+const replaySentinel = ^uint64(0) // 0xFFFFFFFFFFFFFFFF
+
+// replayQueue is a fixed-capacity ring buffer of replayEntry values.
+// When full, the oldest entry is silently overwritten (sliding window).
+type replayQueue struct {
+	mu       sync.Mutex
+	buf      []replayEntry
+	head     int // next write slot
+	size     int // number of valid entries
+	capacity int
+}
+
+func newReplayQueue(capacity int) *replayQueue {
+	return &replayQueue{
+		buf:      make([]replayEntry, capacity),
+		capacity: capacity,
+	}
+}
+
+// push adds an entry, overwriting the oldest when full.
+func (q *replayQueue) push(entry replayEntry) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.buf[q.head] = entry
+	q.head = (q.head + 1) % q.capacity
+	if q.size < q.capacity {
+		q.size++
+	}
+}
+
+// since returns all stored entries with seq >= startSeq, in insertion order.
+// Entries are stored in strictly increasing sequence order. The loop short-circuits
+// on the first match and appends everything from that point on
+func (q *replayQueue) since(startSeq uint64) []replayEntry {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// head points one slot past the newest entry, so stepping back size slots
+	// reaches the oldest entry.
+	// +capacity before % prevents a negative result when
+	// head has wrapped around.
+	oldest := (q.head - q.size + q.capacity) % q.capacity
+
+	var result []replayEntry
+	collecting := false
+	for i := 0; i < q.size; i++ {
+		e := q.buf[(oldest+i)%q.capacity]
+		if !collecting {
+			if e.seq >= startSeq {
+				collecting = true
+			} else {
+				continue
+			}
+		}
+		result = append(result, e)
+	}
+	return result
+}
+
+// len returns the number of entries currently stored.
+func (q *replayQueue) len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.size
+}
+
+// kvEventsReplayer binds a ZMQ ROUTER socket on the replay endpoint.
+type kvEventsReplayer struct {
+	endpoint string
+	topic    string
+	queue    *replayQueue
+	logger   logr.Logger
+}
+
+// newKVEventsReplayer creates a replayer that will bind a ROUTER socket on endpoint.
+// topic is included in every replayed batch frame, matching the live PUB stream.
+func newKVEventsReplayer(endpoint string, topic string, queueSize int, logger logr.Logger) *kvEventsReplayer {
+	return &kvEventsReplayer{
+		endpoint: endpoint,
+		topic:    topic,
+		queue:    newReplayQueue(queueSize),
+		logger:   logger,
+	}
+}
+
+// store is called by KVEventSender each time a batch is published, recording
+// the msgpack payload and its sequence number in the sliding queue.
+func (r *kvEventsReplayer) store(seq uint64, payload []byte) {
+	r.queue.push(replayEntry{seq: seq, payload: payload})
+	r.logger.V(logging.DEBUG).Info("KV events replayer stored batch", "seq", seq, "queue_size", r.queue.len())
+}
+
+// run binds the ROUTER socket and handles replay requests until ctx is cancelled.
+// Each request arrives as [identity, empty-delimiter, 8-byte-seq] (REQ/ROUTER
+// pair). Replies are sent back to the same identity.
+func (r *kvEventsReplayer) run(ctx context.Context) error {
+	socket := zmq4.NewRouter(ctx)
+	defer socket.Close() //nolint:errcheck
+
+	if err := socket.Listen(r.endpoint); err != nil {
+		return err
+	}
+	r.logger.V(logging.INFO).Info("KV events replayer listening", "endpoint", r.endpoint)
+
+	for {
+		msg, err := socket.Recv()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			r.logger.Error(err, "KV events replayer receive error")
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(replayRecvErrorBackoff):
+			}
+			continue
+		}
+
+		// ROUTER + REQ framing: [identity, empty-delimiter, payload]
+		if len(msg.Frames) != 3 {
+			r.logger.V(logging.DEBUG).Info("KV events replayer: unexpected frame count, ignoring",
+				"frames", len(msg.Frames))
+			continue
+		}
+
+		// msg.Frames[1] is the empty delimiter inserted by the REQ socket.
+		r.handleReplayRequest(ctx, socket, msg.Frames[0], msg.Frames[2])
+	}
+}
+
+// handleReplayRequest parses the start sequence number, looks up matched
+// batches, and sends them (plus the end-of-replay sentinel) back
+// to the requesting client over the ROUTER socket.
+// Each reply frame follows the same [topic, seq(8B big-endian), payload] wire
+// format as the live PUB stream so subscribers can decode them identically.
+//
+// The send loop runs in a goroutine so a slow client doesn't block the
+// ROUTER's receive loop (Recv/Send use independent locks in go-zeromq/zmq4).
+// Send() itself blocks for as long as the client takes to drain its socket —
+// there is no per-message timeout, since go-zeromq's Send() performs a
+// literal blocking OS write with no way to bound or cancel it once in
+// flight, so a timeout here couldn't actually free a stuck client's
+// connection anyway; a slow-but-still-reading client (the expected case)
+// just waits, at the cost of leaking this goroutine if a client vanishes
+// without closing its connection.
+func (r *kvEventsReplayer) handleReplayRequest(ctx context.Context, socket zmq4.Socket, identity []byte, frame []byte) {
+	if len(frame) < 8 {
+		r.logger.V(logging.DEBUG).Info("KV events replayer: replay request frame too short, ignoring")
+		return
+	}
+
+	startSeq := binary.BigEndian.Uint64(frame)
+	batches := r.queue.since(startSeq)
+	r.logger.V(logging.INFO).Info("KV events replayer replay request",
+		"start_seq", startSeq, "batches_to_replay", len(batches))
+
+	// Copy identity so the goroutine closure is safe after run() advances.
+	id := make([]byte, len(identity))
+	copy(id, identity)
+
+	topic := []byte(r.topic)
+
+	go func() {
+		for _, b := range batches {
+			if ctx.Err() != nil {
+				return
+			}
+			reply := zmq4.NewMsgFrom(id, []byte{}, topic, common.EncodeSeq(b.seq), b.payload)
+			if err := socket.Send(reply); err != nil {
+				r.logger.Error(err, "KV events replayer: failed to send replay batch, abandoning remaining replay",
+					"seq", b.seq)
+				return
+			}
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		// End-of-replay sentinel: empty topic, seq=0xFFFFFFFFFFFFFFFF, empty payload.
+		sentinel := zmq4.NewMsgFrom(id, []byte{}, []byte{}, common.EncodeSeq(replaySentinel), []byte{})
+		if err := socket.Send(sentinel); err != nil {
+			r.logger.Error(err, "KV events replayer: failed to send end-of-replay sentinel")
+		}
+	}()
+}

--- a/pkg/kv-cache/kv_events_replayer.go
+++ b/pkg/kv-cache/kv_events_replayer.go
@@ -18,6 +18,7 @@ package kvcache
 import (
 	"context"
 	"encoding/binary"
+	"net"
 	"sync"
 	"time"
 
@@ -42,61 +43,50 @@ type replayEntry struct {
 // replaySentinel is the sequence value used in the vLLM end-of-replay sentinel frame.
 const replaySentinel = ^uint64(0) // 0xFFFFFFFFFFFFFFFF
 
-// replayQueue is a fixed-capacity ring buffer of replayEntry values.
-// When full, the oldest entry is silently overwritten (sliding window).
+// replayQueue is a bounded FIFO of replayEntry values, holding at most
+// capacity entries in insertion order. When full, the oldest entry is
+// dropped to make room (sliding window).
 type replayQueue struct {
 	mu       sync.Mutex
 	buf      []replayEntry
-	head     int // next write slot
-	size     int // number of valid entries
 	capacity int
 }
 
 func newReplayQueue(capacity int) *replayQueue {
 	return &replayQueue{
-		buf:      make([]replayEntry, capacity),
+		buf:      make([]replayEntry, 0, capacity),
 		capacity: capacity,
 	}
 }
 
-// push adds an entry, overwriting the oldest when full.
+// push adds an entry, dropping the oldest when full.
 func (q *replayQueue) push(entry replayEntry) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	q.buf[q.head] = entry
-	q.head = (q.head + 1) % q.capacity
-	if q.size < q.capacity {
-		q.size++
+	if len(q.buf) == q.capacity {
+		copy(q.buf, q.buf[1:])
+		q.buf = q.buf[:len(q.buf)-1]
 	}
+	q.buf = append(q.buf, entry)
 }
 
 // since returns all stored entries with seq >= startSeq, in insertion order.
-// Entries are stored in strictly increasing sequence order. The loop short-circuits
-// on the first match and appends everything from that point on
+// Entries are stored in strictly increasing sequence order, so the search
+// short-circuits on the first match and the rest is copied out in one go.
 func (q *replayQueue) since(startSeq uint64) []replayEntry {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	// head points one slot past the newest entry, so stepping back size slots
-	// reaches the oldest entry.
-	// +capacity before % prevents a negative result when
-	// head has wrapped around.
-	oldest := (q.head - q.size + q.capacity) % q.capacity
-
-	var result []replayEntry
-	collecting := false
-	for i := 0; i < q.size; i++ {
-		e := q.buf[(oldest+i)%q.capacity]
-		if !collecting {
-			if e.seq >= startSeq {
-				collecting = true
-			} else {
-				continue
-			}
+	start := len(q.buf)
+	for i, e := range q.buf {
+		if e.seq >= startSeq {
+			start = i
+			break
 		}
-		result = append(result, e)
 	}
+	result := make([]replayEntry, len(q.buf)-start)
+	copy(result, q.buf[start:])
 	return result
 }
 
@@ -104,7 +94,7 @@ func (q *replayQueue) since(startSeq uint64) []replayEntry {
 func (q *replayQueue) len() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return q.size
+	return len(q.buf)
 }
 
 // kvEventsReplayer binds a ZMQ ROUTER socket on the replay endpoint.
@@ -113,6 +103,7 @@ type kvEventsReplayer struct {
 	topic    string
 	queue    *replayQueue
 	logger   logr.Logger
+	socket   zmq4.Socket // set by listen; nil until then
 }
 
 // newKVEventsReplayer creates a replayer that will bind a ROUTER socket on endpoint.
@@ -130,20 +121,34 @@ func newKVEventsReplayer(endpoint string, topic string, queueSize int, logger lo
 // the msgpack payload and its sequence number in the sliding queue.
 func (r *kvEventsReplayer) store(seq uint64, payload []byte) {
 	r.queue.push(replayEntry{seq: seq, payload: payload})
-	r.logger.V(logging.DEBUG).Info("KV events replayer stored batch", "seq", seq, "queue_size", r.queue.len())
+	r.logger.V(logging.TRACE).Info("KV events replayer stored batch", "seq", seq, "queue_size", r.queue.len())
 }
 
-// run binds the ROUTER socket and handles replay requests until ctx is cancelled.
-// Each request arrives as [identity, empty-delimiter, 8-byte-seq] (REQ/ROUTER
-// pair). Replies are sent back to the same identity.
-func (r *kvEventsReplayer) run(ctx context.Context) error {
+// listen creates and binds the ROUTER socket, returning the resolved address.
+// This matters when endpoint uses a wildcard port (e.g. "tcp://127.0.0.1:0"):
+// the caller can only learn the OS-assigned port after Listen succeeds, which
+// is why binding is split out from serve rather than happening inside it.
+// The socket is kept open until serve returns; call serve exactly once after
+// a successful listen.
+func (r *kvEventsReplayer) listen(ctx context.Context) (net.Addr, error) {
 	socket := zmq4.NewRouter(ctx)
-	defer socket.Close() //nolint:errcheck
-
 	if err := socket.Listen(r.endpoint); err != nil {
-		return err
+		_ = socket.Close()
+		return nil, err
 	}
-	r.logger.V(logging.INFO).Info("KV events replayer listening", "endpoint", r.endpoint)
+	r.socket = socket
+
+	addr := socket.Addr()
+	r.logger.V(logging.INFO).Info("KV events replayer listening", "endpoint", addr.String())
+	return addr, nil
+}
+
+// serve handles replay requests on the socket bound by listen, until ctx is
+// cancelled. Each request arrives as [identity, empty-delimiter, 8-byte-seq]
+// (REQ/ROUTER pair). Replies are sent back to the same identity.
+func (r *kvEventsReplayer) serve(ctx context.Context) error {
+	socket := r.socket
+	defer socket.Close() //nolint:errcheck
 
 	for {
 		msg, err := socket.Recv()
@@ -179,14 +184,23 @@ func (r *kvEventsReplayer) run(ctx context.Context) error {
 // format as the live PUB stream so subscribers can decode them identically.
 //
 // The send loop runs in a goroutine so a slow client doesn't block the
-// ROUTER's receive loop (Recv/Send use independent locks in go-zeromq/zmq4).
-// Send() itself blocks for as long as the client takes to drain its socket —
-// there is no per-message timeout, since go-zeromq's Send() performs a
-// literal blocking OS write with no way to bound or cancel it once in
-// flight, so a timeout here couldn't actually free a stuck client's
-// connection anyway; a slow-but-still-reading client (the expected case)
-// just waits, at the cost of leaking this goroutine if a client vanishes
-// without closing its connection.
+// ROUTER's receive loop — Recv and Send use independent locks in
+// go-zeromq/zmq4, so new incoming replay requests are still parsed while a
+// reply is in flight.
+//
+// This does NOT isolate clients from each other, though: every Send() on a
+// ROUTER socket funnels through zmq4's routerMWriter.write(), which holds a
+// single mutex for the entire blocking OS write, regardless of which peer
+// it's writing to (verified against go-zeromq/zmq4@v0.17.0's router.go). So
+// while this goroutine is blocked inside Send() for one client, every other
+// client's reply goroutine — call it from a request received concurrently —
+// blocks too, waiting on that same mutex, even if its own connection is
+// healthy and actively draining. There is no per-message timeout to bound
+// this: go-zeromq's Send() performs a literal blocking OS write with no way
+// to cancel it once in flight (the context timeout it wraps the write in is
+// never wired to a net.Conn deadline), so a single client that stops
+// draining its socket without closing the connection can stall replay for
+// every other client on this rank until that connection is closed.
 func (r *kvEventsReplayer) handleReplayRequest(ctx context.Context, socket zmq4.Socket, identity []byte, frame []byte) {
 	if len(frame) < 8 {
 		r.logger.V(logging.DEBUG).Info("KV events replayer: replay request frame too short, ignoring")

--- a/pkg/kv-cache/kv_events_replayer_test.go
+++ b/pkg/kv-cache/kv_events_replayer_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package kvcache
+
+import (
+	"context"
+	"encoding/binary"
+	"time"
+
+	zmq4 "github.com/go-zeromq/zmq4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// sendReplayRequestAndRecv connects a REQ socket to the replayer ROUTER endpoint,
+// sends an 8-byte big-endian start sequence number, and returns all reply frames
+// received until the end-of-replay sentinel (seq == 0xFFFFFFFFFFFFFFFF).
+func sendReplayRequestAndRecv(ctx context.Context, endpoint string, startSeq uint64) []zmq4.Msg {
+	req := zmq4.NewReq(ctx)
+	defer req.Close() //nolint:errcheck
+
+	err := req.Dial(endpoint)
+	Expect(err).NotTo(HaveOccurred())
+
+	frame := make([]byte, 8)
+	binary.BigEndian.PutUint64(frame, startSeq)
+	err = req.Send(zmq4.NewMsg(frame))
+	Expect(err).NotTo(HaveOccurred())
+
+	var replies []zmq4.Msg
+	for {
+		msg, err := req.Recv()
+		Expect(err).NotTo(HaveOccurred())
+		// REQ socket strips the identity + delimiter; frames are [topic, seq(8B), payload]
+		Expect(msg.Frames).To(HaveLen(3))
+		seq := binary.BigEndian.Uint64(msg.Frames[1])
+		replies = append(replies, msg)
+		if seq == replaySentinel {
+			break
+		}
+	}
+	return replies
+}
+
+var _ = Describe("kvEventsReplayer", func() {
+	const (
+		replayEndpoint = "tcp://127.0.0.1:15558"
+		replayTopic    = "kv.test-topic"
+	)
+
+	Describe("replayQueue", func() {
+		It("stores entries and returns them in insertion order", func() {
+			q := newReplayQueue(5)
+			for i := uint64(1); i <= 3; i++ {
+				q.push(replayEntry{seq: i, payload: []byte{byte(i)}})
+			}
+			Expect(q.len()).To(Equal(3))
+			Expect(q.since(1)).To(HaveLen(3))
+			Expect(q.since(2)).To(HaveLen(2))
+			Expect(q.since(3)).To(HaveLen(1))
+			Expect(q.since(4)).To(BeEmpty())
+		})
+
+		It("overwrites the oldest entry when full", func() {
+			q := newReplayQueue(3)
+			for i := uint64(1); i <= 5; i++ {
+				q.push(replayEntry{seq: i, payload: []byte{byte(i)}})
+			}
+			Expect(q.len()).To(Equal(3))
+			// seq 1 and 2 have been dropped; only 3, 4, 5 remain
+			Expect(q.since(1)).To(HaveLen(3))
+			seqs := make([]uint64, 0, 3)
+			for _, e := range q.since(1) {
+				seqs = append(seqs, e.seq)
+			}
+			Expect(seqs).To(Equal([]uint64{3, 4, 5}))
+		})
+
+		It("returns correct payloads for since", func() {
+			q := newReplayQueue(10)
+			for i := uint64(1); i <= 5; i++ {
+				q.push(replayEntry{seq: i, payload: []byte{byte(i * 10)}})
+			}
+			entries := q.since(3)
+			Expect(entries).To(HaveLen(3))
+			Expect(entries[0].seq).To(Equal(uint64(3)))
+			Expect(entries[1].seq).To(Equal(uint64(4)))
+			Expect(entries[2].seq).To(Equal(uint64(5)))
+		})
+	})
+
+	Describe("kvEventsReplayer.store", func() {
+		It("feeds batches into the queue", func() {
+			r := newKVEventsReplayer(replayEndpoint, replayTopic, 10, GinkgoLogr)
+
+			r.store(1, []byte("batch-1"))
+			r.store(2, []byte("batch-2"))
+			r.store(3, []byte("batch-3"))
+
+			Expect(r.queue.len()).To(Equal(3))
+			entries := r.queue.since(2)
+			Expect(entries).To(HaveLen(2))
+			Expect(entries[0].seq).To(Equal(uint64(2)))
+			Expect(entries[0].payload).To(Equal([]byte("batch-2")))
+		})
+
+		It("slides out old batches when queue is full", func() {
+			r := newKVEventsReplayer(replayEndpoint, replayTopic, 3, GinkgoLogr)
+
+			for i := uint64(1); i <= 5; i++ {
+				r.store(i, []byte{byte(i)})
+			}
+
+			Expect(r.queue.len()).To(Equal(3))
+			// only seq 3, 4, 5 remain
+			Expect(r.queue.since(1)).To(HaveLen(3))
+			Expect(r.queue.since(1)[0].seq).To(Equal(uint64(3)))
+		})
+	})
+
+	Describe("kvEventsReplayer.run", func() {
+		It("receives replay request and sends matched batches back to the requester", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			r := newKVEventsReplayer(replayEndpoint, replayTopic, 10, GinkgoLogr)
+
+			// Pre-populate the queue with 4 batches
+			for i := uint64(1); i <= 4; i++ {
+				r.store(i, []byte{byte(i)})
+			}
+
+			// Start the replayer in the background
+			runDone := make(chan struct{})
+			go func() {
+				defer close(runDone)
+				_ = r.run(ctx)
+			}()
+
+			// Give the socket time to bind
+			time.Sleep(300 * time.Millisecond)
+
+			// Send a replay request from seq 3; expect 2 batches + sentinel back
+			replies := sendReplayRequestAndRecv(ctx, replayEndpoint, 3)
+
+			// Last reply is the sentinel; the rest are the matched batches
+			Expect(replies).To(HaveLen(3)) // seq 3, seq 4, sentinel
+			Expect(string(replies[0].Frames[0])).To(Equal(replayTopic))
+			Expect(binary.BigEndian.Uint64(replies[0].Frames[1])).To(Equal(uint64(3)))
+			Expect(string(replies[1].Frames[0])).To(Equal(replayTopic))
+			Expect(binary.BigEndian.Uint64(replies[1].Frames[1])).To(Equal(uint64(4)))
+			// The sentinel carries an empty topic frame, distinguishing it from real batches.
+			Expect(replies[2].Frames[0]).To(BeEmpty())
+			Expect(binary.BigEndian.Uint64(replies[2].Frames[1])).To(Equal(replaySentinel))
+
+			cancel()
+			Eventually(runDone, 3*time.Second).Should(BeClosed())
+		})
+
+		It("ignores messages with unexpected frame counts", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			r := newKVEventsReplayer(replayEndpoint, replayTopic, 10, GinkgoLogr)
+			r.store(1, []byte{0x01})
+
+			runDone := make(chan struct{})
+			go func() {
+				defer close(runDone)
+				_ = r.run(ctx)
+			}()
+
+			time.Sleep(300 * time.Millisecond)
+
+			// A DEALER socket is a legal raw peer for ROUTER but does NOT add an empty
+			// delimiter frame. Sending one frame from DEALER produces [identity, data] at
+			// the ROUTER — 2 frames, not the expected 3 — so it must be ignored.
+			dealer := zmq4.NewDealer(ctx)
+			defer dealer.Close() //nolint:errcheck
+			Expect(dealer.Dial(replayEndpoint)).To(Succeed())
+			err := dealer.Send(zmq4.NewMsg([]byte("bad-request")))
+			Expect(err).NotTo(HaveOccurred())
+
+			time.Sleep(200 * time.Millisecond)
+			// Queue should be unchanged
+			Expect(r.queue.len()).To(Equal(1))
+
+			cancel()
+			Eventually(runDone, 3*time.Second).Should(BeClosed())
+		})
+	})
+})

--- a/pkg/kv-cache/kv_events_replayer_test.go
+++ b/pkg/kv-cache/kv_events_replayer_test.go
@@ -25,39 +25,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// sendReplayRequestAndRecv connects a REQ socket to the replayer ROUTER endpoint,
-// sends an 8-byte big-endian start sequence number, and returns all reply frames
-// received until the end-of-replay sentinel (seq == 0xFFFFFFFFFFFFFFFF).
-func sendReplayRequestAndRecv(ctx context.Context, endpoint string, startSeq uint64) []zmq4.Msg {
-	req := zmq4.NewReq(ctx)
-	defer req.Close() //nolint:errcheck
-
-	err := req.Dial(endpoint)
-	Expect(err).NotTo(HaveOccurred())
-
-	frame := make([]byte, 8)
-	binary.BigEndian.PutUint64(frame, startSeq)
-	err = req.Send(zmq4.NewMsg(frame))
-	Expect(err).NotTo(HaveOccurred())
-
-	var replies []zmq4.Msg
-	for {
-		msg, err := req.Recv()
-		Expect(err).NotTo(HaveOccurred())
-		// REQ socket strips the identity + delimiter; frames are [topic, seq(8B), payload]
-		Expect(msg.Frames).To(HaveLen(3))
-		seq := binary.BigEndian.Uint64(msg.Frames[1])
-		replies = append(replies, msg)
-		if seq == replaySentinel {
-			break
-		}
-	}
-	return replies
-}
-
 var _ = Describe("kvEventsReplayer", func() {
 	const (
-		replayEndpoint = "tcp://127.0.0.1:15558"
+		// Port 0 lets the OS assign a free port; listen() reports back which one.
+		replayEndpoint = "tcp://127.0.0.1:0"
 		replayTopic    = "kv.test-topic"
 	)
 
@@ -116,22 +87,24 @@ var _ = Describe("kvEventsReplayer", func() {
 			Expect(entries[0].seq).To(Equal(uint64(2)))
 			Expect(entries[0].payload).To(Equal([]byte("batch-2")))
 		})
-
-		It("slides out old batches when queue is full", func() {
-			r := newKVEventsReplayer(replayEndpoint, replayTopic, 3, GinkgoLogr)
-
-			for i := uint64(1); i <= 5; i++ {
-				r.store(i, []byte{byte(i)})
-			}
-
-			Expect(r.queue.len()).To(Equal(3))
-			// only seq 3, 4, 5 remain
-			Expect(r.queue.since(1)).To(HaveLen(3))
-			Expect(r.queue.since(1)[0].seq).To(Equal(uint64(3)))
-		})
 	})
 
 	Describe("kvEventsReplayer.run", func() {
+		// startReplayer binds r and serves it in the background, returning the
+		// resolved endpoint (with the OS-assigned port, if any) and a channel
+		// closed once serve returns.
+		startReplayer := func(ctx context.Context, r *kvEventsReplayer) (string, chan struct{}) {
+			addr, err := r.listen(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_ = r.serve(ctx)
+			}()
+			return "tcp://" + addr.String(), done
+		}
+
 		It("receives replay request and sends matched batches back to the requester", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -143,18 +116,10 @@ var _ = Describe("kvEventsReplayer", func() {
 				r.store(i, []byte{byte(i)})
 			}
 
-			// Start the replayer in the background
-			runDone := make(chan struct{})
-			go func() {
-				defer close(runDone)
-				_ = r.run(ctx)
-			}()
-
-			// Give the socket time to bind
-			time.Sleep(300 * time.Millisecond)
+			endpoint, runDone := startReplayer(ctx, r)
 
 			// Send a replay request from seq 3; expect 2 batches + sentinel back
-			replies := sendReplayRequestAndRecv(ctx, replayEndpoint, 3)
+			replies := SendReplayRequestAndRecv(ctx, endpoint, 3)
 
 			// Last reply is the sentinel; the rest are the matched batches
 			Expect(replies).To(HaveLen(3)) // seq 3, seq 4, sentinel
@@ -177,20 +142,14 @@ var _ = Describe("kvEventsReplayer", func() {
 			r := newKVEventsReplayer(replayEndpoint, replayTopic, 10, GinkgoLogr)
 			r.store(1, []byte{0x01})
 
-			runDone := make(chan struct{})
-			go func() {
-				defer close(runDone)
-				_ = r.run(ctx)
-			}()
-
-			time.Sleep(300 * time.Millisecond)
+			endpoint, runDone := startReplayer(ctx, r)
 
 			// A DEALER socket is a legal raw peer for ROUTER but does NOT add an empty
 			// delimiter frame. Sending one frame from DEALER produces [identity, data] at
 			// the ROUTER — 2 frames, not the expected 3 — so it must be ignored.
 			dealer := zmq4.NewDealer(ctx)
 			defer dealer.Close() //nolint:errcheck
-			Expect(dealer.Dial(replayEndpoint)).To(Succeed())
+			Expect(dealer.Dial(endpoint)).To(Succeed())
 			err := dealer.Send(zmq4.NewMsg([]byte("bad-request")))
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/kv-cache/kv_test_helper.go
+++ b/pkg/kv-cache/kv_test_helper.go
@@ -17,8 +17,10 @@ limitations under the License.
 package kvcache
 
 import (
+	"context"
 	"encoding/binary"
 
+	zmq4 "github.com/go-zeromq/zmq4"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents/engineadapter"
 	"github.com/onsi/ginkgo/v2"
@@ -121,6 +123,35 @@ func CountKVEventBlocks(parts [][]byte, expectedTopic string, expectedSeq uint64
 	}
 
 	return storedCount, removedCount, allCleared
+}
+
+// SendReplayRequestAndRecv connects a REQ socket to a KV events replay ROUTER
+// endpoint, sends startSeq as an 8-byte big-endian frame, and returns all
+// reply messages up to and including the end-of-replay sentinel. The REQ
+// socket strips the identity + empty-delimiter frames automatically, so each
+// returned message has frames [topic, seq(8B big-endian), payload]; the
+// sentinel is distinguished from real batches by its empty topic frame.
+func SendReplayRequestAndRecv(ctx context.Context, endpoint string, startSeq uint64) []zmq4.Msg {
+	req := zmq4.NewReq(ctx)
+	defer req.Close() //nolint:errcheck
+
+	gomega.Expect(req.Dial(endpoint)).To(gomega.Succeed())
+
+	frame := make([]byte, 8)
+	binary.BigEndian.PutUint64(frame, startSeq)
+	gomega.Expect(req.Send(zmq4.NewMsg(frame))).To(gomega.Succeed())
+
+	var replies []zmq4.Msg
+	for {
+		msg, err := req.Recv()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(msg.Frames).To(gomega.HaveLen(3))
+		replies = append(replies, msg)
+		if len(msg.Frames[0]) == 0 {
+			break
+		}
+	}
+	return replies
 }
 
 // ParseKVBatchRank decodes the DataParallelRank field from a raw ZMQ message.

--- a/pkg/llm-d-inference-sim/helpers.go
+++ b/pkg/llm-d-inference-sim/helpers.go
@@ -19,8 +19,6 @@ package llmdinferencesim
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/llm-d/llm-d-inference-sim/pkg/api"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
@@ -104,19 +102,4 @@ func buildECTransferParams(mmHashes map[string][]string) map[string]api.ECTransf
 		}
 	}
 	return params
-}
-
-// offsetZMQEndpointPort adds the given offset to the port in a ZMQ endpoint
-// string (e.g. "tcp://127.0.0.1:5557"). Returns the original endpoint unchanged
-// if parsing fails.
-func offsetZMQEndpointPort(endpoint string, offset int) string {
-	lastColon := strings.LastIndex(endpoint, ":")
-	if lastColon < 0 {
-		return endpoint
-	}
-	basePort, err := strconv.Atoi(endpoint[lastColon+1:])
-	if err != nil {
-		return endpoint
-	}
-	return endpoint[:lastColon+1] + strconv.Itoa(basePort+offset)
 }

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -125,8 +125,20 @@ func Start(ctx context.Context, config *common.Configuration, logger logr.Logger
 		}
 		if dpRank > 0 {
 			rankConfig.Port = config.Port + dpRank
+		}
+		// Offset ZMQ endpoints by the rank: dpRank when this process
+		// hosts all ranks, or the externally-assigned rank when each rank runs in
+		// its own process (config.Rank set).
+		effectiveRank := dpRank
+		if config.Rank >= 0 {
+			effectiveRank = config.Rank
+		}
+		if effectiveRank > 0 {
 			if config.ZMQEndpoint != "" {
-				rankConfig.ZMQEndpoint = offsetZMQEndpointPort(config.ZMQEndpoint, dpRank)
+				rankConfig.ZMQEndpoint = common.OffsetEndpointPort(config.ZMQEndpoint, effectiveRank)
+			}
+			if config.KVEventsReplayEndpoint != "" {
+				rankConfig.KVEventsReplayEndpoint = common.OffsetEndpointPort(config.KVEventsReplayEndpoint, effectiveRank)
 			}
 		}
 		// Store the effective rank in the per-rank config so downstream

--- a/pkg/tests/data_parallel_test.go
+++ b/pkg/tests/data_parallel_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Data Parallel", func() {
 		longPrompt := "This is a test message for kv cache events, has to be long enough to be tokenized into multiple blocks."
 
 		// Rank 0 gets a random port; ranks 1 and 2 get port+1 and port+2 respectively
-		// (the simulator calls offsetZMQEndpointPort(base, rank) for ranks > 0).
+		// (the simulator calls common.OffsetEndpointPort(base, rank) for ranks > 0).
 		topic := kvcache.CreateKVEventsTopic("localhost", model)
 		sub0, zmqEndpoint := common.CreateSub(ctx, topic)
 		defer sub0.Close() //nolint:errcheck

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"bufio"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	zmq4 "github.com/go-zeromq/zmq4"
 	"github.com/llm-d/llm-d-inference-sim/pkg/api"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	"github.com/llm-d/llm-d-inference-sim/pkg/communication"
@@ -1221,6 +1223,174 @@ force-dummy-tokenizer: false
 			firstCall := queryEngines(client)
 			secondCall := queryEngines(client)
 			Expect(secondCall).To(Equal(firstCall))
+		})
+	})
+
+	Context("kv-events replay", func() {
+		const (
+			replayEndpoint = "tcp://127.0.0.1:15559"
+			replayModel    = common.QwenModelName
+			replayMode     = common.ModeRandom
+			replayPrompt   = "This is a test message for kv cache events, has to be long enough to be tokenized into multiple blocks."
+		)
+
+		// setupReplayServer starts the simulator with replay enabled.
+		// Returns the HTTP client, the PUB subscriber (for watching live events), and the topic.
+		setupReplayServer := func(ctx context.Context) (*http.Client, zmq4.Socket, string) {
+			topic := kvcache.CreateKVEventsTopic("localhost", replayModel)
+			sub, zmqEndpoint := common.CreateSub(ctx, topic)
+
+			args := []string{"cmd", "--model", replayModel, "--mode", replayMode,
+				"--enable-kvcache", "true", "--kv-cache-size", "16", "--block-size", "8",
+				"--event-batch-size", "1", "--zmq-endpoint", zmqEndpoint,
+				"--kv-events-replay-endpoint", replayEndpoint,
+				"--kv-events-replay-queue-size", "64",
+			}
+			client, err := startServerWithArgsAndEnv(ctx, replayMode, args, map[string]string{"POD_IP": "localhost"})
+			Expect(err).NotTo(HaveOccurred())
+			return client, sub, topic
+		}
+
+		// sendReplayRequestAndRecv connects a REQ socket to the ROUTER replay endpoint,
+		// sends startSeq, and collects all reply batches until the sentinel.
+		// Replies are [topic, seq(8B), payload] frames (REQ strips identity+delimiter),
+		// the same shape as the live PUB stream.
+		// Returns (totalStoredBlocks, lastSeq).
+		sendReplayRequestAndRecv := func(ctx context.Context, startSeq uint64) (int, uint64) {
+			req := zmq4.NewReq(ctx)
+			DeferCleanup(req.Close)
+
+			Expect(req.Dial(replayEndpoint)).To(Succeed())
+			frame := make([]byte, 8)
+			binary.BigEndian.PutUint64(frame, startSeq)
+			Expect(req.Send(zmq4.NewMsg(frame))).To(Succeed())
+
+			totalStored := 0
+			var lastSeq uint64
+			for {
+				msg, err := req.Recv()
+				Expect(err).NotTo(HaveOccurred())
+				// Each reply: [topic, seq(8B), payload]
+				Expect(msg.Frames).To(HaveLen(3))
+				seq := binary.BigEndian.Uint64(msg.Frames[1])
+				if seq == ^uint64(0) {
+					// End-of-replay sentinel
+					break
+				}
+				stored, _, _ := kvcache.CountKVEventBlocks(msg.Frames, kvcache.CreateKVEventsTopic("localhost", replayModel), seq)
+				totalStored += stored
+				lastSeq = seq
+			}
+			return totalStored, lastSeq
+		}
+
+		// startSubReceiver pumps all PUB messages from sub into a channel.
+		startSubReceiver := func(sub zmq4.Socket) chan zmq4.Msg {
+			ch := make(chan zmq4.Msg, 64)
+			go func() {
+				for {
+					msg, err := sub.Recv()
+					if err != nil {
+						return
+					}
+					ch <- msg
+				}
+			}()
+			return ch
+		}
+
+		// drainPubUntilQuiet reads live PUB events until idle, returning
+		// total stored blocks and last sequence number seen.
+		drainPubUntilQuiet := func(msgCh chan zmq4.Msg, topic string, timeout time.Duration) (totalStored int, lastSeq uint64) {
+			for {
+				select {
+				case msg := <-msgCh:
+					if len(msg.Frames) != 3 {
+						continue
+					}
+					seq := binary.BigEndian.Uint64(msg.Frames[1])
+					stored, _, _ := kvcache.CountKVEventBlocks(msg.Frames, topic, seq)
+					totalStored += stored
+					lastSeq = seq
+				case <-time.After(timeout):
+					return
+				}
+			}
+		}
+
+		It("stores published batches and replays them from a given sequence number", func() {
+			ctx := context.TODO()
+			client, sub, topic := setupReplayServer(ctx)
+			defer sub.Close() //nolint:errcheck
+
+			msgCh := startSubReceiver(sub)
+
+			// Allow replayer socket to bind
+			time.Sleep(300 * time.Millisecond)
+
+			// Trigger two chat completions
+			for range 2 {
+				openaiclient, params := getOpenAIClientAndChatParams(client, replayModel, replayPrompt, false)
+				resp, err := openaiclient.Chat.Completions.New(ctx, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.Choices).ShouldNot(BeEmpty())
+			}
+
+			// Drain all live events; record last seq published
+			_, lastSeq := drainPubUntilQuiet(msgCh, topic, 500*time.Millisecond)
+			Expect(lastSeq).To(BeNumerically(">", 0))
+
+			// Request replay from the last seq — exactly that one batch should come back
+			replayedTotal, replayedLastSeq := sendReplayRequestAndRecv(ctx, lastSeq)
+			Expect(replayedTotal).To(BeNumerically(">", 0))
+			Expect(replayedLastSeq).To(Equal(lastSeq))
+		})
+
+		It("replays all stored batches when startSeq is 1", func() {
+			ctx := context.TODO()
+			client, sub, topic := setupReplayServer(ctx)
+			defer sub.Close() //nolint:errcheck
+
+			msgCh := startSubReceiver(sub)
+
+			time.Sleep(300 * time.Millisecond)
+
+			// Trigger one completion
+			openaiclient, params := getOpenAIClientAndChatParams(client, replayModel, replayPrompt, false)
+			resp, err := openaiclient.Chat.Completions.New(ctx, params)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Choices).ShouldNot(BeEmpty())
+
+			// Count blocks from the live PUB stream
+			origTotal, _ := drainPubUntilQuiet(msgCh, topic, 500*time.Millisecond)
+			Expect(origTotal).To(BeNumerically(">", 0))
+
+			// Replay from seq 1 — all stored batches must be returned
+			replayedTotal, _ := sendReplayRequestAndRecv(ctx, 1)
+			Expect(replayedTotal).To(Equal(origTotal))
+		})
+
+		It("returns only the sentinel when startSeq is beyond all stored batches", func() {
+			ctx := context.TODO()
+			client, sub, topic := setupReplayServer(ctx)
+			defer sub.Close() //nolint:errcheck
+
+			msgCh := startSubReceiver(sub)
+
+			time.Sleep(300 * time.Millisecond)
+
+			// Trigger one completion
+			openaiclient, params := getOpenAIClientAndChatParams(client, replayModel, replayPrompt, false)
+			resp, err := openaiclient.Chat.Completions.New(ctx, params)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Choices).ShouldNot(BeEmpty())
+
+			// Drain live events
+			drainPubUntilQuiet(msgCh, topic, 500*time.Millisecond)
+
+			// Ask for a seq far beyond what was stored — only the sentinel comes back
+			replayedTotal, _ := sendReplayRequestAndRecv(ctx, 999999)
+			Expect(replayedTotal).To(Equal(0))
 		})
 	})
 })

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -1228,17 +1228,23 @@ force-dummy-tokenizer: false
 
 	Context("kv-events replay", func() {
 		const (
-			replayEndpoint = "tcp://127.0.0.1:15559"
-			replayModel    = common.QwenModelName
-			replayMode     = common.ModeRandom
-			replayPrompt   = "This is a test message for kv cache events, has to be long enough to be tokenized into multiple blocks."
+			replayModel  = common.QwenModelName
+			replayMode   = common.ModeRandom
+			replayPrompt = "This is a test message for kv cache events, has to be long enough to be tokenized into multiple blocks."
 		)
 
-		// setupReplayServer starts the simulator with replay enabled.
-		// Returns the HTTP client, the PUB subscriber (for watching live events), and the topic.
-		setupReplayServer := func(ctx context.Context) (*http.Client, zmq4.Socket, string) {
+		// setupReplayServer starts the simulator with replay enabled on a freshly
+		// probed free port (see freeTCPPort), rather than a fixed port that could
+		// collide with other tests or a leftover process.
+		// Returns the HTTP client, the PUB subscriber (for watching live events),
+		// the topic, and the replay endpoint the simulator was told to bind.
+		setupReplayServer := func(ctx context.Context) (*http.Client, zmq4.Socket, string, string) {
 			topic := kvcache.CreateKVEventsTopic("localhost", replayModel)
 			sub, zmqEndpoint := common.CreateSub(ctx, topic)
+
+			replayPort, err := common.FreeTCPPort()
+			Expect(err).NotTo(HaveOccurred())
+			replayEndpoint := fmt.Sprintf("tcp://127.0.0.1:%d", replayPort)
 
 			args := []string{"cmd", "--model", replayModel, "--mode", replayMode,
 				"--enable-kvcache", "true", "--kv-cache-size", "16", "--block-size", "8",
@@ -1248,35 +1254,23 @@ force-dummy-tokenizer: false
 			}
 			client, err := startServerWithArgsAndEnv(ctx, replayMode, args, map[string]string{"POD_IP": "localhost"})
 			Expect(err).NotTo(HaveOccurred())
-			return client, sub, topic
+			return client, sub, topic, replayEndpoint
 		}
 
-		// sendReplayRequestAndRecv connects a REQ socket to the ROUTER replay endpoint,
-		// sends startSeq, and collects all reply batches until the sentinel.
-		// Replies are [topic, seq(8B), payload] frames (REQ strips identity+delimiter),
-		// the same shape as the live PUB stream.
-		// Returns (totalStoredBlocks, lastSeq).
-		sendReplayRequestAndRecv := func(ctx context.Context, startSeq uint64) (int, uint64) {
-			req := zmq4.NewReq(ctx)
-			DeferCleanup(req.Close)
-
-			Expect(req.Dial(replayEndpoint)).To(Succeed())
-			frame := make([]byte, 8)
-			binary.BigEndian.PutUint64(frame, startSeq)
-			Expect(req.Send(zmq4.NewMsg(frame))).To(Succeed())
+		// sendReplayRequestAndRecv requests replay from startSeq via the shared
+		// kvcache.SendReplayRequestAndRecv helper and aggregates the blocks in the
+		// returned batches, skipping the end-of-replay sentinel (identified by its
+		// empty topic frame). Returns (totalStoredBlocks, lastSeq).
+		sendReplayRequestAndRecv := func(ctx context.Context, replayEndpoint string, startSeq uint64) (int, uint64) {
+			msgs := kvcache.SendReplayRequestAndRecv(ctx, replayEndpoint, startSeq)
 
 			totalStored := 0
 			var lastSeq uint64
-			for {
-				msg, err := req.Recv()
-				Expect(err).NotTo(HaveOccurred())
-				// Each reply: [topic, seq(8B), payload]
-				Expect(msg.Frames).To(HaveLen(3))
-				seq := binary.BigEndian.Uint64(msg.Frames[1])
-				if seq == ^uint64(0) {
-					// End-of-replay sentinel
+			for _, msg := range msgs {
+				if len(msg.Frames[0]) == 0 {
 					break
 				}
+				seq := binary.BigEndian.Uint64(msg.Frames[1])
 				stored, _, _ := kvcache.CountKVEventBlocks(msg.Frames, kvcache.CreateKVEventsTopic("localhost", replayModel), seq)
 				totalStored += stored
 				lastSeq = seq
@@ -1320,7 +1314,7 @@ force-dummy-tokenizer: false
 
 		It("stores published batches and replays them from a given sequence number", func() {
 			ctx := context.TODO()
-			client, sub, topic := setupReplayServer(ctx)
+			client, sub, topic, replayEndpoint := setupReplayServer(ctx)
 			defer sub.Close() //nolint:errcheck
 
 			msgCh := startSubReceiver(sub)
@@ -1341,14 +1335,14 @@ force-dummy-tokenizer: false
 			Expect(lastSeq).To(BeNumerically(">", 0))
 
 			// Request replay from the last seq — exactly that one batch should come back
-			replayedTotal, replayedLastSeq := sendReplayRequestAndRecv(ctx, lastSeq)
+			replayedTotal, replayedLastSeq := sendReplayRequestAndRecv(ctx, replayEndpoint, lastSeq)
 			Expect(replayedTotal).To(BeNumerically(">", 0))
 			Expect(replayedLastSeq).To(Equal(lastSeq))
 		})
 
 		It("replays all stored batches when startSeq is 1", func() {
 			ctx := context.TODO()
-			client, sub, topic := setupReplayServer(ctx)
+			client, sub, topic, replayEndpoint := setupReplayServer(ctx)
 			defer sub.Close() //nolint:errcheck
 
 			msgCh := startSubReceiver(sub)
@@ -1366,13 +1360,13 @@ force-dummy-tokenizer: false
 			Expect(origTotal).To(BeNumerically(">", 0))
 
 			// Replay from seq 1 — all stored batches must be returned
-			replayedTotal, _ := sendReplayRequestAndRecv(ctx, 1)
+			replayedTotal, _ := sendReplayRequestAndRecv(ctx, replayEndpoint, 1)
 			Expect(replayedTotal).To(Equal(origTotal))
 		})
 
 		It("returns only the sentinel when startSeq is beyond all stored batches", func() {
 			ctx := context.TODO()
-			client, sub, topic := setupReplayServer(ctx)
+			client, sub, topic, replayEndpoint := setupReplayServer(ctx)
 			defer sub.Close() //nolint:errcheck
 
 			msgCh := startSubReceiver(sub)
@@ -1389,7 +1383,7 @@ force-dummy-tokenizer: false
 			drainPubUntilQuiet(msgCh, topic, 500*time.Millisecond)
 
 			// Ask for a seq far beyond what was stored — only the sentinel comes back
-			replayedTotal, _ := sendReplayRequestAndRecv(ctx, 999999)
+			replayedTotal, _ := sendReplayRequestAndRecv(ctx, replayEndpoint, 999999)
 			Expect(replayedTotal).To(Equal(0))
 		})
 	})


### PR DESCRIPTION
## What does this PR do?

Adds an optional ROUTER-socket replay endpoint (`--kv-events-replay-endpoint`) that lets clients request missed KV cache event batches by sequence number, matching vLLM's replay wire format (topic/seq/payload framing, end-of-replay sentinel). Published batches are kept in a bounded, configurable ring buffer (`--kv-events-replay-queue-size`, default 1024) and offset by data-parallel rank the same way as the existing ZMQ publish endpoint, with validation to prevent the two endpoints' ports from colliding across ranks.

## Related Issues

Fixes #477 
