### PR TITLE
feat: accept Claude/Anthropic-shaped tool schemas (skip-validation + type normalization)

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -206,6 +206,28 @@ type Configuration struct {
 	// in an object in a tool call, optional, defaults to 50
 	ObjectToolCallNotRequiredParamProbability int `yaml:"object-tool-call-not-required-field-probability" json:"object-tool-call-not-required-field-probability"`
 
+	// SkipToolValidation, when true, bypasses the built-in JSON Schema
+	// validation of incoming tool definitions and forwards them to the
+	// tool-call generator as-is. Matches real vLLM's behavior — real vLLM
+	// does not meta-validate the input tool spec. Useful when clients
+	// (e.g. Anthropic → OpenAI translators, Claude Code) send tool schemas
+	// with fields outside the sim's strict inline schema (default, format,
+	// title, oneOf, $ref, examples, minLength, minimum, pattern, ...).
+	// Default false — backward compat.
+	SkipToolValidation bool `yaml:"skip-tool-validation" json:"skip-tool-validation"`
+
+	// ToolChoiceOverride, when non-empty, ignores the request's tool_choice
+	// and forces the sim to behave as if the client had sent this value
+	// instead. Valid values: "" (default, no override), "none", "auto",
+	// "required". Ignored for a client-forced-specific-function tool_choice.
+	ToolChoiceOverride string `yaml:"tool-choice-override" json:"tool-choice-override"`
+
+	// MaxCompletionTokensCap, when > 0, is a HARD upper bound the sim applies
+	// to the effective completion-token count regardless of the request's
+	// max_tokens / max_completion_tokens. Guards against unbounded random-
+	// mode responses. Default 0 = no cap.
+	MaxCompletionTokensCap int `yaml:"max-completion-tokens-cap" json:"max-completion-tokens-cap"`
+
 	// EnableKVCache defines if kv cache feature will be enabled
 	EnableKVCache bool `yaml:"enable-kvcache" json:"enable-kvcache"`
 	//  KVCacheSize is the maximum number of token blocks in kv cache, the default value is 1024

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -148,6 +148,10 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.IntVar(&config.ToolCallNotRequiredParamProbability, "tool-call-not-required-param-probability", config.ToolCallNotRequiredParamProbability, "Probability to add a parameter, that is not required, in a tool call")
 	f.IntVar(&config.ObjectToolCallNotRequiredParamProbability, "object-tool-call-not-required-field-probability", config.ObjectToolCallNotRequiredParamProbability, "Probability to add a field, that is not required, in an object in a tool call")
 
+	f.BoolVar(&config.SkipToolValidation, "skip-tool-validation", config.SkipToolValidation, "Skip JSON Schema validation of incoming tool definitions; forward to the tool-call generator as-is (matches real vLLM behavior)")
+	f.StringVar(&config.ToolChoiceOverride, "tool-choice-override", config.ToolChoiceOverride, "Override the request's tool_choice: \"none\" always returns text (no tool calls), \"auto\" lets the sim decide, \"required\" always calls at least one tool. Empty (default) honors the client's tool_choice.")
+	f.IntVar(&config.MaxCompletionTokensCap, "max-completion-tokens-cap", config.MaxCompletionTokensCap, "Hard upper bound on the effective completion-token count regardless of the request's max_tokens; guards against unbounded random-mode responses. 0 (default) = no cap.")
+
 	f.BoolVar(&config.EnableKVCache, "enable-kvcache", config.EnableKVCache, "Defines if KV cache feature is enabled")
 	f.IntVar(&config.KVCacheSize, "kv-cache-size", config.KVCacheSize, "Maximum number of token blocks in kv cache")
 	f.Float64Var(&config.GlobalCacheHitThreshold, "global-cache-hit-threshold", 0, "Default cache hit threshold [0, 1] for all requests. If a request specifies cache_hit_threshold, it takes precedence")

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -18,6 +18,8 @@ package communication
 
 import (
 	"bufio"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -977,6 +979,35 @@ func truncateBodyForLog(body []byte) string {
 	return string(body[:maxHTTPLogBodyBytes]) + fmt.Sprintf(" ... [truncated, total %d bytes]", len(body))
 }
 
+// decompressForLog returns the body decoded per the given Content-Encoding.
+// Only gzip is handled today (the sole encoding fasthttp emits by default);
+// unknown / empty encodings return the body unchanged. A decompression error
+// falls back to the raw bytes so logging never becomes lossy on best-effort
+// human readability. Result feeds truncateBodyForLog so the maxHTTPLogBodyBytes
+// cap still applies to the DECODED payload (a small gzipped blob can expand
+// a lot). Only mutates a copy for logging — the wire body is never touched.
+func decompressForLog(body []byte, encoding string) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
+	case "", "identity":
+		return body
+	case "gzip":
+		r, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return body
+		}
+		defer r.Close()
+		out, err := io.ReadAll(io.LimitReader(r, maxHTTPLogBodyBytes+1))
+		if err != nil {
+			return body
+		}
+		return out
+	}
+	return body
+}
+
 func (c *Communication) logHTTPMiddleware(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		c.logHTTPRequest(ctx)
@@ -986,12 +1017,13 @@ func (c *Communication) logHTTPMiddleware(next fasthttp.RequestHandler) fasthttp
 }
 
 func (c *Communication) logHTTPRequest(ctx *fasthttp.RequestCtx) {
+	reqBody := decompressForLog(ctx.Request.Body(), string(ctx.Request.Header.ContentEncoding()))
 	c.logger.V(logging.INFO).Info("HTTP request",
 		"method", string(ctx.Method()),
 		"requestURI", string(ctx.RequestURI()),
 		"remoteAddr", ctx.RemoteAddr().String(),
 		"headers", formatRequestHeaders(&ctx.Request.Header),
-		"body", truncateBodyForLog(ctx.Request.Body()),
+		"body", truncateBodyForLog(reqBody),
 	)
 }
 
