### PR TITLE
fix: bump golangci-lint to v2.10.1 to fix analysis panic

### DIFF
--- a/Makefile.tools.mk
+++ b/Makefile.tools.mk
@@ -30,7 +30,7 @@ ln -sf $$(realpath $(1)-$(3)) $(1)
 endef
 
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
-GOLANGCI_LINT_VERSION = v2.10.0
+GOLANGCI_LINT_VERSION = v2.10.1
 GINKGO = $(LOCALBIN)/ginkgo
 GINKGO_VERSION = v2.25.3
 


### PR DESCRIPTION
`make lint` panics on v2.10.0 and is fixed upstream in v2.10.1.

Change: bump `GOLANGCI_LINT_VERSION` from v2.10.0 to v2.10.1.

