### PR TITLE
feat(responses): add function_call tool turns

### DIFF
--- a/docs/http-endpoints.md
+++ b/docs/http-endpoints.md
@@ -269,7 +269,7 @@ Structure of requests/responses
           - output_tokens
           - total_tokens
 
-    Tool turns (non-streaming): when `tools` are present and `tool_choice` is not `none`, the simulator emits exactly one `function_call` output item. If `input` already contains a `function_call_output` (agentic loop re-entry), it returns a normal assistant `message` instead. Parallel / multi tool calls are not supported.
+    Tool turns: when `tools` are present and `tool_choice` is not `none`, the simulator emits exactly one `function_call` output item (non-streaming) or the equivalent SSE event sequence (streaming; see below). If `input` already contains a `function_call_output` (agentic loop re-entry), it returns a normal assistant `message` instead. Parallel / multi tool calls are not supported.
 
 - `/inference/v1/generate`
     - **request**
@@ -416,6 +416,8 @@ curl -N -X POST http://localhost:8000/v1/responses \
 ```
 
 The streaming response uses Server-Sent Events (SSE) and emits the following event types in order: `response.created`, `response.in_progress`, `response.output_item.added`, `response.content_part.added`, one or more `response.output_text.delta`, `response.output_text.done`, `response.content_part.done`, `response.output_item.done`, `response.completed`.
+
+When the turn is a tool call (`tools` present and `tool_choice` is not `none`, and `input` has no `function_call_output`), the stream instead emits: `response.created`, `response.in_progress`, `response.output_item.added` (item type `function_call`), one or more `response.function_call_arguments.delta`, `response.function_call_arguments.done`, `response.output_item.done`, `response.completed` (with a single `function_call` in `output`).
 
 ## `finish_reason` values
 

--- a/docs/http-endpoints.md
+++ b/docs/http-endpoints.md
@@ -269,7 +269,9 @@ Structure of requests/responses
           - output_tokens
           - total_tokens
 
-    Tool turns (non-streaming): when `tools` are present and `tool_choice` is not `none`, the simulator emits exactly one `function_call` output item. If `input` already contains a `function_call_output` (agentic loop re-entry), it returns a normal assistant `message` instead. Parallel / multi tool calls are not supported.- `/inference/v1/generate`
+    Tool turns (non-streaming): when `tools` are present and `tool_choice` is not `none`, the simulator emits exactly one `function_call` output item. If `input` already contains a `function_call_output` (agentic loop re-entry), it returns a normal assistant `message` instead. Parallel / multi tool calls are not supported.
+
+- `/inference/v1/generate`
     - **request**
         - stream
         - model

--- a/docs/http-endpoints.md
+++ b/docs/http-endpoints.md
@@ -234,7 +234,7 @@ Structure of requests/responses
         - instructions
         - max_output_tokens
         - tools (array of function tools; flat Responses shape: `type`, `name`, `description`, `parameters`)
-        - tool_choice (`none`, `auto`, `required`, or `{"type":"function","name":"..."}`)
+        - tool_choice (`none`, `auto`, `required`, `{"type":"function","name":"..."}`, or wire shapes `allowed_tools` / `custom` — the latter two are accepted but not enforced)
         - text
           - format
             - type (`text`, `json_object`, `json_schema`)
@@ -269,7 +269,7 @@ Structure of requests/responses
           - output_tokens
           - total_tokens
 
-    Tool turns: when `tools` are present and `tool_choice` is not `none`, the simulator emits exactly one `function_call` output item (non-streaming) or the equivalent SSE event sequence (streaming; see below). If `input` already contains a `function_call_output` (agentic loop re-entry), it returns a normal assistant `message` instead. Parallel / multi tool calls are not supported.
+    Tool turns: when `tools` are present and `tool_choice` is not `none`, the simulator emits exactly one `function_call` output item (non-streaming) or the equivalent SSE event sequence (streaming; see below). On the first tool turn, omitted or `auto` `tool_choice` is forced to call a tool 100% of the time (unlike the real Responses API). If `input` already contains any `function_call_output`, tool-calling stays off for the rest of that conversation — including a later, unrelated user turn that still carries prior tool history — and the simulator returns a normal assistant `message` instead. `allowed_tools` / `custom` `tool_choice` values are accepted on the wire but are not enforced (same limitation as chat completions). Parallel / multi tool calls are not supported.
 
 - `/inference/v1/generate`
     - **request**

--- a/docs/http-endpoints.md
+++ b/docs/http-endpoints.md
@@ -221,16 +221,20 @@ Structure of requests/responses
         - stream
         - model
         - input (array of input items)
-            - type (`message`)
-            - role (`user`, `system`, `developer`)
-            - content (string or array of content blocks)
+            - type (`message`, `function_call`, or `function_call_output`)
+            - role (`user`, `system`, `developer`) — for `message`
+            - content (string or array of content blocks) — for `message`
               - type (`input_text`, `input_image`, or `input_audio`)
               - text (for `input_text`)
               - image_url (for `input_image` — a URL string)
               - data (for `input_audio` — base64-encoded audio data)
               - format (for `input_audio` — e.g. `wav`, `mp3`)
+            - id, call_id, name, arguments, status — for `function_call`
+            - call_id, output — for `function_call_output`
         - instructions
         - max_output_tokens
+        - tools (array of function tools; flat Responses shape: `type`, `name`, `description`, `parameters`)
+        - tool_choice (`none`, `auto`, `required`, or `{"type":"function","name":"..."}`)
         - text
           - format
             - type (`text`, `json_object`, `json_schema`)
@@ -244,11 +248,11 @@ Structure of requests/responses
         - status (`completed`, `in_progress`)
         - instructions
         - output (array of output items)
-            - type (`message`)
+            - type (`message` or `function_call`)
             - id
-            - role (`assistant`)
+            - role (`assistant`) — for `message`
             - status
-            - content
+            - content — for `message`
               - type (`output_text`)
               - text
               - logprobs (when `include` contains `message.output_text.logprobs`)
@@ -256,6 +260,7 @@ Structure of requests/responses
                 - logprob
                 - bytes
                 - top_logprobs
+            - call_id, name, arguments — for `function_call` (`status` is `completed`)
         - text
           - format
             - type
@@ -263,7 +268,8 @@ Structure of requests/responses
           - input_tokens
           - output_tokens
           - total_tokens
-- `/inference/v1/generate`
+
+    Tool turns (non-streaming): when `tools` are present and `tool_choice` is not `none`, the simulator emits exactly one `function_call` output item. If `input` already contains a `function_call_output` (agentic loop re-entry), it returns a normal assistant `message` instead. Parallel / multi tool calls are not supported.- `/inference/v1/generate`
     - **request**
         - stream
         - model

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -1051,11 +1051,11 @@ func unmarshalResponsesTools(data []byte) ([]Tool, error) {
 	for _, r := range raw {
 		var nested Tool
 		if err := json.Unmarshal(r, &nested); err == nil && nested.Function.Name != "" {
-			if nested.Type != "" && nested.Type != "function" {
+			if nested.Type != "" && nested.Type != toolChoiceTypeFunction {
 				return nil, fmt.Errorf("unsupported tool type %q", nested.Type)
 			}
 			if nested.Type == "" {
-				nested.Type = "function"
+				nested.Type = toolChoiceTypeFunction
 			}
 			tools = append(tools, nested)
 			continue
@@ -1069,14 +1069,14 @@ func unmarshalResponsesTools(data []byte) ([]Tool, error) {
 		if err := json.Unmarshal(r, &flat); err != nil {
 			return nil, fmt.Errorf("invalid tool entry: %w", err)
 		}
-		if flat.Type != "" && flat.Type != "function" {
+		if flat.Type != "" && flat.Type != toolChoiceTypeFunction {
 			return nil, fmt.Errorf("unsupported tool type %q", flat.Type)
 		}
 		if flat.Name == "" {
 			return nil, errors.New("tool name is required")
 		}
 		tools = append(tools, Tool{
-			Type: "function",
+			Type: toolChoiceTypeFunction,
 			Function: function{
 				Name:        flat.Name,
 				Description: flat.Description,

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -26,15 +26,17 @@ import (
 )
 
 const (
-	RoleAssistant         = "assistant"
-	RoleUser              = "user"
-	inputItemMessage      = "message"
-	ResponsesInputText    = "input_text"
-	ResponsesInputImage   = "input_image"
-	ResponsesInputAudio   = "input_audio"
-	StartMessageSeparator = "### "
-	EndMessageSeparator   = "\n"
-	nullString            = "null"
+	RoleAssistant               = "assistant"
+	RoleUser                    = "user"
+	inputItemMessage            = "message"
+	inputItemFunctionCall       = "function_call"
+	inputItemFunctionCallOutput = "function_call_output"
+	ResponsesInputText          = "input_text"
+	ResponsesInputImage         = "input_image"
+	ResponsesInputAudio         = "input_audio"
+	StartMessageSeparator       = "### "
+	EndMessageSeparator         = "\n"
+	nullString                  = "null"
 	// ResponsesIncludeLogprobs is the include value that enables logprobs in the Responses API
 	ResponsesIncludeLogprobs = "message.output_text.logprobs"
 )
@@ -751,6 +753,10 @@ type ResponsesRequest struct {
 	Include []string `json:"include,omitempty"`
 	// TopLogprobs specifies the number of most likely tokens to return at each position with log probabilities.
 	TopLogprobs *int `json:"top_logprobs,omitempty"`
+	// Tools is a list of tools the model may call (Responses flat function schema, normalized to Tool).
+	Tools []Tool `json:"tools,omitempty"`
+	// ToolChoice controls which (if any) tool is called by the model.
+	ToolChoice ToolChoice `json:"tool_choice,omitzero"`
 }
 
 var _ Request = (*ResponsesRequest)(nil)
@@ -783,6 +789,65 @@ type InputMessage struct {
 }
 
 func (InputMessage) isInputItem() {}
+
+// InputFunctionCall is a prior model function_call item echoed in Responses input.
+type InputFunctionCall struct {
+	Type      string `json:"type"` // always "function_call"
+	ID        string `json:"id,omitempty"`
+	CallID    string `json:"call_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+	Status    string `json:"status,omitempty"`
+}
+
+func (InputFunctionCall) isInputItem() {}
+
+func (f *InputFunctionCall) UnmarshalJSON(data []byte) error {
+	type alias InputFunctionCall
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	if a.Type != "" && a.Type != inputItemFunctionCall {
+		return fmt.Errorf("unsupported input item type %q", a.Type)
+	}
+	a.Type = inputItemFunctionCall
+	*f = InputFunctionCall(a)
+	return nil
+}
+
+// InputFunctionCallOutput is a tool result item in Responses input.
+type InputFunctionCallOutput struct {
+	Type   string `json:"type"` // always "function_call_output"
+	CallID string `json:"call_id,omitempty"`
+	Output string `json:"output,omitempty"`
+}
+
+func (InputFunctionCallOutput) isInputItem() {}
+
+func (f *InputFunctionCallOutput) UnmarshalJSON(data []byte) error {
+	type alias InputFunctionCallOutput
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	if a.Type != "" && a.Type != inputItemFunctionCallOutput {
+		return fmt.Errorf("unsupported input item type %q", a.Type)
+	}
+	a.Type = inputItemFunctionCallOutput
+	*f = InputFunctionCallOutput(a)
+	return nil
+}
+
+// HasFunctionCallOutput reports whether input contains any function_call_output item.
+func HasFunctionCallOutput(input []InputItem) bool {
+	for _, item := range input {
+		if _, ok := item.(*InputFunctionCallOutput); ok {
+			return true
+		}
+	}
+	return false
+}
 
 func (m *InputMessage) UnmarshalJSON(data []byte) error {
 	var raw struct {
@@ -875,11 +940,11 @@ func (c *InputContent) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// At the moment UnmarshalJSON handles only two forms of the `input` field:
+// UnmarshalJSON handles:
 // - a plain string: wrapped into a single user InputMessage
-// - an array of message objects: each element is unmarshaled as *InputMessage
+// - an array of input items: message, function_call, function_call_output
 func (req *ResponsesRequest) UnmarshalJSON(data []byte) error {
-	// Use an alias to unmarshal all fields except Input normally.
+	// Use an alias to unmarshal all fields except Input and tools normally.
 	type alias struct {
 		baseRequest
 		Input           json.RawMessage `json:"input,omitempty"`
@@ -888,6 +953,8 @@ func (req *ResponsesRequest) UnmarshalJSON(data []byte) error {
 		Text            *TextSettings   `json:"text,omitempty"`
 		Include         []string        `json:"include,omitempty"`
 		TopLogprobs     *int            `json:"top_logprobs,omitempty"`
+		Tools           json.RawMessage `json:"tools,omitempty"`
+		ToolChoice      ToolChoice      `json:"tool_choice,omitzero"`
 	}
 	var a alias
 	if err := json.Unmarshal(data, &a); err != nil {
@@ -899,6 +966,15 @@ func (req *ResponsesRequest) UnmarshalJSON(data []byte) error {
 	req.Text = a.Text
 	req.Include = a.Include
 	req.TopLogprobs = a.TopLogprobs
+	req.ToolChoice = a.ToolChoice
+
+	if len(a.Tools) > 0 && string(a.Tools) != nullString {
+		tools, err := unmarshalResponsesTools(a.Tools)
+		if err != nil {
+			return err
+		}
+		req.Tools = tools
+	}
 
 	if len(a.Input) == 0 || string(a.Input) == nullString {
 		return errors.New("input is required")
@@ -915,28 +991,105 @@ func (req *ResponsesRequest) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// array input: unmarshal each element as *InputMessage
+	// array input: dispatch each element by type
 	var raw []json.RawMessage
 	if err := json.Unmarshal(a.Input, &raw); err != nil {
 		return fmt.Errorf("input must be a string or array: %w", err)
 	}
 	req.Input = make([]InputItem, 0, len(raw))
 	for _, r := range raw {
-		msg := &InputMessage{}
-		if err := json.Unmarshal(r, msg); err != nil {
+		item, err := unmarshalInputItem(r)
+		if err != nil {
 			return err
 		}
-		req.Input = append(req.Input, msg)
+		req.Input = append(req.Input, item)
 	}
 	return nil
 }
 
+// unmarshalInputItem dispatches a single Responses input array element by its type field.
+func unmarshalInputItem(data []byte) (InputItem, error) {
+	var typeDetector struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &typeDetector); err != nil {
+		return nil, err
+	}
+	switch typeDetector.Type {
+	case "", inputItemMessage:
+		msg := &InputMessage{}
+		if err := json.Unmarshal(data, msg); err != nil {
+			return nil, err
+		}
+		return msg, nil
+	case inputItemFunctionCall:
+		fc := &InputFunctionCall{}
+		if err := json.Unmarshal(data, fc); err != nil {
+			return nil, err
+		}
+		return fc, nil
+	case inputItemFunctionCallOutput:
+		out := &InputFunctionCallOutput{}
+		if err := json.Unmarshal(data, out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported input item type %q", typeDetector.Type)
+	}
+}
+
+// unmarshalResponsesTools normalizes Responses flat function tools into nested Tool values.
+// Wire shape: {"type":"function","name":"...","description":"...","parameters":{...}}
+// Also accepts the chat-completions nested shape {"type":"function","function":{...}}.
+func unmarshalResponsesTools(data []byte) ([]Tool, error) {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("tools must be an array: %w", err)
+	}
+	tools := make([]Tool, 0, len(raw))
+	for _, r := range raw {
+		var nested Tool
+		if err := json.Unmarshal(r, &nested); err == nil && nested.Function.Name != "" {
+			if nested.Type == "" {
+				nested.Type = "function"
+			}
+			tools = append(tools, nested)
+			continue
+		}
+		var flat struct {
+			Type        string         `json:"type"`
+			Name        string         `json:"name"`
+			Description string         `json:"description"`
+			Parameters  map[string]any `json:"parameters"`
+		}
+		if err := json.Unmarshal(r, &flat); err != nil {
+			return nil, fmt.Errorf("invalid tool entry: %w", err)
+		}
+		if flat.Type != "" && flat.Type != "function" {
+			return nil, fmt.Errorf("unsupported tool type %q", flat.Type)
+		}
+		if flat.Name == "" {
+			return nil, errors.New("tool name is required")
+		}
+		tools = append(tools, Tool{
+			Type: "function",
+			Function: function{
+				Name:        flat.Name,
+				Description: flat.Description,
+				Parameters:  flat.Parameters,
+			},
+		})
+	}
+	return tools, nil
+}
+
 func (req *ResponsesRequest) GetTools() []Tool {
-	return nil
+	return req.Tools
 }
 
 func (req *ResponsesRequest) GetToolChoice() ToolChoice {
-	return ToolChoice{}
+	return req.ToolChoice
 }
 
 func (req *ResponsesRequest) GetMaxCompletionTokens() *int64 {

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -1051,6 +1051,9 @@ func unmarshalResponsesTools(data []byte) ([]Tool, error) {
 	for _, r := range raw {
 		var nested Tool
 		if err := json.Unmarshal(r, &nested); err == nil && nested.Function.Name != "" {
+			if nested.Type != "" && nested.Type != "function" {
+				return nil, fmt.Errorf("unsupported tool type %q", nested.Type)
+			}
 			if nested.Type == "" {
 				nested.Type = "function"
 			}

--- a/pkg/api/request_test.go
+++ b/pkg/api/request_test.go
@@ -445,4 +445,23 @@ var _ = Describe("ResponsesRequest tools and function call input", func() {
 		var req ResponsesRequest
 		Expect(json.Unmarshal(jsonData, &req)).To(HaveOccurred())
 	})
+
+	It("rejects nested non-function tool types", func() {
+		jsonData := []byte(`{
+			"model": "m",
+			"input": "hello",
+			"tools": [{
+				"type": "custom",
+				"function": {
+					"name": "get_weather",
+					"description": "Get weather",
+					"parameters": {"type": "object", "properties": {}}
+				}
+			}]
+		}`)
+		var req ResponsesRequest
+		err := json.Unmarshal(jsonData, &req)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`unsupported tool type "custom"`))
+	})
 })

--- a/pkg/api/request_test.go
+++ b/pkg/api/request_test.go
@@ -375,3 +375,74 @@ var _ = Describe("InputMessage PlainText with content types", func() {
 		Expect(text).To(Equal("user: hello\nimage: https://example.com/img.png"))
 	})
 })
+
+var _ = Describe("ResponsesRequest tools and function call input", func() {
+	It("unmarshals flat function tools and tool_choice", func() {
+		jsonData := []byte(`{
+			"model": "m",
+			"input": "hello",
+			"tool_choice": "auto",
+			"tools": [{
+				"type": "function",
+				"name": "get_weather",
+				"description": "Get weather",
+				"parameters": {
+					"type": "object",
+					"properties": {"city": {"type": "string"}},
+					"required": ["city"]
+				}
+			}]
+		}`)
+		var req ResponsesRequest
+		Expect(json.Unmarshal(jsonData, &req)).To(Succeed())
+		Expect(req.Tools).To(HaveLen(1))
+		Expect(req.Tools[0].Type).To(Equal("function"))
+		Expect(req.Tools[0].Function.Name).To(Equal("get_weather"))
+		Expect(req.Tools[0].Function.Parameters["type"]).To(Equal("object"))
+		Expect(req.GetTools()).To(HaveLen(1))
+	})
+
+	It("unmarshals function_call and function_call_output input items", func() {
+		jsonData := []byte(`{
+			"model": "m",
+			"input": [
+				{"type": "message", "role": "user", "content": "weather?"},
+				{
+					"type": "function_call",
+					"id": "fc_1",
+					"call_id": "call_1",
+					"name": "get_weather",
+					"arguments": "{\"city\":\"Paris\"}",
+					"status": "completed"
+				},
+				{
+					"type": "function_call_output",
+					"call_id": "call_1",
+					"output": "sunny"
+				}
+			]
+		}`)
+		var req ResponsesRequest
+		Expect(json.Unmarshal(jsonData, &req)).To(Succeed())
+		Expect(req.Input).To(HaveLen(3))
+		_, okMsg := req.Input[0].(*InputMessage)
+		Expect(okMsg).To(BeTrue())
+		fc, okFC := req.Input[1].(*InputFunctionCall)
+		Expect(okFC).To(BeTrue())
+		Expect(fc.CallID).To(Equal("call_1"))
+		Expect(fc.Name).To(Equal("get_weather"))
+		out, okOut := req.Input[2].(*InputFunctionCallOutput)
+		Expect(okOut).To(BeTrue())
+		Expect(out.Output).To(Equal("sunny"))
+		Expect(HasFunctionCallOutput(req.Input)).To(BeTrue())
+	})
+
+	It("rejects unknown input item types", func() {
+		jsonData := []byte(`{
+			"model": "m",
+			"input": [{"type": "reasoning", "id": "rs_1"}]
+		}`)
+		var req ResponsesRequest
+		Expect(json.Unmarshal(jsonData, &req)).To(HaveOccurred())
+	})
+})

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -606,16 +606,18 @@ type ResponsesUsage struct {
 
 // Responses API streaming event types
 const (
-	ResponsesEventCreated           = "response.created"
-	ResponsesEventInProgress        = "response.in_progress"
-	ResponsesEventOutputItemAdded   = "response.output_item.added"
-	ResponsesEventContentPartAdded  = "response.content_part.added"
-	ResponsesEventTextDelta         = "response.output_text.delta"
-	ResponsesEventTextLogprobsDelta = "response.output_text.logprobs.delta"
-	ResponsesEventTextDone          = "response.output_text.done"
-	ResponsesEventContentPartDone   = "response.content_part.done"
-	ResponsesEventOutputItemDone    = "response.output_item.done"
-	ResponsesEventCompleted         = "response.completed"
+	ResponsesEventCreated                    = "response.created"
+	ResponsesEventInProgress                 = "response.in_progress"
+	ResponsesEventOutputItemAdded            = "response.output_item.added"
+	ResponsesEventContentPartAdded           = "response.content_part.added"
+	ResponsesEventTextDelta                  = "response.output_text.delta"
+	ResponsesEventTextLogprobsDelta          = "response.output_text.logprobs.delta"
+	ResponsesEventTextDone                   = "response.output_text.done"
+	ResponsesEventContentPartDone            = "response.content_part.done"
+	ResponsesEventFunctionCallArgumentsDelta = "response.function_call_arguments.delta"
+	ResponsesEventFunctionCallArgumentsDone  = "response.function_call_arguments.done"
+	ResponsesEventOutputItemDone             = "response.output_item.done"
+	ResponsesEventCompleted                  = "response.completed"
 )
 
 // ResponsesResponseEvent is used for events that carry a full response object
@@ -627,7 +629,7 @@ type ResponsesResponseEvent struct {
 
 // ResponsesItemEvent is used for all item/content/text streaming events
 // (output_item.added/done, content_part.added/done, output_text.delta/done,
-// output_text.logprobs.delta).
+// output_text.logprobs.delta, function_call_arguments.delta/done).
 // Fields not relevant to a given event type are omitted via omitempty.
 type ResponsesItemEvent struct {
 	Type         string              `json:"type"`
@@ -638,6 +640,8 @@ type ResponsesItemEvent struct {
 	Part         *OutputContent      `json:"part,omitempty"`
 	Delta        string              `json:"delta,omitempty"`
 	Text         string              `json:"text,omitempty"`
+	Name         string              `json:"name,omitempty"`
+	Arguments    string              `json:"arguments,omitempty"`
 	Logprobs     *[]ResponsesLogprob `json:"logprobs,omitempty"`
 }
 

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -26,18 +26,21 @@ import (
 )
 
 const (
-	chatComplIDPrefix         = "chatcmpl-"
-	textComplIDPrefix         = "cmpl-"
-	ResponsesIDPrefix         = "resp_"
-	ResponsesMessageIDPrefix  = "msg_"
-	TextCompletionObject      = "text_completion"
-	ChatCompletionObject      = "chat.completion"
-	ChatCompletionChunkObject = "chat.completion.chunk"
-	ResponsesObject           = "response"
-	ResponsesStatusCompleted  = "completed"
-	ResponsesStatusInProgress = "in_progress"
-	ResponsesOutputText       = "output_text"
-	ResponsesOutputMessage    = "message"
+	chatComplIDPrefix             = "chatcmpl-"
+	textComplIDPrefix             = "cmpl-"
+	ResponsesIDPrefix             = "resp_"
+	ResponsesMessageIDPrefix      = "msg_"
+	ResponsesFunctionCallIDPrefix = "fc_"
+	ResponsesCallIDPrefix         = "call_"
+	TextCompletionObject          = "text_completion"
+	ChatCompletionObject          = "chat.completion"
+	ChatCompletionChunkObject     = "chat.completion.chunk"
+	ResponsesObject               = "response"
+	ResponsesStatusCompleted      = "completed"
+	ResponsesStatusInProgress     = "in_progress"
+	ResponsesOutputText           = "output_text"
+	ResponsesOutputMessage        = "message"
+	ResponsesOutputFunctionCall   = "function_call"
 
 	SSEDoneMarker = "[DONE]"
 	SSEDataPrefix = "data: "
@@ -539,6 +542,29 @@ func (m MessageOutput) MarshalJSON() ([]byte, error) {
 	}
 	type alias MessageOutput
 	return json.Marshal(alias(m))
+}
+
+// FunctionCallOutputItem is a function_call item in a Responses API output array.
+type FunctionCallOutputItem struct {
+	Type      string `json:"type"` // function_call
+	ID        string `json:"id,omitempty"`
+	CallID    string `json:"call_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+	Status    string `json:"status,omitempty"`
+}
+
+func (FunctionCallOutputItem) isOutputItem() {}
+
+func (f FunctionCallOutputItem) MarshalJSON() ([]byte, error) {
+	if f.Type == "" {
+		f.Type = ResponsesOutputFunctionCall
+	}
+	if f.Status == "" {
+		f.Status = ResponsesStatusCompleted
+	}
+	type alias FunctionCallOutputItem
+	return json.Marshal(alias(f))
 }
 
 // TopLogprob represents a top alternative token in Responses API logprobs

--- a/pkg/api/tool_choice.go
+++ b/pkg/api/tool_choice.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/openai/openai-go/v3"
@@ -67,12 +68,27 @@ func (t *ToolChoice) UnmarshalJSON(data []byte) error {
 
 	// Based on the detected type, unmarshal the data into the correct struct.
 	switch typeDetector.Type {
-	case "function":
-		var functionChoice openai.ChatCompletionNamedToolChoiceParam
-		if err := functionChoice.UnmarshalJSON(data); err != nil {
+	case toolChoiceTypeFunction:
+		// Responses API uses a flat shape {"type":"function","name":"..."}.
+		// Chat completions uses {"type":"function","function":{"name":"..."}}.
+		var flat struct {
+			Type     string `json:"type"`
+			Name     string `json:"name"`
+			Function *struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		}
+		if err := json.Unmarshal(data, &flat); err != nil {
 			return err
 		}
-		t.OfFunctionToolChoice = &functionChoice
+		name := flat.Name
+		if flat.Function != nil && flat.Function.Name != "" {
+			name = flat.Function.Name
+		}
+		if name == "" {
+			return errors.New("tool_choice function requires a name")
+		}
+		*t = NewToolChoiceFunction(name)
 	case "custom":
 		var customChoice openai.ChatCompletionNamedToolChoiceCustomParam
 		if err := customChoice.UnmarshalJSON(data); err != nil {
@@ -115,4 +131,5 @@ func NewToolChoiceFunction(name string) ToolChoice {
 const (
 	toolChoiceRequiredValue = "required"
 	toolChoiceNoneValue     = "none"
+	toolChoiceTypeFunction  = "function"
 )

--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -431,6 +431,35 @@ type responsesHTTPRespBuilder struct {
 	accumulatedTokens int
 	// logprobs for the accumulated text
 	accumulatedLogprobs []api.ResponsesLogprob
+
+	// tool-call streaming state (set when ToolCalls() is non-empty)
+	inToolMode      bool
+	accumulatedArgs strings.Builder
+	fcID            string
+	callID          string
+	toolName        string
+}
+
+// functionCallOutputItem builds a Responses function_call output item from an internal ToolCall.
+// Internal ToolCall.ID uses the fc_ prefix; derive a matching call_ id for Praxis.
+func functionCallOutputItem(tc api.ToolCall, status string) api.FunctionCallOutputItem {
+	name := ""
+	if tc.Function.Name != nil {
+		name = *tc.Function.Name
+	}
+	fcID := tc.ID
+	callID := strings.Replace(fcID, api.ResponsesFunctionCallIDPrefix, api.ResponsesCallIDPrefix, 1)
+	if callID == fcID {
+		callID = api.ResponsesCallIDPrefix + fcID
+	}
+	return api.FunctionCallOutputItem{
+		Type:      api.ResponsesOutputFunctionCall,
+		ID:        fcID,
+		CallID:    callID,
+		Name:      name,
+		Arguments: tc.Function.Arguments,
+		Status:    status,
+	}
 }
 
 func (respBuilder *responsesHTTPRespBuilder) createResponse(respCtxPerChoice []vllmsim.ResponseContext,
@@ -442,24 +471,7 @@ func (respBuilder *responsesHTTPRespBuilder) createResponse(respCtxPerChoice []v
 	if toolCalls := respCtx.ToolCalls(); len(toolCalls) > 0 {
 		output = make([]api.OutputItem, 0, len(toolCalls))
 		for _, tc := range toolCalls {
-			name := ""
-			if tc.Function.Name != nil {
-				name = *tc.Function.Name
-			}
-			// Internal ToolCall.ID uses the fc_ prefix; derive a matching call_ id for Praxis.
-			fcID := tc.ID
-			callID := strings.Replace(fcID, api.ResponsesFunctionCallIDPrefix, api.ResponsesCallIDPrefix, 1)
-			if callID == fcID {
-				callID = api.ResponsesCallIDPrefix + fcID
-			}
-			output = append(output, api.FunctionCallOutputItem{
-				Type:      api.ResponsesOutputFunctionCall,
-				ID:        fcID,
-				CallID:    callID,
-				Name:      name,
-				Arguments: tc.Function.Arguments,
-				Status:    api.ResponsesStatusCompleted,
-			})
+			output = append(output, functionCallOutputItem(tc, api.ResponsesStatusCompleted))
 		}
 	} else {
 		text := strings.Join(tokens[0].Strings, "")
@@ -498,19 +510,28 @@ func (respBuilder *responsesHTTPRespBuilder) createResponse(respCtxPerChoice []v
 func (respBuilder *responsesHTTPRespBuilder) createUsageChunk(respCtxPerChoice []vllmsim.ResponseContext) sseChunk {
 	respCtx := respCtxPerChoice[0]
 	usage := aggregateUsage(respCtxPerChoice)
-	text := respBuilder.accumulated.String()
-	completedContent := api.OutputContent{Type: api.ResponsesOutputText, Text: text}
-	if respCtx.TopLogprobs() != nil && len(respBuilder.accumulatedLogprobs) > 0 {
-		logprobs := make([]api.ResponsesLogprob, len(respBuilder.accumulatedLogprobs))
-		copy(logprobs, respBuilder.accumulatedLogprobs)
-		completedContent.Logprobs = &logprobs
-	}
-	resp := api.CreateResponsesResponse(
-		respCtx.DisplayModel(),
-		respCtx.RequestID(),
-		respCtx.CreationTime(),
-		respCtx.Instructions(),
-		[]api.OutputItem{
+
+	var output []api.OutputItem
+	if respBuilder.inToolMode {
+		output = []api.OutputItem{
+			api.FunctionCallOutputItem{
+				Type:      api.ResponsesOutputFunctionCall,
+				ID:        respBuilder.fcID,
+				CallID:    respBuilder.callID,
+				Name:      respBuilder.toolName,
+				Arguments: respBuilder.accumulatedArgs.String(),
+				Status:    api.ResponsesStatusCompleted,
+			},
+		}
+	} else {
+		text := respBuilder.accumulated.String()
+		completedContent := api.OutputContent{Type: api.ResponsesOutputText, Text: text}
+		if respCtx.TopLogprobs() != nil && len(respBuilder.accumulatedLogprobs) > 0 {
+			logprobs := make([]api.ResponsesLogprob, len(respBuilder.accumulatedLogprobs))
+			copy(logprobs, respBuilder.accumulatedLogprobs)
+			completedContent.Logprobs = &logprobs
+		}
+		output = []api.OutputItem{
 			api.MessageOutput{
 				Type:    api.ResponsesOutputMessage,
 				ID:      api.ResponsesMessageIDPrefix + respCtx.RequestID(),
@@ -518,7 +539,15 @@ func (respBuilder *responsesHTTPRespBuilder) createUsageChunk(respCtxPerChoice [
 				Status:  api.ResponsesStatusCompleted,
 				Content: []api.OutputContent{completedContent},
 			},
-		},
+		}
+	}
+
+	resp := api.CreateResponsesResponse(
+		respCtx.DisplayModel(),
+		respCtx.RequestID(),
+		respCtx.CreationTime(),
+		respCtx.Instructions(),
+		output,
 		&api.ResponsesUsage{
 			InputTokens:  usage.PromptTokens,
 			OutputTokens: usage.CompletionTokens,
@@ -535,6 +564,9 @@ func (respBuilder *responsesHTTPRespBuilder) createUsageChunk(respCtxPerChoice [
 
 func (respBuilder *responsesHTTPRespBuilder) createChunk(respCtx vllmsim.ResponseContext,
 	tokens *api.Tokenized, tool *api.ToolCall, role string, finishReason *string, choiceIdx int) sseChunk {
+	if tool != nil {
+		return respBuilder.createToolChunk(tool)
+	}
 	if tokens == nil || len(tokens.Strings) == 0 {
 		return nil
 	}
@@ -577,6 +609,37 @@ func (respBuilder *responsesHTTPRespBuilder) createChunk(respCtx vllmsim.Respons
 	return &namedEventChunk{names: []string{api.ResponsesEventTextDelta}, data: []any{deltaEvent}}
 }
 
+// createToolChunk emits function_call streaming events for one argument token fragment.
+// On the first fragment (tool.Function.Name != nil) it also emits output_item.added.
+func (respBuilder *responsesHTTPRespBuilder) createToolChunk(tool *api.ToolCall) sseChunk {
+	var names []string
+	var data []any
+
+	if tool.Function.Name != nil {
+		item := functionCallOutputItem(*tool, api.ResponsesStatusInProgress)
+		item.Arguments = ""
+		respBuilder.fcID = item.ID
+		respBuilder.callID = item.CallID
+		respBuilder.toolName = item.Name
+		outputItemAdded := api.ResponsesItemEvent{
+			Type: api.ResponsesEventOutputItemAdded,
+			Item: item,
+		}
+		names = append(names, outputItemAdded.Type)
+		data = append(data, outputItemAdded)
+	}
+
+	respBuilder.accumulatedArgs.WriteString(tool.Function.Arguments)
+	deltaEvent := api.ResponsesItemEvent{
+		Type:   api.ResponsesEventFunctionCallArgumentsDelta,
+		ItemID: respBuilder.fcID,
+		Delta:  tool.Function.Arguments,
+	}
+	names = append(names, deltaEvent.Type)
+	data = append(data, deltaEvent)
+	return &namedEventChunk{names: names, data: data}
+}
+
 func (respBuilder *responsesHTTPRespBuilder) createInitialChunk(respCtx vllmsim.ResponseContext) sseChunk {
 	resp := api.CreateResponsesResponse(
 		respCtx.DisplayModel(),
@@ -597,6 +660,12 @@ func (respBuilder *responsesHTTPRespBuilder) createInitialChunk(respCtx vllmsim.
 }
 
 func (respBuilder *responsesHTTPRespBuilder) createFirstChunk(respCtx vllmsim.ResponseContext, choiceIdx int) sseChunk {
+	respBuilder.inToolMode = len(respCtx.ToolCalls()) > 0
+	if respBuilder.inToolMode {
+		// output_item.added for function_call is emitted in createToolChunk on the first arg token.
+		return nil
+	}
+
 	itemID := api.ResponsesMessageIDPrefix + respCtx.RequestID()
 	outputItemAdded := api.ResponsesItemEvent{
 		Type: api.ResponsesEventOutputItemAdded,
@@ -625,6 +694,31 @@ func (respBuilder *responsesHTTPRespBuilder) createFirstChunk(respCtx vllmsim.Re
 }
 
 func (respBuilder *responsesHTTPRespBuilder) createLastChunk(respCtx vllmsim.ResponseContext, _ string, choiceIdx int) sseChunk {
+	if respBuilder.inToolMode {
+		args := respBuilder.accumulatedArgs.String()
+		argsDone := api.ResponsesItemEvent{
+			Type:      api.ResponsesEventFunctionCallArgumentsDone,
+			ItemID:    respBuilder.fcID,
+			Name:      respBuilder.toolName,
+			Arguments: args,
+		}
+		outputItemDone := api.ResponsesItemEvent{
+			Type: api.ResponsesEventOutputItemDone,
+			Item: api.FunctionCallOutputItem{
+				Type:      api.ResponsesOutputFunctionCall,
+				ID:        respBuilder.fcID,
+				CallID:    respBuilder.callID,
+				Name:      respBuilder.toolName,
+				Arguments: args,
+				Status:    api.ResponsesStatusCompleted,
+			},
+		}
+		return &namedEventChunk{
+			names: []string{argsDone.Type, outputItemDone.Type},
+			data:  []any{argsDone, outputItemDone},
+		}
+	}
+
 	itemID := api.ResponsesMessageIDPrefix + respCtx.RequestID()
 	text := respBuilder.accumulated.String()
 

--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -436,17 +436,49 @@ type responsesHTTPRespBuilder struct {
 func (respBuilder *responsesHTTPRespBuilder) createResponse(respCtxPerChoice []vllmsim.ResponseContext,
 	tokens []api.Tokenized) any {
 	respCtx := respCtxPerChoice[0]
-	text := strings.Join(tokens[0].Strings, "")
 	usage := respCtx.UsageData()
 
-	outputContent := api.OutputContent{
-		Type: api.ResponsesOutputText,
-		Text: text,
-	}
-
-	if respCtx.TopLogprobs() != nil {
-		logprobs := common.GenerateMessagesLogprobs(tokens[0].Strings, *respCtx.TopLogprobs())
-		outputContent.Logprobs = &logprobs
+	var output []api.OutputItem
+	if toolCalls := respCtx.ToolCalls(); len(toolCalls) > 0 {
+		output = make([]api.OutputItem, 0, len(toolCalls))
+		for _, tc := range toolCalls {
+			name := ""
+			if tc.Function.Name != nil {
+				name = *tc.Function.Name
+			}
+			// Internal ToolCall.ID uses the fc_ prefix; derive a matching call_ id for Praxis.
+			fcID := tc.ID
+			callID := strings.Replace(fcID, api.ResponsesFunctionCallIDPrefix, api.ResponsesCallIDPrefix, 1)
+			if callID == fcID {
+				callID = api.ResponsesCallIDPrefix + fcID
+			}
+			output = append(output, api.FunctionCallOutputItem{
+				Type:      api.ResponsesOutputFunctionCall,
+				ID:        fcID,
+				CallID:    callID,
+				Name:      name,
+				Arguments: tc.Function.Arguments,
+				Status:    api.ResponsesStatusCompleted,
+			})
+		}
+	} else {
+		text := strings.Join(tokens[0].Strings, "")
+		outputContent := api.OutputContent{
+			Type: api.ResponsesOutputText,
+			Text: text,
+		}
+		if respCtx.TopLogprobs() != nil {
+			logprobs := common.GenerateMessagesLogprobs(tokens[0].Strings, *respCtx.TopLogprobs())
+			outputContent.Logprobs = &logprobs
+		}
+		output = []api.OutputItem{
+			api.MessageOutput{
+				Type:    api.ResponsesOutputMessage,
+				Role:    api.RoleAssistant,
+				Status:  api.ResponsesStatusCompleted,
+				Content: []api.OutputContent{outputContent},
+			},
+		}
 	}
 
 	return api.CreateResponsesResponse(
@@ -454,14 +486,7 @@ func (respBuilder *responsesHTTPRespBuilder) createResponse(respCtxPerChoice []v
 		respCtx.RequestID(),
 		time.Now().Unix(),
 		respCtx.Instructions(),
-		[]api.OutputItem{
-			api.MessageOutput{
-				Type:    api.ResponsesOutputMessage,
-				Role:    api.RoleAssistant,
-				Status:  api.ResponsesStatusCompleted,
-				Content: []api.OutputContent{outputContent},
-			},
-		},
+		output,
 		&api.ResponsesUsage{
 			InputTokens:  usage.PromptTokens,
 			OutputTokens: usage.CompletionTokens,

--- a/pkg/communication/response_builder_tools_test.go
+++ b/pkg/communication/response_builder_tools_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package communication
+
+import (
+	"encoding/json"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/api"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func eventTypesFromChunk(chunk sseChunk) []string {
+	Expect(chunk).NotTo(BeNil())
+	named, ok := chunk.(*namedEventChunk)
+	Expect(ok).To(BeTrue())
+	return named.names
+}
+
+func eventPayloadsFromChunk(chunk sseChunk) []json.RawMessage {
+	named := chunk.(*namedEventChunk)
+	out := make([]json.RawMessage, len(named.data))
+	for i, d := range named.data {
+		b, err := json.Marshal(d)
+		Expect(err).NotTo(HaveOccurred())
+		out[i] = b
+	}
+	return out
+}
+
+var _ = Describe("Responses HTTP tool streaming", func() {
+	It("builds function_call output items with call_ id derived from fc_ id", func() {
+		name := "get_weather"
+		item := functionCallOutputItem(api.ToolCall{
+			ID: "fc_abc123",
+			Function: api.FunctionCall{
+				Name:      &name,
+				Arguments: `{"city":"Paris"}`,
+			},
+		}, api.ResponsesStatusCompleted)
+		Expect(item.ID).To(Equal("fc_abc123"))
+		Expect(item.CallID).To(Equal("call_abc123"))
+		Expect(item.Name).To(Equal("get_weather"))
+		Expect(item.Arguments).To(Equal(`{"city":"Paris"}`))
+		Expect(item.Status).To(Equal(api.ResponsesStatusCompleted))
+	})
+
+	It("emits function_call SSE events for argument tokens", func() {
+		b := &responsesHTTPRespBuilder{inToolMode: true}
+		name := "get_weather"
+
+		first := &api.ToolCall{
+			ID:   "fc_abc123",
+			Type: "function",
+			Function: api.FunctionCall{
+				Name:      &name,
+				Arguments: `{"city":`,
+			},
+		}
+		chunk1 := b.createToolChunk(first)
+		Expect(eventTypesFromChunk(chunk1)).To(Equal([]string{
+			api.ResponsesEventOutputItemAdded,
+			api.ResponsesEventFunctionCallArgumentsDelta,
+		}))
+		payloads := eventPayloadsFromChunk(chunk1)
+		Expect(string(payloads[0])).To(ContainSubstring(`"type":"function_call"`))
+		Expect(string(payloads[0])).To(ContainSubstring(`"name":"get_weather"`))
+		Expect(string(payloads[0])).To(ContainSubstring(`"status":"in_progress"`))
+		Expect(string(payloads[0])).To(ContainSubstring(`"call_id":"call_abc123"`))
+
+		second := &api.ToolCall{
+			ID:   "fc_abc123",
+			Type: "function",
+			Function: api.FunctionCall{
+				Arguments: `"Paris"}`,
+			},
+		}
+		chunk2 := b.createToolChunk(second)
+		Expect(eventTypesFromChunk(chunk2)).To(Equal([]string{
+			api.ResponsesEventFunctionCallArgumentsDelta,
+		}))
+
+		last := b.createLastChunk(nil, "tool_calls", 0)
+		Expect(eventTypesFromChunk(last)).To(Equal([]string{
+			api.ResponsesEventFunctionCallArgumentsDone,
+			api.ResponsesEventOutputItemDone,
+		}))
+		lastPayloads := eventPayloadsFromChunk(last)
+		var argsDone api.ResponsesItemEvent
+		Expect(json.Unmarshal(lastPayloads[0], &argsDone)).To(Succeed())
+		Expect(argsDone.Name).To(Equal("get_weather"))
+		Expect(argsDone.Arguments).To(Equal(`{"city":"Paris"}`))
+		Expect(argsDone.ItemID).To(Equal("fc_abc123"))
+		Expect(string(lastPayloads[1])).To(ContainSubstring(`"status":"completed"`))
+	})
+})

--- a/pkg/llm-d-inference-sim/responses.go
+++ b/pkg/llm-d-inference-sim/responses.go
@@ -98,22 +98,25 @@ func (r *responsesReqCtx) request() Request {
 	return r.req
 }
 
-// convertInputToMessages converts ResponsesRequest Input to Messages
+// convertInputToMessages converts ResponsesRequest Input to Messages for tokenization.
+// function_call / function_call_output items are mapped to chat-style assistant/tool
+// messages so they contribute to usage.input_tokens (and prefix/cache logic).
 func convertInputToMessages(input []api.InputItem) []api.Message {
 	messages := make([]api.Message, 0, len(input))
 	for _, item := range input {
-		if inputMsg, ok := item.(*api.InputMessage); ok {
+		switch v := item.(type) {
+		case *api.InputMessage:
 			msg := api.Message{
-				Role: inputMsg.Role,
+				Role: v.Role,
 			}
 
-			if len(inputMsg.Content) == 1 && inputMsg.Content[0].Type == api.ResponsesInputText {
+			if len(v.Content) == 1 && v.Content[0].Type == api.ResponsesInputText {
 				// Simple text content
-				msg.Content.Raw = inputMsg.Content[0].Text
+				msg.Content.Raw = v.Content[0].Text
 			} else {
 				// Structured content (text, images, audio)
-				blocks := make([]api.ChatComplContentBlock, 0, len(inputMsg.Content))
-				for _, content := range inputMsg.Content {
+				blocks := make([]api.ChatComplContentBlock, 0, len(v.Content))
+				for _, content := range v.Content {
 					switch content.Type {
 					case api.ResponsesInputText:
 						blocks = append(blocks, api.ChatComplContentBlock{
@@ -136,6 +139,29 @@ func convertInputToMessages(input []api.InputItem) []api.Message {
 			}
 
 			messages = append(messages, msg)
+		case *api.InputFunctionCall:
+			name := v.Name
+			tcID := v.ID
+			if tcID == "" {
+				tcID = v.CallID
+			}
+			messages = append(messages, api.Message{
+				Role: api.RoleAssistant,
+				ToolCalls: []api.ToolCall{{
+					ID:   tcID,
+					Type: "function",
+					Function: api.FunctionCall{
+						Name:      &name,
+						Arguments: v.Arguments,
+					},
+				}},
+			})
+		case *api.InputFunctionCallOutput:
+			messages = append(messages, api.Message{
+				Role:       "tool",
+				ToolCallID: v.CallID,
+				Content:    api.ChatComplContent{Raw: v.Output},
+			})
 		}
 	}
 	return messages
@@ -158,8 +184,8 @@ func (r *responsesReqCtx) createToolCalls() ([]api.ToolCall, int, string, error)
 
 	toolChoice := req.GetToolChoice()
 	// Deterministic first tool turn: treat omitted/auto as required unless a function is forced.
-	if toolChoice.GetFunction() == nil &&
-		(param.IsOmitted(toolChoice.OfAuto) || toolChoice.OfAuto.Or("") == toolChoiceAuto) {
+	// Do not upgrade allowed_tools/custom — those are unenforced and must keep auto-like min=0.
+	if shouldForceRequiredToolChoice(toolChoice) {
 		toolChoice = api.NewToolChoiceRequired()
 	}
 
@@ -174,13 +200,29 @@ func (r *responsesReqCtx) createToolCalls() ([]api.ToolCall, int, string, error)
 	return toolCalls, completionTokens, common.ToolsFinishReason, nil
 }
 
+// shouldForceRequiredToolChoice reports whether Responses should rewrite tool_choice
+// to required for a deterministic first tool turn.
+func shouldForceRequiredToolChoice(toolChoice api.ToolChoice) bool {
+	if toolChoice.OfAllowedTools != nil || toolChoice.OfCustomToolChoice != nil {
+		return false
+	}
+	if toolChoice.GetFunction() != nil {
+		return false
+	}
+	return param.IsOmitted(toolChoice.OfAuto) || toolChoice.OfAuto.Or("") == toolChoiceAuto
+}
+
 func (r *responsesReqCtx) tokenizedPromptForEcho() (*api.Tokenized, error) {
-	// echo the text of the last input message, matching chat completion behavior
+	// echo the text of the last input item, matching chat completion behavior for messages
 	lastMsg := ""
 	if len(r.req.Input) > 0 {
-		// in echo mode return the last message without role
-		if msg, ok := r.req.Input[len(r.req.Input)-1].(*api.InputMessage); ok {
-			lastMsg = msg.PlainText(false)
+		switch last := r.req.Input[len(r.req.Input)-1].(type) {
+		case *api.InputMessage:
+			lastMsg = last.PlainText(false)
+		case *api.InputFunctionCallOutput:
+			lastMsg = last.Output
+		case *api.InputFunctionCall:
+			lastMsg = last.Name + "(" + last.Arguments + ")"
 		}
 	}
 	tokens, strTokens, err := r.sim.Tokenizer.RenderText(lastMsg)

--- a/pkg/llm-d-inference-sim/responses.go
+++ b/pkg/llm-d-inference-sim/responses.go
@@ -19,6 +19,9 @@ package llmdinferencesim
 import (
 	"encoding/json"
 
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/valyala/fasthttp"
+
 	"github.com/llm-d/llm-d-inference-sim/pkg/api"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 )
@@ -34,6 +37,20 @@ func (r *ResponsesRequest) Unmarshal(data []byte) error {
 }
 
 func (r *ResponsesRequest) validate(toolsValidator *toolsValidator) *api.Error {
+	for _, tool := range r.Tools {
+		toolJson, err := json.Marshal(tool.Function)
+		if err != nil {
+			serverErr := api.NewError("Failed to marshal request tools: "+err.Error(),
+				fasthttp.StatusBadRequest, nil)
+			return &serverErr
+		}
+		err = toolsValidator.validateTool(toolJson)
+		if err != nil {
+			serverErr := api.NewError("Tool validation failed: "+err.Error(),
+				fasthttp.StatusBadRequest, nil)
+			return &serverErr
+		}
+	}
 	return validateRequest(r)
 }
 
@@ -42,6 +59,7 @@ func (r *ResponsesRequest) buildRequestContext(simCtx *SimContext, channel commo
 	reqCtx := &responsesReqCtx{
 		baseRequestContext: newBaseRequestContext(simCtx, channel, choiceIdx, doneFn),
 		req:                r,
+		toolIDPrefix:       api.ResponsesFunctionCallIDPrefix,
 	}
 	reqCtx.requestContext = reqCtx
 	return reqCtx
@@ -58,6 +76,7 @@ func (r *ResponsesRequest) createResponseContext(reqCtx requestContext, displayM
 		logprobs, r.GetRequestID(), r.IsDoRemotePrefill(), r.IsDoRemoteDecode(), r.GetNumberOfCachedPromptTokens())
 	return &responsesResponseCtx{
 		baseResponseContext: base,
+		toolsCalls:          toolCalls,
 	}
 }
 
@@ -71,7 +90,8 @@ var _ Request = (*ResponsesRequest)(nil)
 // Implementation of requestContext for /responses requests
 type responsesReqCtx struct {
 	baseRequestContext
-	req *ResponsesRequest
+	req          *ResponsesRequest
+	toolIDPrefix string
 }
 
 func (r *responsesReqCtx) request() Request {
@@ -127,7 +147,31 @@ func (r *responsesReqCtx) encode() ([]uint32, []string, *api.RenderMMFeatures, e
 }
 
 func (r *responsesReqCtx) createToolCalls() ([]api.ToolCall, int, string, error) {
-	return nil, 0, "", nil
+	req := r.req
+	if isToolChoiceNone(req.GetToolChoice()) || len(req.GetTools()) == 0 {
+		return nil, 0, "", nil
+	}
+	// After tool results are present, finish with a normal message so Praxis can exit the loop.
+	if api.HasFunctionCallOutput(req.Input) {
+		return nil, 0, "", nil
+	}
+
+	toolChoice := req.GetToolChoice()
+	// Deterministic first tool turn: treat omitted/auto as required unless a function is forced.
+	if toolChoice.GetFunction() == nil &&
+		(param.IsOmitted(toolChoice.OfAuto) || toolChoice.OfAuto.Or("") == toolChoiceAuto) {
+		toolChoice = api.NewToolChoiceRequired()
+	}
+
+	toolCalls, completionTokens, err := createSingleToolCall(
+		req.GetTools(), toolChoice, r.sim.Config(), r.sim.Random, r.sim.Tokenizer, r.toolIDPrefix)
+	if err != nil {
+		return nil, 0, "", err
+	}
+	if len(toolCalls) == 0 {
+		return nil, 0, "", nil
+	}
+	return toolCalls, completionTokens, common.ToolsFinishReason, nil
 }
 
 func (r *responsesReqCtx) tokenizedPromptForEcho() (*api.Tokenized, error) {
@@ -151,6 +195,7 @@ var _ requestContext = (*responsesReqCtx)(nil)
 // Implementation of responseContext for /responses requests
 type responsesResponseCtx struct {
 	baseResponseContext
+	toolsCalls []api.ToolCall
 }
 
 func (respCtx *responsesResponseCtx) Instructions() *string {
@@ -161,7 +206,7 @@ func (respCtx *responsesResponseCtx) Instructions() *string {
 }
 
 func (respCtx *responsesResponseCtx) ToolCalls() []api.ToolCall {
-	return nil
+	return respCtx.toolsCalls
 }
 
 var _ ResponseContext = (*responsesResponseCtx)(nil)

--- a/pkg/llm-d-inference-sim/responses_test.go
+++ b/pkg/llm-d-inference-sim/responses_test.go
@@ -18,6 +18,7 @@ package llmdinferencesim
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/llm-d/llm-d-inference-sim/pkg/api"
@@ -148,6 +149,132 @@ var _ = Describe("Responses createToolCalls policy", func() {
 		Expect(calls).To(HaveLen(1))
 		Expect(finish).To(Equal(common.ToolsFinishReason))
 		Expect(*calls[0].Function.Name).To(Equal("get_temperature"))
+	})
+
+	It("keeps tools disabled after function_call_output even with a later user message", func() {
+		ctx := newResponsesToolTestCtx(
+			[]api.Tool{mustTool("get_weather")},
+			api.ToolChoice{},
+			[]api.InputItem{
+				&api.InputMessage{
+					Type:    "message",
+					Role:    api.RoleUser,
+					Content: []api.InputContent{{Type: api.ResponsesInputText, Text: "weather?"}},
+				},
+				&api.InputFunctionCall{
+					Type: "function_call", CallID: "call_1", Name: "get_weather", Arguments: `{"city":"Paris"}`,
+				},
+				&api.InputFunctionCallOutput{Type: "function_call_output", CallID: "call_1", Output: "sunny"},
+				&api.InputMessage{
+					Type:    "message",
+					Role:    api.RoleUser,
+					Content: []api.InputContent{{Type: api.ResponsesInputText, Text: "and the stock price?"}},
+				},
+			},
+		)
+		calls, tokens, finish, err := ctx.createToolCalls()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(calls).To(BeNil())
+		Expect(tokens).To(Equal(0))
+		Expect(finish).To(Equal(""))
+	})
+
+	It("does not force-required for allowed_tools tool_choice", func() {
+		var choice api.ToolChoice
+		Expect(json.Unmarshal([]byte(`{
+			"type": "allowed_tools",
+			"allowed_tools": {
+				"mode": "auto",
+				"tools": [{"type": "function", "name": "get_weather"}]
+			}
+		}`), &choice)).To(Succeed())
+		Expect(choice.OfAllowedTools).NotTo(BeNil())
+		Expect(shouldForceRequiredToolChoice(choice)).To(BeFalse())
+		Expect(shouldForceRequiredToolChoice(api.ToolChoice{})).To(BeTrue())
+		Expect(shouldForceRequiredToolChoice(api.NewToolChoiceFunction("get_weather"))).To(BeFalse())
+	})
+
+	It("does not force-required for custom tool_choice", func() {
+		var choice api.ToolChoice
+		Expect(json.Unmarshal([]byte(`{"type":"custom","custom":{"name":"my_custom"}}`), &choice)).To(Succeed())
+		Expect(choice.OfCustomToolChoice).NotTo(BeNil())
+		Expect(shouldForceRequiredToolChoice(choice)).To(BeFalse())
+	})
+})
+
+var _ = Describe("Responses convertInputToMessages", func() {
+	It("includes function_call and function_call_output in tokenized prompt", func() {
+		tok := tokenizer.NewSimpleTokenizer()
+		msgOnly := convertInputToMessages([]api.InputItem{
+			&api.InputMessage{
+				Type:    "message",
+				Role:    api.RoleUser,
+				Content: []api.InputContent{{Type: api.ResponsesInputText, Text: "weather?"}},
+			},
+		})
+		withTools := convertInputToMessages([]api.InputItem{
+			&api.InputMessage{
+				Type:    "message",
+				Role:    api.RoleUser,
+				Content: []api.InputContent{{Type: api.ResponsesInputText, Text: "weather?"}},
+			},
+			&api.InputFunctionCall{
+				Type: "function_call", ID: "fc_1", CallID: "call_1",
+				Name: "get_weather", Arguments: `{"city":"Paris"}`,
+			},
+			&api.InputFunctionCallOutput{
+				Type: "function_call_output", CallID: "call_1", Output: "sunny, 22C",
+			},
+		})
+		Expect(withTools).To(HaveLen(3))
+		Expect(withTools[1].Role).To(Equal(api.RoleAssistant))
+		Expect(withTools[1].ToolCalls).To(HaveLen(1))
+		Expect(withTools[2].Role).To(Equal("tool"))
+		Expect(withTools[2].Content.Raw).To(Equal("sunny, 22C"))
+
+		tokensOnly, _, _, err := tok.RenderMessages(msgOnly)
+		Expect(err).NotTo(HaveOccurred())
+		tokensWith, _, _, err := tok.RenderMessages(withTools)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(tokensWith)).To(BeNumerically(">", len(tokensOnly)))
+	})
+})
+
+var _ = Describe("Responses tokenizedPromptForEcho", func() {
+	It("echoes function_call_output text when it is the last input item", func() {
+		ctx := newResponsesToolTestCtx(
+			[]api.Tool{mustTool("get_weather")},
+			api.ToolChoice{},
+			[]api.InputItem{
+				&api.InputMessage{
+					Type:    "message",
+					Role:    api.RoleUser,
+					Content: []api.InputContent{{Type: api.ResponsesInputText, Text: "weather?"}},
+				},
+				&api.InputFunctionCallOutput{
+					Type: "function_call_output", CallID: "call_1", Output: "sunny, 22C",
+				},
+			},
+		)
+		tokenized, err := ctx.tokenizedPromptForEcho()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Join(tokenized.Strings, "")).To(Equal("sunny, 22C"))
+	})
+
+	It("echoes function_call name and arguments when it is the last input item", func() {
+		ctx := newResponsesToolTestCtx(
+			nil,
+			api.ToolChoice{},
+			[]api.InputItem{
+				&api.InputFunctionCall{
+					Type: "function_call", CallID: "call_1",
+					Name: "get_weather", Arguments: `{"city":"Paris"}`,
+				},
+			},
+		)
+		tokenized, err := ctx.tokenizedPromptForEcho()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Join(tokenized.Strings, "")).To(Equal(`get_weather({"city":"Paris"})`))
 	})
 })
 

--- a/pkg/llm-d-inference-sim/responses_test.go
+++ b/pkg/llm-d-inference-sim/responses_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmdinferencesim
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/api"
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	"github.com/llm-d/llm-d-inference-sim/pkg/tokenizer"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func mustTool(name string) api.Tool {
+	body := `{"model":"m","input":"x","tools":[{
+		"type": "function",
+		"name": "` + name + `",
+		"description": "test tool ` + name + `",
+		"parameters": {
+			"type": "object",
+			"properties": {"city": {"type": "string"}},
+			"required": ["city"]
+		}
+	}]}`
+	var req api.ResponsesRequest
+	Expect(json.Unmarshal([]byte(body), &req)).To(Succeed())
+	Expect(req.Tools).To(HaveLen(1))
+	return req.Tools[0]
+}
+
+func newResponsesToolTestCtx(tools []api.Tool, choice api.ToolChoice, input []api.InputItem) *responsesReqCtx {
+	cfg := &common.Configuration{
+		MaxToolCallIntegerParam:                   100,
+		MinToolCallIntegerParam:                   0,
+		MaxToolCallNumberParam:                    100,
+		MinToolCallNumberParam:                    0,
+		MaxToolCallArrayParamLength:               5,
+		MinToolCallArrayParamLength:               1,
+		ToolCallNotRequiredParamProbability:       50,
+		ObjectToolCallNotRequiredParamProbability: 50,
+	}
+	sim := &SimContext{}
+	sim.SetConfig(cfg)
+	sim.Random = common.NewRandom(time.Now().UnixNano(), 8080)
+	sim.Tokenizer = tokenizer.NewSimpleTokenizer()
+
+	req := &ResponsesRequest{}
+	req.Tools = tools
+	req.ToolChoice = choice
+	req.Input = input
+	req.RequestID = "req-test"
+
+	return &responsesReqCtx{
+		baseRequestContext: baseRequestContext{sim: sim},
+		req:                req,
+		toolIDPrefix:       api.ResponsesFunctionCallIDPrefix,
+	}
+}
+
+var _ = Describe("Responses createToolCalls policy", func() {
+	It("emits exactly one tool call when tools are present", func() {
+		ctx := newResponsesToolTestCtx(
+			[]api.Tool{mustTool("get_weather"), mustTool("get_temperature")},
+			api.ToolChoice{},
+			[]api.InputItem{&api.InputMessage{
+				Type:    "message",
+				Role:    api.RoleUser,
+				Content: []api.InputContent{{Type: api.ResponsesInputText, Text: "weather?"}},
+			}},
+		)
+		calls, tokens, finish, err := ctx.createToolCalls()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(calls).To(HaveLen(1))
+		Expect(tokens).To(BeNumerically(">", 0))
+		Expect(finish).To(Equal(common.ToolsFinishReason))
+		Expect(calls[0].ID).To(HavePrefix(api.ResponsesFunctionCallIDPrefix))
+		Expect(calls[0].Function.Name).NotTo(BeNil())
+		Expect(*calls[0].Function.Name).To(BeElementOf("get_weather", "get_temperature"))
+	})
+
+	It("returns nil when function_call_output is already in input", func() {
+		ctx := newResponsesToolTestCtx(
+			[]api.Tool{mustTool("get_weather")},
+			api.ToolChoice{},
+			[]api.InputItem{
+				&api.InputMessage{
+					Type:    "message",
+					Role:    api.RoleUser,
+					Content: []api.InputContent{{Type: api.ResponsesInputText, Text: "weather?"}},
+				},
+				&api.InputFunctionCall{
+					Type: "function_call", CallID: "call_1", Name: "get_weather", Arguments: `{"city":"Paris"}`,
+				},
+				&api.InputFunctionCallOutput{Type: "function_call_output", CallID: "call_1", Output: "sunny"},
+			},
+		)
+		calls, tokens, finish, err := ctx.createToolCalls()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(calls).To(BeNil())
+		Expect(tokens).To(Equal(0))
+		Expect(finish).To(Equal(""))
+	})
+
+	It("returns nil when tool_choice is none", func() {
+		ctx := newResponsesToolTestCtx(
+			[]api.Tool{mustTool("get_weather")},
+			api.NewToolChoiceNone(),
+			[]api.InputItem{&api.InputMessage{
+				Type:    "message",
+				Role:    api.RoleUser,
+				Content: []api.InputContent{{Type: api.ResponsesInputText, Text: "weather?"}},
+			}},
+		)
+		calls, _, finish, err := ctx.createToolCalls()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(calls).To(BeNil())
+		Expect(finish).To(Equal(""))
+	})
+
+	It("honors forced function tool_choice", func() {
+		ctx := newResponsesToolTestCtx(
+			[]api.Tool{mustTool("get_weather"), mustTool("get_temperature")},
+			api.NewToolChoiceFunction("get_temperature"),
+			[]api.InputItem{&api.InputMessage{
+				Type:    "message",
+				Role:    api.RoleUser,
+				Content: []api.InputContent{{Type: api.ResponsesInputText, Text: "need data"}},
+			}},
+		)
+		calls, _, finish, err := ctx.createToolCalls()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(calls).To(HaveLen(1))
+		Expect(finish).To(Equal(common.ToolsFinishReason))
+		Expect(*calls[0].Function.Name).To(Equal("get_temperature"))
+	})
+})
+
+var _ = Describe("createSingleToolCall", func() {
+	It("never returns more than one call", func() {
+		cfg := &common.Configuration{
+			MaxToolCallIntegerParam:                   100,
+			MinToolCallIntegerParam:                   0,
+			MaxToolCallNumberParam:                    100,
+			MinToolCallNumberParam:                    0,
+			MaxToolCallArrayParamLength:               5,
+			MinToolCallArrayParamLength:               1,
+			ToolCallNotRequiredParamProbability:       50,
+			ObjectToolCallNotRequiredParamProbability: 50,
+		}
+		random := common.NewRandom(1, 8080)
+		tok := tokenizer.NewSimpleTokenizer()
+		tools := []api.Tool{mustTool("get_weather"), mustTool("get_temperature")}
+		for range 20 {
+			calls, _, err := createSingleToolCall(
+				tools,
+				api.NewToolChoiceRequired(),
+				cfg,
+				random,
+				tok,
+				api.ResponsesFunctionCallIDPrefix,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(calls).To(HaveLen(1))
+		}
+	})
+})

--- a/pkg/llm-d-inference-sim/tools_utils.go
+++ b/pkg/llm-d-inference-sim/tools_utils.go
@@ -207,6 +207,24 @@ func createToolCalls(
 	return generateCalls(tools, min)
 }
 
+// createSingleToolCall generates at most one tool call. Used by the Responses API
+// path where Praxis requires exactly one function_call per round.
+func createSingleToolCall(
+	tools []api.Tool,
+	toolChoice api.ToolChoice,
+	config *common.Configuration,
+	random *common.Random,
+	tokenizer tokenizer.Tokenizer,
+	idPrefix string,
+) ([]api.ToolCall, int, error) {
+	calls, tokens, err := createToolCalls(tools, toolChoice, config, random, tokenizer, idPrefix)
+	if err != nil || len(calls) <= 1 {
+		return calls, tokens, err
+	}
+	calls = calls[:1]
+	return calls, countTokensForToolCalls(calls), nil
+}
+
 func generateToolArguments(tool api.Tool, config *common.Configuration, random *common.Random) (map[string]any, error) {
 	arguments := make(map[string]any)
 	properties, _ := tool.Function.Parameters["properties"].(map[string]any)

--- a/pkg/tests/responses_tools_test.go
+++ b/pkg/tests/responses_tools_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/api"
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func responsesWeatherTool() responses.ToolUnionParam {
+	tool := responses.ToolParamOfFunction(
+		"get_weather",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"city": map[string]any{"type": "string"},
+			},
+			"required": []any{"city"},
+		},
+		false,
+	)
+	tool.OfFunction.Description = param.NewOpt("Get current weather for a city")
+	return tool
+}
+
+func responsesTemperatureTool() responses.ToolUnionParam {
+	tool := responses.ToolParamOfFunction(
+		"get_temperature",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"city": map[string]any{"type": "string"},
+			},
+			"required": []any{"city"},
+		},
+		false,
+	)
+	tool.OfFunction.Description = param.NewOpt("Get temperature for a city")
+	return tool
+}
+
+var _ = Describe("Responses API tools", func() {
+	It("emits exactly one function_call when tools are present", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient, params := getOpenAIClientAndResponsesParams(client, common.TestModelName, "What is the weather in Paris?")
+		params.Tools = []responses.ToolUnionParam{responsesWeatherTool()}
+
+		resp, err := openaiclient.Responses.New(ctx, params)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Status).To(Equal(responses.ResponseStatusCompleted))
+		Expect(resp.Output).To(HaveLen(1))
+		Expect(resp.Output[0].Type).To(Equal("function_call"))
+
+		fc := resp.Output[0].AsFunctionCall()
+		Expect(fc.Name).To(Equal("get_weather"))
+		Expect(fc.Status).To(Equal(responses.ResponseFunctionToolCallStatusCompleted))
+		Expect(fc.ID).To(HavePrefix(api.ResponsesFunctionCallIDPrefix))
+		Expect(fc.CallID).To(HavePrefix(api.ResponsesCallIDPrefix))
+		var args map[string]any
+		Expect(json.Unmarshal([]byte(fc.Arguments), &args)).To(Succeed())
+		Expect(args).To(HaveKey("city"))
+	})
+
+	It("returns a message after function_call_output is present in input", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient := openai.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithHTTPClient(client),
+			option.WithMaxRetries(0))
+
+		params := responses.ResponseNewParams{
+			Model: common.TestModelName,
+			Input: responses.ResponseNewParamsInputUnion{
+				OfInputItemList: responses.ResponseInputParam{
+					responses.ResponseInputItemParamOfMessage("What is the weather?", responses.EasyInputMessageRoleUser),
+					responses.ResponseInputItemParamOfFunctionCall(`{"city":"Paris"}`, "call_1", "get_weather"),
+					responses.ResponseInputItemParamOfFunctionCallOutput("call_1", "sunny, 22C"),
+				},
+			},
+			Tools: []responses.ToolUnionParam{responsesWeatherTool()},
+		}
+
+		resp, err := openaiclient.Responses.New(ctx, params)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Output).NotTo(BeEmpty())
+		Expect(resp.Output[0].Type).To(Equal("message"))
+		Expect(resp.OutputText()).NotTo(BeEmpty())
+	})
+
+	It("returns a message when tool_choice is none", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient, params := getOpenAIClientAndResponsesParams(client, common.TestModelName, "What is the weather?")
+		params.Tools = []responses.ToolUnionParam{responsesWeatherTool()}
+		params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsNone),
+		}
+
+		resp, err := openaiclient.Responses.New(ctx, params)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Output).NotTo(BeEmpty())
+		Expect(resp.Output[0].Type).To(Equal("message"))
+	})
+
+	It("emits exactly one function_call when multiple tools are defined", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient, params := getOpenAIClientAndResponsesParams(client, common.TestModelName, "Need weather and temperature")
+		params.Tools = []responses.ToolUnionParam{responsesWeatherTool(), responsesTemperatureTool()}
+
+		resp, err := openaiclient.Responses.New(ctx, params)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Output).To(HaveLen(1))
+		Expect(resp.Output[0].Type).To(Equal("function_call"))
+		fc := resp.Output[0].AsFunctionCall()
+		Expect(fc.Name).To(BeElementOf("get_weather", "get_temperature"))
+	})
+
+	It("honors forced function tool_choice", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient, params := getOpenAIClientAndResponsesParams(client, common.TestModelName, "Need data")
+		params.Tools = []responses.ToolUnionParam{responsesWeatherTool(), responsesTemperatureTool()}
+		params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+			OfFunctionTool: &responses.ToolChoiceFunctionParam{Name: "get_temperature"},
+		}
+
+		resp, err := openaiclient.Responses.New(ctx, params)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Output).To(HaveLen(1))
+		Expect(resp.Output[0].Type).To(Equal("function_call"))
+		Expect(resp.Output[0].AsFunctionCall().Name).To(Equal("get_temperature"))
+	})
+
+	It("rejects invalid tool schemas with 400", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		reqBody := `{
+			"model": "` + common.TestModelName + `",
+			"input": "hello",
+			"tools": [{
+				"type": "function",
+				"name": "bad_tool",
+				"description": "missing parameters type"
+			}]
+		}`
+		resp, err := client.Post("http://localhost/v1/responses", "application/json", strings.NewReader(reqBody))
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			Expect(resp.Body.Close()).To(Succeed())
+		}()
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(body)).To(ContainSubstring("Tool validation failed"))
+	})
+})

--- a/pkg/tests/responses_tools_test.go
+++ b/pkg/tests/responses_tools_test.go
@@ -347,4 +347,126 @@ var _ = Describe("Responses API tools", func() {
 		Expect(stream.Err()).NotTo(HaveOccurred())
 		Expect(addedName).To(Equal("get_temperature"))
 	})
+
+	It("errors when forced tool_choice names a missing function", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, postErr := client.Post("http://localhost/v1/responses", "application/json", strings.NewReader(`{
+			"model": "`+common.TestModelName+`",
+			"input": "Need data",
+			"tools": [{
+				"type": "function",
+				"name": "get_weather",
+				"description": "Get weather",
+				"parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+			}],
+			"tool_choice": {"type": "function", "name": "does_not_exist"}
+		}`))
+		Expect(postErr).NotTo(HaveOccurred())
+		defer func() { Expect(resp.Body.Close()).To(Succeed()) }()
+		Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(body)).To(ContainSubstring("not found in the tools list"))
+	})
+
+	It("echoes function_call_output in echo mode", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeEcho)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient := openai.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithHTTPClient(client),
+			option.WithMaxRetries(0))
+
+		const toolOutput = "sunny, 22C"
+		params := responses.ResponseNewParams{
+			Model: common.TestModelName,
+			Input: responses.ResponseNewParamsInputUnion{
+				OfInputItemList: responses.ResponseInputParam{
+					responses.ResponseInputItemParamOfMessage("What is the weather?", responses.EasyInputMessageRoleUser),
+					responses.ResponseInputItemParamOfFunctionCall(`{"city":"Paris"}`, "call_1", "get_weather"),
+					responses.ResponseInputItemParamOfFunctionCallOutput("call_1", toolOutput),
+				},
+			},
+			Tools: []responses.ToolUnionParam{responsesWeatherTool()},
+		}
+
+		resp, err := openaiclient.Responses.New(ctx, params)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Output).NotTo(BeEmpty())
+		Expect(resp.Output[0].Type).To(Equal("message"))
+		Expect(resp.OutputText()).To(Equal(toolOutput))
+	})
+
+	It("keeps tools disabled on a later user turn after function_call_output", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient := openai.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithHTTPClient(client),
+			option.WithMaxRetries(0))
+
+		params := responses.ResponseNewParams{
+			Model: common.TestModelName,
+			Input: responses.ResponseNewParamsInputUnion{
+				OfInputItemList: responses.ResponseInputParam{
+					responses.ResponseInputItemParamOfMessage("What is the weather?", responses.EasyInputMessageRoleUser),
+					responses.ResponseInputItemParamOfFunctionCall(`{"city":"Paris"}`, "call_1", "get_weather"),
+					responses.ResponseInputItemParamOfFunctionCallOutput("call_1", "sunny, 22C"),
+					responses.ResponseInputItemParamOfMessage("What is the stock price of ACME?", responses.EasyInputMessageRoleUser),
+				},
+			},
+			Tools: []responses.ToolUnionParam{responsesWeatherTool()},
+		}
+
+		resp, err := openaiclient.Responses.New(ctx, params)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Output).NotTo(BeEmpty())
+		Expect(resp.Output[0].Type).To(Equal("message"))
+	})
+
+	It("counts function_call input items toward usage.input_tokens", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient := openai.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithHTTPClient(client),
+			option.WithMaxRetries(0))
+
+		msgOnly, err := openaiclient.Responses.New(ctx, responses.ResponseNewParams{
+			Model: common.TestModelName,
+			Input: responses.ResponseNewParamsInputUnion{
+				OfInputItemList: responses.ResponseInputParam{
+					responses.ResponseInputItemParamOfMessage("What is the weather?", responses.EasyInputMessageRoleUser),
+				},
+			},
+			ToolChoice: responses.ResponseNewParamsToolChoiceUnion{
+				OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsNone),
+			},
+			Tools: []responses.ToolUnionParam{responsesWeatherTool()},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		withHistory, err := openaiclient.Responses.New(ctx, responses.ResponseNewParams{
+			Model: common.TestModelName,
+			Input: responses.ResponseNewParamsInputUnion{
+				OfInputItemList: responses.ResponseInputParam{
+					responses.ResponseInputItemParamOfMessage("What is the weather?", responses.EasyInputMessageRoleUser),
+					responses.ResponseInputItemParamOfFunctionCall(`{"city":"Paris"}`, "call_1", "get_weather"),
+					responses.ResponseInputItemParamOfFunctionCallOutput("call_1", "sunny, 22C"),
+				},
+			},
+			Tools: []responses.ToolUnionParam{responsesWeatherTool()},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(withHistory.Usage.InputTokens).To(BeNumerically(">", msgOnly.Usage.InputTokens))
+	})
 })

--- a/pkg/tests/responses_tools_test.go
+++ b/pkg/tests/responses_tools_test.go
@@ -194,4 +194,157 @@ var _ = Describe("Responses API tools", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(body)).To(ContainSubstring("Tool validation failed"))
 	})
+
+	It("streams function_call events when tools are present", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient, params := getOpenAIClientAndResponsesParams(client, common.TestModelName, "What is the weather in Paris?")
+		params.Tools = []responses.ToolUnionParam{responsesWeatherTool()}
+
+		stream := openaiclient.Responses.NewStreaming(ctx, params)
+		defer func() {
+			Expect(stream.Close()).NotTo(HaveOccurred())
+		}()
+
+		var eventTypes []string
+		var argDeltas []string
+		var addedName string
+		var doneArgs string
+		var doneName string
+
+		for stream.Next() {
+			event := stream.Current()
+			eventTypes = append(eventTypes, event.Type)
+			switch event.Type {
+			case api.ResponsesEventOutputItemAdded:
+				added := event.AsResponseOutputItemAdded()
+				Expect(added.Item.Type).To(Equal("function_call"))
+				fc := added.Item.AsFunctionCall()
+				addedName = fc.Name
+				Expect(fc.ID).To(HavePrefix(api.ResponsesFunctionCallIDPrefix))
+				Expect(fc.CallID).To(HavePrefix(api.ResponsesCallIDPrefix))
+			case api.ResponsesEventFunctionCallArgumentsDelta:
+				delta := event.AsResponseFunctionCallArgumentsDelta()
+				argDeltas = append(argDeltas, delta.Delta)
+				Expect(delta.ItemID).To(HavePrefix(api.ResponsesFunctionCallIDPrefix))
+			case api.ResponsesEventFunctionCallArgumentsDone:
+				done := event.AsResponseFunctionCallArgumentsDone()
+				doneArgs = done.Arguments
+				doneName = done.Name
+				Expect(done.ItemID).To(HavePrefix(api.ResponsesFunctionCallIDPrefix))
+			case api.ResponsesEventCompleted:
+				completed := event.AsResponseCompleted()
+				Expect(string(completed.Response.Status)).To(Equal(api.ResponsesStatusCompleted))
+				Expect(completed.Response.Output).To(HaveLen(1))
+				Expect(completed.Response.Output[0].Type).To(Equal("function_call"))
+				fc := completed.Response.Output[0].AsFunctionCall()
+				Expect(fc.Name).To(Equal(addedName))
+				Expect(fc.Arguments).To(Equal(doneArgs))
+			}
+		}
+		Expect(stream.Err()).NotTo(HaveOccurred())
+
+		Expect(eventTypes[0]).To(Equal(api.ResponsesEventCreated))
+		Expect(eventTypes[1]).To(Equal(api.ResponsesEventInProgress))
+		Expect(eventTypes).To(ContainElement(api.ResponsesEventOutputItemAdded))
+		Expect(eventTypes).To(ContainElement(api.ResponsesEventFunctionCallArgumentsDelta))
+		Expect(eventTypes).To(ContainElement(api.ResponsesEventFunctionCallArgumentsDone))
+		Expect(eventTypes).To(ContainElement(api.ResponsesEventOutputItemDone))
+		Expect(eventTypes[len(eventTypes)-1]).To(Equal(api.ResponsesEventCompleted))
+		Expect(eventTypes).NotTo(ContainElement(api.ResponsesEventTextDelta))
+		Expect(eventTypes).NotTo(ContainElement(api.ResponsesEventContentPartAdded))
+
+		Expect(addedName).To(Equal("get_weather"))
+		Expect(doneName).To(Equal("get_weather"))
+		Expect(doneArgs).To(Equal(strings.Join(argDeltas, "")))
+		var args map[string]any
+		Expect(json.Unmarshal([]byte(doneArgs), &args)).To(Succeed())
+		Expect(args).To(HaveKey("city"))
+
+		functionCallAddedCount := 0
+		for _, t := range eventTypes {
+			if t == api.ResponsesEventOutputItemAdded {
+				functionCallAddedCount++
+			}
+		}
+		Expect(functionCallAddedCount).To(Equal(1))
+	})
+
+	It("streams a message after function_call_output on re-entry", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient := openai.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithHTTPClient(client),
+			option.WithMaxRetries(0))
+
+		params := responses.ResponseNewParams{
+			Model: common.TestModelName,
+			Input: responses.ResponseNewParamsInputUnion{
+				OfInputItemList: responses.ResponseInputParam{
+					responses.ResponseInputItemParamOfMessage("What is the weather?", responses.EasyInputMessageRoleUser),
+					responses.ResponseInputItemParamOfFunctionCall(`{"city":"Paris"}`, "call_1", "get_weather"),
+					responses.ResponseInputItemParamOfFunctionCallOutput("call_1", "sunny, 22C"),
+				},
+			},
+			Tools: []responses.ToolUnionParam{responsesWeatherTool()},
+		}
+
+		stream := openaiclient.Responses.NewStreaming(ctx, params)
+		defer func() {
+			Expect(stream.Close()).NotTo(HaveOccurred())
+		}()
+
+		var eventTypes []string
+		for stream.Next() {
+			event := stream.Current()
+			eventTypes = append(eventTypes, event.Type)
+			if event.Type == api.ResponsesEventCompleted {
+				completed := event.AsResponseCompleted()
+				Expect(completed.Response.Output).NotTo(BeEmpty())
+				Expect(completed.Response.Output[0].Type).To(Equal("message"))
+			}
+		}
+		Expect(stream.Err()).NotTo(HaveOccurred())
+		Expect(eventTypes).To(ContainElement(api.ResponsesEventTextDelta))
+		Expect(eventTypes).NotTo(ContainElement(api.ResponsesEventFunctionCallArgumentsDelta))
+		Expect(eventTypes[len(eventTypes)-1]).To(Equal(api.ResponsesEventCompleted))
+	})
+
+	It("streams forced function tool_choice name on output_item.added", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient, params := getOpenAIClientAndResponsesParams(client, common.TestModelName, "Need data")
+		params.Tools = []responses.ToolUnionParam{responsesWeatherTool(), responsesTemperatureTool()}
+		params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+			OfFunctionTool: &responses.ToolChoiceFunctionParam{Name: "get_temperature"},
+		}
+
+		stream := openaiclient.Responses.NewStreaming(ctx, params)
+		defer func() {
+			Expect(stream.Close()).NotTo(HaveOccurred())
+		}()
+
+		var addedName string
+		for stream.Next() {
+			event := stream.Current()
+			switch event.Type {
+			case api.ResponsesEventOutputItemAdded:
+				fc := event.AsResponseOutputItemAdded().Item.AsFunctionCall()
+				addedName = fc.Name
+			case api.ResponsesEventCompleted:
+				completed := event.AsResponseCompleted()
+				Expect(completed.Response.Output).To(HaveLen(1))
+				Expect(completed.Response.Output[0].AsFunctionCall().Name).To(Equal("get_temperature"))
+			}
+		}
+		Expect(stream.Err()).NotTo(HaveOccurred())
+		Expect(addedName).To(Equal("get_temperature"))
+	})
 })


### PR DESCRIPTION
## What does this PR do?

Emit one function_call on the first tool turn, accept function_call_output on re-entry, then return a message so the driver can exit the loop.

## Why is this change needed?

Support Agentic Loop round-trips driven by an external client.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes #602
