### PR TITLE
fix: remove deprecated /ready endpoint

### DIFF
--- a/helm/llm-d-inference-sim/templates/deployment.yaml
+++ b/helm/llm-d-inference-sim/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
               port: http
           readinessProbe:
             httpGet:
-              path: /ready
+              path: /health/ready
               port: http
           {{- with .Values.resources }}
           resources:

--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -45,7 +45,6 @@ type Communication struct {
 
 	pb.UnimplementedVllmEngineServer
 
-	readyDeprecatedLogged       bool
 	fakeMetricsDeprecatedLogged bool
 
 	// startTime records when the server started, used for startup-duration readiness check

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -87,7 +87,6 @@ func (c *Communication) startHTTPServer(ctx context.Context, listener net.Listen
 	r.GET("/health/ready", c.HandleHealthReady)
 	// emulates vLLM's Mooncake bootstrap endpoint on the prefill pod; the routing sidecar queries it to resolve remote engine ids
 	r.GET("/query", c.HandleMooncakeQuery)
-	r.GET("/ready", c.HandleReady)
 	r.POST("/tokenize", c.HandleTokenize)
 	r.POST("/sleep", c.HandleSleep)
 	r.POST("/wake_up", c.HandleWakeUp)
@@ -811,17 +810,6 @@ func (c *Communication) HandleHealthReady(ctx *fasthttp.RequestCtx) {
 		ctx.Response.Header.SetStatusCode(fasthttp.StatusServiceUnavailable)
 		return
 	}
-	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
-}
-
-// HandleReady http handler for /ready
-func (c *Communication) HandleReady(ctx *fasthttp.RequestCtx) {
-	c.logger.V(logging.TRACE).Info("Readiness request received")
-	if !c.readyDeprecatedLogged {
-		c.readyDeprecatedLogged = true
-		c.logger.V(logging.INFO).Info("/ready endpoint is deprecated and will be removed in a future release; please use /health/ready instead")
-	}
-	ctx.Response.Header.SetContentType("application/json")
 	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
 }
 


### PR DESCRIPTION
## What does this PR do?

Removes the deprecated `/ready` HTTP endpoint and updates the Helm chart readiness probe to use `/health/ready` instead.

## Why is this change needed?

`/ready` was marked deprecated in release v0.9.0 in favor of `/health/ready`. Per the deprecation timeline, it can be removed in v0.11.0.

Callers and probes should use `/health/ready`, which also respects `startup-duration` (returning 503 during simulated GPU load), unlike the old `/ready` handler which always returned 200.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `go build ./...` succeeds
- `go test ./pkg/communication/` passes
- Existing `/health/ready` tests in `pkg/tests/http_server_test.go` cover the replacement endpoint (including `startup-duration` behavior)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`go test ./pkg/communication/`)
- [ ] Linters pass (`make lint`)
- [x] Documentation updated (if applicable) — docs already documented `/health/ready` only; no doc changes required

## Related Issues

Fixes #465
