### PR TITLE
fix test and lint targets with symbolic links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-LOCALBIN ?= $(shell pwd)/bin
+LOCALBIN ?= $(CURDIR)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 


### PR DESCRIPTION
when SHELL is set, "$(shell pwd)" ends up with invoking "$(SHELL) -c pwd". in case of bash, it ends up with invoking "pwd" internal command, which prints the PWD environment variable. it doesn't always match make's own idea of the current directory and yields build failures like the following:

```shell
yamt-test% ls -l /home/ubuntu/llm-d-inference-sim
lrwxrwxrwx 1 ubuntu ubuntu 23 Jul 31 04:29 /home/ubuntu/llm-d-inference-sim -> git/llm-d-inference-sim/
yamt-test% pwd
/home/ubuntu/llm-d-inference-sim
yamt-test% pwd -P
/home/ubuntu/git/llm-d-inference-sim
yamt-test% make lint
make: *** No rule to make target '/home/ubuntu/llm-d-inference-sim/bin/golangci-lint', needed by 'lint'.  Stop.
yamt-test%
```

## What does this PR do?

use make's CURDIR

## Why is this change needed?

see above

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
