### PR TITLE
feat: configurable truncated-geometric tool-call count distribution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,7 @@ For a detailed explanation of how the simulator models inference time and what e
 - `tool-call-not-required-param-probability`: the probability to add a parameter, that is not required, in a tool call, optional, defaults to 50
 - `object-tool-call-not-required-field-probability`: the probability to add a field, that is not required, in an object in a tool call, optional, defaults to 50
 - `skip-tool-validation`: skip the built-in validation of incoming tool schemas, optional, defaults to `false`. The simulator validates every tool's `function.parameters` against a strict schema that whitelists a small subset of JSON Schema fields. Real vLLM does not meta-validate tool schemas, so a schema using fields outside that whitelist is rejected with a 400 by the simulator but accepted upstream. Enable this to match vLLM's behavior. Note that tool call generation still synthesizes arguments from the schema, so unsupported parameter types fail at generation time rather than at validation time
+- `tool-call-extra-call-probability`: the probability (0-100) to make one additional tool call beyond the minimum. The roll repeats until a roll fails or all available tools are called, so the number of calls follows a truncated geometric distribution that almost always equals the minimum but can reach the total number of available tools. `0` always produces the minimum number of calls (1 for `tool_choice: "required"`, 0 for `"auto"`); `100` always calls every available tool. Optional, defaults to 45.
 
 
 ## KV cache

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -209,6 +209,12 @@ type Configuration struct {
 	// Real vLLM forwards tool schemas to the model verbatim, so schemas using fields outside
 	// the simulator's whitelist are rejected here but accepted upstream. Optional, defaults to false.
 	SkipToolValidation bool `yaml:"skip-tool-validation" json:"skip-tool-validation"`
+	// ToolCallExtraCallProbability is the probability (0-100) to make one additional tool call beyond the
+	// minimum. Rolls repeat until a roll fails or len(availableTools) is reached, so the number of calls
+	// follows a truncated geometric distribution that almost always equals the minimum but can reach
+	// the total number of available tools. A value of 0 always produces the minimum number of calls;
+	// a value of 100 always produces len(availableTools) calls. Optional, defaults to 45.
+	ToolCallExtraCallProbability int `yaml:"tool-call-extra-call-probability" json:"tool-call-extra-call-probability"`
 
 	// EnableKVCache defines if kv cache feature will be enabled
 	EnableKVCache bool `yaml:"enable-kvcache" json:"enable-kvcache"`
@@ -375,20 +381,21 @@ func newConfig() *Configuration {
 		MinToolCallArrayParamLength:         1,
 		ToolCallNotRequiredParamProbability: 50,
 		ObjectToolCallNotRequiredParamProbability: 50,
-		KVCacheSize:                1024,
-		TokenBlockSize:             16,
-		ZMQEndpoint:                "tcp://127.0.0.1:5557",
-		KVEventsReplayQueueSize:    1024,
-		EventBatchSize:             16,
-		DPSize:                     1,
-		Rank:                       -1,
-		DatasetTableName:           DefaultDSTableName,
-		DefaultEmbeddingDimensions: 384,
-		FakeMetricsRefreshInterval: 100 * time.Millisecond,
-		MaxRequestBodySizeMB:       4,
-		RenderURL:                  "http://localhost:8082",
-		RenderTimeout:              30 * time.Second,
-		MMRenderTimeout:            60 * time.Second,
+		ToolCallExtraCallProbability:              45,
+		KVCacheSize:                               1024,
+		TokenBlockSize:                            16,
+		ZMQEndpoint:                               "tcp://127.0.0.1:5557",
+		KVEventsReplayQueueSize:                   1024,
+		EventBatchSize:                            16,
+		DPSize:                                    1,
+		Rank:                                      -1,
+		DatasetTableName:                          DefaultDSTableName,
+		DefaultEmbeddingDimensions:                384,
+		FakeMetricsRefreshInterval:                100 * time.Millisecond,
+		MaxRequestBodySizeMB:                      4,
+		RenderURL:                                 "http://localhost:8082",
+		RenderTimeout:                             30 * time.Second,
+		MMRenderTimeout:                           60 * time.Second,
 	}
 }
 
