### PR TITLE
fix: bump CI's golangci-lint pin to v2.10.1

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Run lint checks
         uses: golangci/golangci-lint-action@v9
         with:
-          version: "v2.10.0"
+          version: "v2.10.1"
           args: "--config=./.golangci.yml"
           skip-cache: true
 


### PR DESCRIPTION
Following up on Nili’s comments in #604. The previous PR fixed a `golangci-lint` panic by bumping the version in `Makefile.tools.mk`, but left CI on the buggy `v2.10.0`. CI stayed green regardless because its cold, skip-cache: true runs never hit the specific cache-warmth condition that triggers the panic, while local make lint, which reuses a persistent cache, did.
