### PR TITLE
fix: allow common JSON schema keywords in tool parameter definitions

### DIFF
--- a/pkg/llm-d-inference-sim/tools_schema_verify_test.go
+++ b/pkg/llm-d-inference-sim/tools_schema_verify_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmdinferencesim
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("tools schema validator", func() {
+	DescribeTable("accepts common JSON schema keywords on parameters",
+		func(toolJSON string) {
+			v, err := createToolsValidator()
+			Expect(err).NotTo(HaveOccurred())
+
+			var value any
+			Expect(json.Unmarshal([]byte(toolJSON), &value)).To(Succeed())
+			Expect(v.validateTool([]byte(toolJSON))).To(Succeed())
+		},
+		Entry(nil, `{
+			"name": "get_weather",
+			"description": "Get the weather",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"location": {"type": "string"},
+					"unit": {"type": "string", "enum": ["C", "F"], "default": "C"}
+				},
+				"required": ["location"]
+			}
+		}`),
+		Entry(nil, `{
+			"name": "get_weather",
+			"description": "Get the weather",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"unit": {"type": "string", "default": "C",
+						"minLength": 1, "maxLength": 3, "pattern": "^[CF]$",
+						"format": "temperature", "title": "Unit"}
+				},
+				"required": ["unit"]
+			}
+		}`),
+		Entry(nil, `{
+			"name": "get_count",
+			"description": "Get a count",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"count": {"type": "integer", "minimum": 0, "maximum": 100,
+						"exclusiveMinimum": 0, "exclusiveMaximum": 100, "default": 5}
+				},
+				"required": ["count"]
+			}
+		}`),
+	)
+})

--- a/pkg/llm-d-inference-sim/tools_utils.go
+++ b/pkg/llm-d-inference-sim/tools_utils.go
@@ -431,6 +431,44 @@ const schema = `{
         "maxItems": {
           "type": "integer",
           "minimum": 0
+        },
+        "default": {
+          "description": "A default value for the parameter"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "exclusiveMinimum": {
+          "type": [
+            "number",
+            "boolean"
+          ]
+        },
+        "exclusiveMaximum": {
+          "type": [
+            "number",
+            "boolean"
+          ]
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
         }
       },
       "required": [

--- a/pkg/tests/tools_test.go
+++ b/pkg/tests/tools_test.go
@@ -596,7 +596,7 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 	)
 
 	// A well-formed JSON Schema that the built-in validator rejects only because
-	// "title" is outside its whitelist. Real vLLM forwards such schemas verbatim.
+	// "$comment" is outside its whitelist. Real vLLM forwards such schemas verbatim.
 	unwhitelistedTool := []openai.ChatCompletionToolUnionParam{
 		{
 			OfFunction: &openai.ChatCompletionFunctionToolParam{
@@ -604,8 +604,8 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 					Name:        functionNameGetWeather,
 					Description: openai.String("Get weather at the given location"),
 					Parameters: openai.FunctionParameters{
-						"type":  "object",
-						"title": "Weather query",
+						"type":     "object",
+						"$comment": "Weather query",
 						"properties": map[string]interface{}{
 							"location": map[string]string{
 								"type": "string",


### PR DESCRIPTION
## What does this PR do?

Adds commonly-used JSON Schema keywords (`default`, `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `minLength`, `maxLength`, `pattern`, `format`, `title`) to the allow-list of the `param_definition` schema used by the tools validator. Previously only `type`, `description`, `enum`, `properties`, `items`, `required`, `additionalProperties`, `minItems`, and `maxItems` were permitted.

## Why is this change needed?

The tools validator rejected otherwise-valid tool definitions that used standard JSON Schema keywords, producing errors like:

```
E0804 20:32:23.690472       1 http.go:578] "Tool validation failed: jsonschema: '/parameters/properties/unit' does not validate with file:///schema.json#/properties/parameters/$ref/properties/properties/additionalProperties/$ref/additionalProperties: additionalProperties 'default' not allowed"
```

This caused the simulator to return HTTP 400 for tool definitions that real-world clients (and the OpenAI API) accept. Existing structural validation (type enum, enum/type consistency via `allOf`, `required`, `items`/`properties` requirements) is unchanged, so genuinely invalid tools are still rejected.

## How was this tested?

- [x] Unit tests added/updated — new Ginkgo spec `tools schema validator` in `pkg/llm-d-inference-sim/tools_schema_verify_test.go` covers `default` and the other newly-allowed keywords (3 specs pass).
- [x] Manual testing performed — built the image and confirmed a request with a tool containing the `default` keyword on a parameter is accepted (previously failed with the error above).
- Existing `check validator` integration test still rejects all pre-existing invalid tools (enum type mismatch, bad type value, missing `parameters`).
- `go build ./...`, `go vet`, and `gofmt` pass.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable) — no user-facing docs need changes; this restores acceptance of standard JSON Schema keywords.

## Related Issues

None reported.