@@ -1005,10 +1037,11 @@ func (c *Communication) logHTTPResponse(ctx *fasthttp.RequestCtx) {
 		)
 		return
 	}
+	respBody := decompressForLog(resp.Body(), string(resp.Header.ContentEncoding()))
 	c.logger.V(logging.INFO).Info("HTTP response",
 		"statusCode", resp.StatusCode(),
 		"headers", formatResponseHeaders(&resp.Header),
-		"body", truncateBodyForLog(resp.Body()),
+		"body", truncateBodyForLog(respBody),
 	)
 }
 

--- a/pkg/dataset/dataset.go
+++ b/pkg/dataset/dataset.go
@@ -120,6 +120,12 @@ type DefaultDataset struct {
 	random             *common.Random
 	histogramHelper    *histogramHelper
 	tokenizedResponses []api.Tokenized
+	// MaxCompletionTokensCap is a HARD upper bound applied on top of the
+	// request's max_tokens and the model-len headroom. 0 (default) disables
+	// the cap. Set from Config.MaxCompletionTokensCap in the sim after Init.
+	// Guards random-mode responses against ballooning to (max-model-len -
+	// prompt) tokens when the client's max_tokens is huge or missing.
+	MaxCompletionTokensCap int
 }
 
 func (d *DefaultDataset) Init(ctx context.Context, logger logr.Logger, random *common.Random, maxModelLen int,
@@ -185,11 +191,20 @@ func (d *DefaultDataset) GetResponseTokens(req api.Request) (*api.Tokenized, str
 func (d *DefaultDataset) calculateResponseMaxLen(req api.Request) (int, bool) {
 	maxTokens := req.GetMaxCompletionTokens()
 
+	var n int
+	var isMax bool
 	if maxTokens != nil {
-		return int(*maxTokens), true
+		n, isMax = int(*maxTokens), true
+	} else {
+		n, isMax = d.maxModelLen-req.TokenizedPrompt().Length(), false
 	}
-
-	return d.maxModelLen - req.TokenizedPrompt().Length(), false
+	if d.MaxCompletionTokensCap > 0 && n > d.MaxCompletionTokensCap {
+		n = d.MaxCompletionTokensCap
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n, isMax
 }
 
 // getRandomResponseLenByDistribution returns int in range [1, responseLenMax]

--- a/pkg/llm-d-inference-sim/chat_completion.go
+++ b/pkg/llm-d-inference-sim/chat_completion.go
@@ -63,19 +63,25 @@ func (c *ChatCompletionsRequest) Render(tk tokenizer.Tokenizer) ([][]uint32, *ap
 	return [][]uint32{tokens}, features, nil
 }
 
-func (c *ChatCompletionsRequest) validate(toolsValidator *toolsValidator) *api.Error {
-	for _, tool := range c.Tools {
-		toolJson, err := json.Marshal(tool.Function)
-		if err != nil {
-			serverErr := api.NewError("Failed to marshal request tools: "+err.Error(),
-				fasthttp.StatusBadRequest, nil)
-			return &serverErr
-		}
-		err = toolsValidator.validateTool(toolJson)
-		if err != nil {
-			serverErr := api.NewError("Tool validation failed: "+err.Error(),
-				fasthttp.StatusBadRequest, nil)
-			return &serverErr
+// validate runs schema checks on the incoming tools array and then delegates
+// to validateRequest for the rest. When skipToolValidation is true, the tools
+// loop is bypassed entirely — matches real vLLM, which does not meta-validate
+// the input tool spec against a JSON Schema (see --skip-tool-validation).
+func (c *ChatCompletionsRequest) validate(toolsValidator *toolsValidator, skipToolValidation bool) *api.Error {
+	if !skipToolValidation {
+		for _, tool := range c.Tools {
+			toolJson, err := json.Marshal(tool.Function)
+			if err != nil {
+				serverErr := api.NewError("Failed to marshal request tools: "+err.Error(),
+					fasthttp.StatusBadRequest, nil)
+				return &serverErr
+			}
+			err = toolsValidator.validateTool(toolJson)
+			if err != nil {
+				serverErr := api.NewError("Tool validation failed: "+err.Error(),
+					fasthttp.StatusBadRequest, nil)
+				return &serverErr
+			}
 		}
 	}
 
@@ -164,10 +170,28 @@ func (c *chatCompletionReqCtx) encode() ([]uint32, []string, *api.RenderMMFeatur
 
 func (c *chatCompletionReqCtx) createToolCalls() ([]api.ToolCall, int, string, error) {
 	req := c.request()
-	if !isToolChoiceNone(req.GetToolChoice()) &&
-		req.GetTools() != nil {
+
+	// Deployment-level tool_choice override — lets an operator force "none"
+	// (text-only) or "required" (always call) via metadata without touching
+	// the client. Applied BEFORE the request's tool_choice is consulted.
+	// See Config.ToolChoiceOverride for accepted values.
+	toolChoice := req.GetToolChoice()
+	switch c.sim.Config().ToolChoiceOverride {
+	case "none":
+		// Never call tools. Skip generation regardless of what the client sent.
+		return nil, 0, "", nil
+	case "auto", "required":
+		// Reconstruct toolChoice by unmarshaling the string form — reuses
+		// ToolChoice.UnmarshalJSON so we don't touch its internals here.
+		var forced api.ToolChoice
+		if err := json.Unmarshal([]byte("\""+c.sim.Config().ToolChoiceOverride+"\""), &forced); err == nil {
+			toolChoice = forced
+		}
+	}
+
+	if !isToolChoiceNone(toolChoice) && req.GetTools() != nil {
 		toolCalls, completionTokens, err :=
-			createToolCalls(req.GetTools(), req.GetToolChoice(), c.sim.Config(), c.sim.Random, c.sim.Tokenizer, c.toolIDPrefix)
+			createToolCalls(req.GetTools(), toolChoice, c.sim.Config(), c.sim.Random, c.sim.Tokenizer, c.toolIDPrefix)
 		finishReason := common.ToolsFinishReason
 		return toolCalls, completionTokens, finishReason, err
 	}

--- a/pkg/llm-d-inference-sim/context.go
+++ b/pkg/llm-d-inference-sim/context.go
@@ -213,6 +213,9 @@ func (s *SimContext) initDataset(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to initialize random dataset: %w", err)
 		}
+		// Post-init: hard cap on effective completion tokens (see
+		// Config.MaxCompletionTokensCap). 0 keeps legacy request-driven size.
+		randDataset.MaxCompletionTokensCap = s.Config().MaxCompletionTokensCap
 		s.logger.V(logging.INFO).Info("No dataset path or URL provided, using random text for responses")
 		s.dataset = randDataset
 		return nil
@@ -224,6 +227,8 @@ func (s *SimContext) initDataset(ctx context.Context) error {
 		s.Config().DatasetInMemory, s.Config().MaxModelLen, s.Tokenizer)
 
 	if err == nil {
+		// Same cap semantics — CustomDataset embeds DefaultDataset.
+		custDataset.MaxCompletionTokensCap = s.Config().MaxCompletionTokensCap
 		s.dataset = custDataset
 		return nil
 	}

--- a/pkg/llm-d-inference-sim/generate.go
+++ b/pkg/llm-d-inference-sim/generate.go
@@ -42,7 +42,7 @@ func (g *GenerateRequest) Unmarshal(data []byte) error {
 	return nil
 }
 
-func (g *GenerateRequest) validate(toolsValidator *toolsValidator) *api.Error {
+func (g *GenerateRequest) validate(toolsValidator *toolsValidator, skipToolValidation bool) *api.Error {
 	if g.TokenIDs == nil {
 		err := api.NewError("Missing input token_ids", fasthttp.StatusBadRequest, nil)
 		return &err

--- a/pkg/llm-d-inference-sim/generation.go
+++ b/pkg/llm-d-inference-sim/generation.go
@@ -30,7 +30,7 @@ func (g *GenerationRequest) Unmarshal(data []byte) error {
 	return nil
 }
 
-func (g *GenerationRequest) validate(toolsValidator *toolsValidator) *api.Error {
+func (g *GenerationRequest) validate(toolsValidator *toolsValidator, skipToolValidation bool) *api.Error {
 	return validateRequest(g)
 }
 

--- a/pkg/llm-d-inference-sim/messages.go
+++ b/pkg/llm-d-inference-sim/messages.go
@@ -64,7 +64,7 @@ func (m *MessagesRequest) validateBlocks() *api.Error {
 	return nil
 }
 
-func (m *MessagesRequest) validate(tv *toolsValidator) *api.Error {
+func (m *MessagesRequest) validate(tv *toolsValidator, skipToolValidation bool) *api.Error {
 	if err := m.validateBlocks(); err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func (m *MessagesRequest) validate(tv *toolsValidator) *api.Error {
 		err := api.NewError("max_tokens is required", fasthttp.StatusBadRequest, nil)
 		return &err
 	}
-	return m.ChatCompletionsRequest.validate(tv)
+	return m.ChatCompletionsRequest.validate(tv, skipToolValidation)
 }
 
 func (m *MessagesRequest) AsString() string {

--- a/pkg/llm-d-inference-sim/request.go
+++ b/pkg/llm-d-inference-sim/request.go
@@ -29,7 +29,7 @@ import (
 
 type requestBuilder interface {
 	Unmarshal(data []byte) error
-	validate(toolsValidator *toolsValidator) *api.Error
+	validate(toolsValidator *toolsValidator, skipToolValidation bool) *api.Error
 	buildRequestContext(simCtx *SimContext, channel common.Channel[*ResponseInfo], choiceIdx int, doneFn func()) requestContext
 	AsString() string
 	createResponseContext(reqCtx requestContext, displayModel string, responseTokens *api.Tokenized,

--- a/pkg/llm-d-inference-sim/responses.go
+++ b/pkg/llm-d-inference-sim/responses.go
@@ -33,7 +33,7 @@ func (r *ResponsesRequest) Unmarshal(data []byte) error {
 	return json.Unmarshal(data, r)
 }
 
-func (r *ResponsesRequest) validate(toolsValidator *toolsValidator) *api.Error {
+func (r *ResponsesRequest) validate(toolsValidator *toolsValidator, skipToolValidation bool) *api.Error {
 	return validateRequest(r)
 }
 

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -352,7 +352,7 @@ func (s *VllmSimulator) HandleRequest(req Request) (numChoices int, isStream boo
 	// in this case the first alias is used, in all other cases the model from the request is used as the displayed model
 	req.SetDisplayedModel(s.Context.getDisplayedModelName(req.GetModel()))
 
-	if serverErr := req.validate(s.toolsValidator); serverErr != nil {
+	if serverErr := req.validate(s.toolsValidator, s.Context.Config().SkipToolValidation); serverErr != nil {
 		return 0, false, nil, serverErr, false
 	}
 

--- a/pkg/llm-d-inference-sim/text_completion.go
+++ b/pkg/llm-d-inference-sim/text_completion.go
@@ -83,7 +83,7 @@ func (t *TextCompletionsParsedRequest) Render(tk tokenizer.Tokenizer) ([][]uint3
 	return result, nil, nil
 }
 
-func (t *TextCompletionsParsedRequest) validate(_ *toolsValidator) *api.Error {
+func (t *TextCompletionsParsedRequest) validate(_ *toolsValidator, _ bool) *api.Error {
 	if err := t.ValidateBody(); err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func (t *TextCompletionsRequest) Unmarshal(data []byte) error {
 	return json.Unmarshal(data, t)
 }
 
-func (t *TextCompletionsRequest) validate(_ *toolsValidator) *api.Error {
+func (t *TextCompletionsRequest) validate(_ *toolsValidator, _ bool) *api.Error {
 	return validateRequest(t)
 }
 

--- a/pkg/llm-d-inference-sim/tools_utils.go
+++ b/pkg/llm-d-inference-sim/tools_utils.go
@@ -241,9 +241,50 @@ func getRequiredAsMap(property map[string]any) map[string]struct{} {
 	return required
 }
 
+// resolvePrimitiveType normalizes a JSON Schema "type" field to the concrete
+// primitive the arg generator can produce a value for. JSON Schema allows
+// "type" to be a string, an array of type strings (the draft-04+ nullable
+// pattern, e.g. ["null","object"]), or absent. Real vLLM tolerates all of
+// these because it forwards the schema to the model instead of synthesizing
+// arguments; the sim must reduce them to a single concrete type.
+//
+//   - string  → returned as-is
+//   - []any   → the first non-"null" entry wins so the mock returns a useful
+//               value for nullable fields; falls back to "null" only when
+//               every entry is "null" (a truly nullable-only field)
+//   - nil     → "string", the broadest safe default when a caller omits the
+//               type field entirely (the actual model would negotiate this
+//               with the tool at call time)
+//   - other   → "", which lets the caller error explicitly instead of panicking
+func resolvePrimitiveType(t any) string {
+	switch v := t.(type) {
+	case string:
+		return v
+	case []any:
+		fallback := ""
+		for _, entry := range v {
+			s, ok := entry.(string)
+			if !ok {
+				continue
+			}
+			if s != "null" && s != "" {
+				return s
+			}
+			if s == "null" {
+				fallback = "null"
+			}
+		}
+		return fallback
+	case nil:
+		return "string"
+	default:
+		return ""
+	}
+}
+
 func createArgument(property any, config *common.Configuration, random *common.Random) (any, error) {
 	propertyMap, _ := property.(map[string]any)
-	paramType := propertyMap["type"]
+	rawType := propertyMap["type"]
 
 	// If there is an enum, choose from it
 	enum, ok := propertyMap["enum"]
@@ -255,6 +296,8 @@ func createArgument(property any, config *common.Configuration, random *common.R
 		}
 	}
 
+	paramType := resolvePrimitiveType(rawType)
+
 	switch paramType {
 	case "string":
 		return getStringArgument(random), nil
@@ -264,9 +307,19 @@ func createArgument(property any, config *common.Configuration, random *common.R
 		return random.RandomFloat(config.MinToolCallNumberParam, config.MaxToolCallNumberParam), nil
 	case "boolean":
 		return random.FlipCoin(), nil
+	case "null":
+		// A schema whose type is (only) "null" is satisfied by the JSON null
+		// value; return the Go nil and let the JSON encoder emit `null`.
+		return nil, nil
 	case "array":
-		items := propertyMap["items"]
-		itemsMap := items.(map[string]any)
+		// items is optional in JSON Schema — an array with no declared items
+		// accepts anything, so returning an empty array is the honest sample.
+		// Guard the type assertion so a nil or non-map items field doesn't
+		// panic (Claude routinely sends arrays with items omitted).
+		itemsMap, ok := propertyMap["items"].(map[string]any)
+		if !ok {
+			return []any{}, nil
+		}
 		minItems := config.MinToolCallArrayParamLength
 		maxItems := config.MaxToolCallArrayParamLength
 		if value, ok := propertyMap["minItems"]; ok {
@@ -290,7 +343,14 @@ func createArgument(property any, config *common.Configuration, random *common.R
 		return array, nil
 	case "object":
 		required := getRequiredAsMap(propertyMap)
-		objectProperties := propertyMap["properties"].(map[string]any)
+		// properties is optional in JSON Schema (open objects,
+		// additionalProperties-only, or fully-permissive schemas). Guard the
+		// type assertion so a nil properties field returns an empty object
+		// instead of panicking.
+		objectProperties, ok := propertyMap["properties"].(map[string]any)
+		if !ok {
+			return map[string]interface{}{}, nil
+		}
 		object := make(map[string]interface{})
 		for fieldName, fieldProperties := range objectProperties {
 			_, fieldIsRequired := required[fieldName]


### PR DESCRIPTION
Closes #607.

## What this PR does

Five focused fixes to make the sim serviceable behind a real OpenAI/Anthropic client (Claude Code, LiteLLM, LangChain, custom agents) without giving up on realistic behavior. Each commit is self-contained; feel free to squash if that fits your history preferences.

## The five fixes (one per commit)

### 1. `--skip-tool-validation` &nbsp;·&nbsp; commit `3d4d862`

The sim runs every incoming tool through a strict inline JSON Schema at [`pkg/llm-d-inference-sim/tools_utils.go:316-408`](https://github.com/llm-d/llm-d-inference-sim/blob/v0.9.0/pkg/llm-d-inference-sim/tools_utils.go#L316-L408) with `additionalProperties: false` — only `type`/`description`/`enum`/`properties`/`items`/`required`/`additionalProperties`/`minItems`/`maxItems` are allowed. Any tool schema containing valid JSON Schema draft-07 fields (`default`, `format`, `title`, `pattern`, `minLength`, `oneOf`, `$ref`, `examples`, …) is rejected 400.

Real vLLM does not meta-validate incoming tool schemas — it forwards them to the model. This flag lets deployments match that behavior; the loop is skipped when the flag is set. Default `false` = zero behavior change.

### 2. Argument-generator normalizes JSON Schema `type` &nbsp;·&nbsp; commit `08c7c43`

Even with `--skip-tool-validation`, the synthetic arg generator's switch on `propertyMap["type"]` only handled a single concrete string type and errored on:
- **`nil`** — property with no `type` field
- **`["null", "object"]`** — the draft-04+ nullable pattern
- **`["null", "array"]`** — same for arrays

New `resolvePrimitiveType()` unwraps arrays to the first non-`"null"` entry, defaults missing type to `"string"`, and treats plain `"null"` as JSON null. Real vLLM tolerates these because it forwards to the model; the sim must reduce them to a concrete type before synthesizing arguments.

### 3. Nil-safe `items` / `properties` in `createArgument` &nbsp;·&nbsp; commit `7fe81a4` (part 1)

The recursive generator did unchecked type assertions:
```go
itemsMap := propertyMap["items"].(map[string]any)              // PANIC if items nil
objectProperties := propertyMap["properties"].(map[string]any) // PANIC if properties nil
```

Both shapes turn up in real tool schemas (e.g. Claude Code's `WebFetch` declares `{"type": "object"}` with no `properties`). Comma-ok assertions now return an empty `{}` / `[]` — matching how real vLLM tolerates under-specified schemas.

### 4. `--tool-choice-override=[none|auto|required]` &nbsp;·&nbsp; commit `7fe81a4` (part 2)

The sim has no model, so its "should I call a tool?" decision in `auto` mode is effectively a dice roll driven by `RandomInt(0, len(tools))`. With a client attaching a full tool suite (~30+ tools), the dice roll almost always picks a tool call — the sim fabricates tool invocations for plain conversational queries.

Real vLLM doesn't have this issue because a real model uses intent understanding. This adds a deployment-level override that ignores the request's `tool_choice`:
- `""` (default) — honor the client's `tool_choice`; behavior unchanged
- `"none"` — never generate tool calls; always return text
- `"auto"` — behave as if the client sent `auto` (the sim decides)
- `"required"` — always generate at least one tool call

### 5. `--max-completion-tokens-cap` &nbsp;·&nbsp; commit `8d245c9`

`DefaultDataset.calculateResponseMaxLen` uses the request's `max_tokens` verbatim, or `max-model-len - prompt_length` when `max_tokens` is unset. With a client that sends huge `max_tokens` (Anthropic's Messages API always sets it), the sim produces very long responses (many hundreds of concatenated random sentences) that read as "infinite."

This adds a hard ceiling: `MaxCompletionTokensCap > 0` clamps the effective max regardless of the request. `CustomDataset` inherits the cap via embedding.

## Bonus: `--log-http` decompresses gzip bodies &nbsp;·&nbsp; commit `1562b96`

`fasthttp` auto-gzips response bodies when the client sends `Accept-Encoding: gzip` (every Prometheus scraper does). The `--log-http` path was writing the raw compressed bytes to the log — operators saw garbled binary in `kubectl logs` instead of the JSON they needed for debugging tool payloads. New `decompressForLog()` transparently gunzips and truncates for the log, symmetric on request and response; raw wire bytes are unchanged.

## Verification

**Unit-level, local build:**
- `go build ./...` clean.
- Manual smoke test with `--tool-choice-override=none` + `tool_choice: "required"` from client + tools declared → response has `finish_reason: "stop"`, `tool_calls: null`, plain text content.
- `--max-completion-tokens-cap=20` + request `max_tokens: 1000` → response has `completion_tokens <= 20`.
- Manual smoke test for each of the three panic modes in fix #3 (object without `properties`, array without `items`, property with missing `type`) — container stays up, all requests return HTTP 200.

**End-to-end, real cluster:**
Deployed a locally-built image (linux/amd64) of the v0.9.0 codebase + these commits onto a k8s cluster fronted by an Anthropic-compatible gateway serving Claude Code traffic. With `--skip-tool-validation --tool-choice-override none --max-completion-tokens-cap 50 --max-model-len 131072` set via metadata, all previously-observed failure modes disappear:
- No more `Tool validation failed: jsonschema: … additionalProperties not allowed`
- No more `tool parameters of type <nil>|[null object]|[null array] are not supported`
- No more `interface conversion: interface {} is nil, not map[string]interface {}` panics
- Every response is text; no fabricated tool calls
- Response length bounded; no "infinite response" complaints

## Commits (in order)

| Commit | Title |
|---|---|
| `3d4d862` | `feat: add --skip-tool-validation to bypass the built-in tool schema validator` |
| `08c7c43` | `feat: normalize JSON Schema type in the arg generator (nullable + missing)` |
| `7fe81a4` | `feat: add --tool-choice-override + defensively handle empty properties/items in arg generator` |
| `1562b96` | `feat: decompress gzipped request/response bodies before logging (--log-http)` |
| `8d245c9` | `feat: add --max-completion-tokens-cap to prevent unbounded random-mode responses` |

## Environment / motivation

Deployed sim standing in for `gemma-4` in an airgapped edge k8s box, gateway translating Anthropic → OpenAI on `/v1/messages` → engine on `/v1/chat/completions`. Client: Claude Code (real tool suite). Before these fixes, the sim's first request from Claude Code returned 400 (tool validation), fixing that surfaced tool-generator errors, fixing those surfaced panics, and fixing those surfaced runaway generation. This PR is the composed end state where every one of those failure modes is addressed at its root and each fix is independently useful.

Happy to squash / rebase / split further based on your preferences.