@@ -549,6 +556,9 @@ func (c *Configuration) validate() error {
 	}
 	if c.ObjectToolCallNotRequiredParamProbability < 0 || c.ObjectToolCallNotRequiredParamProbability > 100 {
 		return errors.New("ObjectToolCallNotRequiredParamProbability should be between 0 and 100")
+	}
+	if c.ToolCallExtraCallProbability < 0 || c.ToolCallExtraCallProbability > 100 {
+		return errors.New("ToolCallExtraCallProbability should be between 0 and 100")
 	}
 
 	if c.TokenBlockSize != 8 && c.TokenBlockSize != 16 && c.TokenBlockSize != 32 &&

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -486,6 +486,12 @@ var _ = Describe("Simulator configuration", func() {
 			expectedError: "ObjectToolCallNotRequiredParamProbability should be between 0 and 100",
 		},
 		{
+			name: "invalid tool-call-extra-call-probability",
+			args: []string{"cmd", "--tool-call-extra-call-probability", "-1",
+				"--config", "../../manifests/config.yaml"},
+			expectedError: "ToolCallExtraCallProbability should be between 0 and 100",
+		},
+		{
 			name: "invalid time-to-first-token-std-dev",
 			args: []string{"cmd", "--time-to-first-token-std-dev", "3000ms",
 				"--config", "../../manifests/config.yaml"},

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -147,6 +147,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.IntVar(&config.MinToolCallArrayParamLength, "min-tool-call-array-param-length", config.MinToolCallArrayParamLength, "Minimum possible length of array parameters in a tool call")
 	f.IntVar(&config.ToolCallNotRequiredParamProbability, "tool-call-not-required-param-probability", config.ToolCallNotRequiredParamProbability, "Probability to add a parameter, that is not required, in a tool call")
 	f.IntVar(&config.ObjectToolCallNotRequiredParamProbability, "object-tool-call-not-required-field-probability", config.ObjectToolCallNotRequiredParamProbability, "Probability to add a field, that is not required, in an object in a tool call")
+	f.IntVar(&config.ToolCallExtraCallProbability, "tool-call-extra-call-probability", config.ToolCallExtraCallProbability, "Probability (0-100) to make one additional tool call beyond the minimum; rolls repeat until a roll fails or all tools are called")
 
 	f.BoolVar(&config.EnableKVCache, "enable-kvcache", config.EnableKVCache, "Defines if KV cache feature is enabled")
 	f.IntVar(&config.KVCacheSize, "kv-cache-size", config.KVCacheSize, "Maximum number of token blocks in kv cache")

--- a/pkg/llm-d-inference-sim/tools_callcount_test.go
+++ b/pkg/llm-d-inference-sim/tools_callcount_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2025 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmdinferencesim
+
+import (
+	"encoding/json"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/api"
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	"github.com/llm-d/llm-d-inference-sim/pkg/tokenizer"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// makeTools builds n tools by unmarshalling minimal JSON definitions, the same
+// path production code uses. Each tool has one required string parameter so
+// generateToolArguments can produce values for the chosen calls.
+func makeTools(n int) []api.Tool {
+	tools := make([]api.Tool, n)
+	for i := range n {
+		name := "tool_" + string(rune('a'+i))
+		toolJSON := `{
+			"type": "function",
+			"function": {
+				"name": "` + name + `",
+				"description": "test tool",
+				"parameters": {
+					"type": "object",
+					"properties": {
+						"location": {"type": "string"}
+					},
+					"required": ["location"]
+				}
+			}
+		}`
+		Expect(json.Unmarshal([]byte(toolJSON), &tools[i])).To(Succeed())
+	}
+	return tools
+}
+
+var _ = Describe("createToolCalls call-count distribution", func() {
+	var (
+		tk         tokenizer.Tokenizer
+		idPrefix   = "call_"
+		numTools   = 5
+		requiredTC = api.NewToolChoiceRequired()
+	)
+
+	BeforeEach(func() {
+		tk = tokenizer.NewSimpleTokenizer()
+	})
+
+	DescribeTable("number of calls follows the ToolCallExtraCallProbability",
+		func(probability, expectedCalls int) {
+			config := &common.Configuration{
+				Model:                        "test",
+				ServedModelNames:             []string{"test"},
+				ToolCallExtraCallProbability: probability,
+			}
+
+			// A single Random is reused across trials so its RNG state advances,
+			// mirroring how production shares one Random across requests. With p
+			// fixed at an edge the count is constant regardless of the rolls.
+			random := common.NewRandom(0, 0)
+			for range 200 {
+				calls, _, err := createToolCalls(
+					makeTools(numTools), requiredTC, config, random, tk, idPrefix)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(calls).To(HaveLen(expectedCalls))
+			}
+		},
+		// p=0 with tool_choice="required" (minCalls=1): never adds extra calls.
+		Entry("probability 0 always produces minCalls", 0, 1),
+		// p=100 always rolls "yes": loops until reaching len(availableTools).
+		Entry("probability 100 always produces maxCalls", 100, numTools),
+	)
+
+	It("with default probability 45, mostly produces minCalls but can reach maxCalls", func() {
+		config := &common.Configuration{
+			Model:                        "test",
+			ServedModelNames:             []string{"test"},
+			ToolCallExtraCallProbability: 45,
+		}
+
+		const trials = 5000
+		counts := make(map[int]int)
+		random := common.NewRandom(0, 0)
+		for range trials {
+			calls, _, err := createToolCalls(
+				makeTools(numTools), requiredTC, config, random, tk, idPrefix)
+			Expect(err).NotTo(HaveOccurred())
+			counts[len(calls)]++
+		}
+
+		// minCalls (1) should be the dominant outcome: P(1) = 1 - 0.45 = 55%.
+		Expect(counts[1]).To(BeNumerically(">", trials*45/100))
+		// The max (5) should be reachable: (0.45)^4 ~= 4.1% of trials.
+		Expect(counts[numTools]).To(BeNumerically(">", 0))
+		// And every count in between should be possible.
+		for i := 2; i < numTools; i++ {
+			Expect(counts[i]).To(BeNumerically(">", 0))
+		}
+	})
+
+	It("with tool_choice auto (minCalls=0), p=0 produces no tool calls", func() {
+		autoTC := api.ToolChoice{}
+		config := &common.Configuration{
+			Model:                        "test",
+			ServedModelNames:             []string{"test"},
+			ToolCallExtraCallProbability: 0,
+		}
+
+		random := common.NewRandom(0, 0)
+		for range 50 {
+			calls, _, err := createToolCalls(
+				makeTools(numTools), autoTC, config, random, tk, idPrefix)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(calls).To(BeEmpty())
+		}
+	})
+})

--- a/pkg/llm-d-inference-sim/tools_utils.go
+++ b/pkg/llm-d-inference-sim/tools_utils.go
@@ -134,9 +134,13 @@ func createToolCalls(
 		}
 
 		numberOfCalls := minCalls
-		if len(availableTools) > minCalls {
-			// Randomly decide how many tools to call, between minCalls and the total available.
-			numberOfCalls = random.RandomInt(minCalls, len(availableTools))
+		maxCalls := len(availableTools)
+		// Truncated geometric: start at minCalls and add one extra call with
+		// probability ToolCallExtraCallProbability, repeating until a roll
+		// fails or we reach maxCalls. The minimum is always possible and the
+		// maximum is always reachable, but higher counts are increasingly rare.
+		for numberOfCalls < maxCalls && random.RandomBool(config.ToolCallExtraCallProbability) {
+			numberOfCalls++
 		}
 
 		if numberOfCalls == 0 {


### PR DESCRIPTION
## What does this PR do?

Replaces the uniform random tool-call count selection with a **truncated geometric** distribution, controlled by a new `--tool-call-extra-call-probability` config flag (default 45, range 0–100).

Previously, the number of tool calls was chosen uniformly between `minCalls` and `len(availableTools)`, so with N tools each request had an equal `1/(N+1)` chance of any count — including calling all tools. This did not match real-world model behavior, where the minimum is the most likely outcome and higher counts are increasingly rare.

The new algorithm starts at `minCalls` and adds one extra call with probability `p`, repeating until a roll fails or all available tools are called:
- `P(minCalls) = 1 - p/100`
- `P(minCalls+k) = (p/100)^k * (1 - p/100)`
- The minimum is always reachable; the maximum is always possible but rare.

## Why is this change needed?

The uniform distribution made the simulator call all available tools far more often than a real model would. With 2 tools and `tool_choice: "required"`, each request had a 50% chance of producing 2 calls. Real-world models almost always call the minimum number of tools, with additional calls becoming increasingly unlikely. This change makes the simulator's tool-calling behavior more realistic while remaining fully configurable.

A value of `0` always produces the minimum (1 for `tool_choice: "required"`, 0 for `"auto"`); `100` always calls every available tool. The default of 45 gives `P(minCalls) = 55%`.

## How was this tested?

- [x] Unit tests added/updated — new Ginkgo specs in `pkg/llm-d-inference-sim/tools_callcount_test.go` cover edge cases (`p=0` → minCalls, `p=100` → maxCalls) and the default distribution (`p=45`: mostly minCalls, all intermediate counts reachable, maxCalls reachable). Also covers `tool_choice: auto` with `minCalls=0`.
- [x] Manual testing performed — built the image and confirmed tool-call counts follow the new distribution with the `--tool-call-extra-call-probability` flag.
- New config validation test in `pkg/common/config_test.go` for out-of-range values.
- `go build ./...`, `go vet`, and `gofmt` pass; `pkg/llm-d-inference-sim` (78 specs) and `pkg/common` test suites pass.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable) — added `tool-call-extra-call-probability` to `docs/configuration.md`

## Related Issues

None reported.