### PR TITLE
feat: add --zmq-bind flag so the ZMQ publisher can bind

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,8 @@ For a detailed explanation of how the simulator models inference time and what e
 - `global-cache-hit-threshold`: default cache hit threshold [0, 1] for all requests. If a request specifies cache_hit_threshold, it takes precedence over this global value
 - `block-size`: token block size for contiguous chunks of tokens, possible values: 8,16,32,64,128
 - `hash-seed`: seed for hash generation. If you omit `--hash-seed` on the command line, a non-empty `PYTHONHASHSEED` environment variable can supply the seed; see [Configuration precedence](#configuration-precedence) and [Environment variables](#environment-variables).
-- `zmq-endpoint`: ZMQ address to publish events
+- `zmq-endpoint`: ZMQ address to publish events; the simulator dials this address by default, or binds/listens when `zmq-bind` is true
+- `zmq-bind`: if true, the simulator binds (listens on) the ZMQ endpoint instead of dialing out. Use in `discoverPods` mode where the EPP connects to each simulator (e.g. `--zmq-endpoint=tcp://*:5557 --zmq-bind`). Default is false.
 - `event-batch-size`: the maximum number of kv-cache events to be sent together, defaults to 16
 - `use-vllm-map-event-format`: when `true`, encodes KV cache events as msgpack maps with named fields, matching the format introduced in vLLM PR #42892. When `false` (the default), events are encoded as positional msgpack arrays (legacy format). Use `true` when the event consumer is the llm-d `VLLMAdapter` parsing the new named-field schema.
 - `kv-events-replay-endpoint`: ZMQ ROUTER address to bind for receiving KV events replay requests. Empty (default) disables the replay listener. Example: `tcp://*:5558`. A client that stops draining its socket without closing the connection stalls replay for every other connected client too, not just its own — see [KV events replay](kv-cache.md#kv-events-replay).

--- a/docs/kv-cache.md
+++ b/docs/kv-cache.md
@@ -33,7 +33,8 @@ All KV cache parameters can be set via CLI flags or the equivalent YAML keys (na
 | `kv-cache-size` | int | `1024` | Maximum number of token blocks the cache can hold |
 | `block-size` | int | `16` | Tokens per block; valid values: `8`, `16`, `32`, `64`, `128` |
 | `hash-seed` | string | value of `PYTHONHASHSEED` env var | Seed for block key hash generation; must match the seed used by real vLLM instances to ensure identical block hashes |
-| `zmq-endpoint` | string | `tcp://127.0.0.1:5557` | ZMQ address to publish events (the simulator dials this address) |
+| `zmq-endpoint` | string | `tcp://127.0.0.1:5557` | ZMQ address to publish events; the simulator dials this address by default, or binds/listens when `zmq-bind` is `true` |
+| `zmq-bind` | bool | `false` | If `true`, the publisher binds (listens on) the endpoint instead of dialing out. Use in `discoverPods` mode where the EPP connects to each simulator (e.g. `--zmq-endpoint=tcp://*:5557 --zmq-bind`) |
 | `event-batch-size` | int | `16` | Maximum number of events bundled into a single ZMQ message |
 | `use-vllm-map-event-format` | bool | `false` | Encode events as msgpack maps with named fields (vLLM PR #42892 format) instead of positional arrays. Set to `true` when the consumer expects the named-field schema. |
 | `kv-events-replay-endpoint` | string | `""` (disabled) | ZMQ ROUTER address to bind for KV events replay requests. See [KV events replay](#kv-events-replay). |

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -221,6 +221,10 @@ type Configuration struct {
 
 	// ZMQEndpoint is the ZMQ address to publish events, the default value is tcp://localhost:5557
 	ZMQEndpoint string `yaml:"zmq-endpoint" json:"zmq-endpoint"`
+	// ZMQBind controls whether the publisher binds (Listen) or connects (Dial).
+	// Set to true for discoverPods mode where the EPP connects to each simulator;
+	// leave false (default) when simulators dial out to the EPP's fixed ZMQ address.
+	ZMQBind bool `yaml:"zmq-bind" json:"zmq-bind"`
 
 	// KVEventsReplayEndpoint is the ZMQ ROUTER address to bind for receiving KV events replay requests.
 	// Empty (default) disables the replay listener. Example: "tcp://*:5558"

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -155,6 +155,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.StringVar(&config.HashSeed, "hash-seed", config.HashSeed,
 		"Seed for hash generation (if omitted on the command line, "+PythonHashSeedEnv+" may set it; see docs)")
 	f.StringVar(&config.ZMQEndpoint, "zmq-endpoint", config.ZMQEndpoint, "ZMQ address to publish events")
+	f.BoolVar(&config.ZMQBind, "zmq-bind", config.ZMQBind, "Bind (Listen) the ZMQ socket instead of dialing out; use with discoverPods mode where the EPP connects to each simulator (e.g. --zmq-endpoint=tcp://*:5557 --zmq-bind)")
 	f.StringVar(&config.KVEventsReplayEndpoint, "kv-events-replay-endpoint", config.KVEventsReplayEndpoint, "ZMQ ROUTER address to bind for receiving KV events replay requests (empty disables)")
 	f.IntVar(&config.KVEventsReplayQueueSize, "kv-events-replay-queue-size", config.KVEventsReplayQueueSize, "Max number of event batches held in the replay queue; oldest dropped when full")
 	f.IntVar(&config.EventBatchSize, "event-batch-size", config.EventBatchSize, "Maximum number of kv-cache events to be sent together")

--- a/pkg/common/publisher.go
+++ b/pkg/common/publisher.go
@@ -75,9 +75,13 @@ type Publisher struct {
 }
 
 // NewPublisher creates a new ZMQ publisher.
-// endpoint is the ZMQ address to bind to (e.g., "tcp://*:5557").
-// retries is the maximum number of connection attempts.
-func NewPublisher(ctx context.Context, endpoint string) (*Publisher, error) {
+//
+// When bind is false (default), the publisher dials out to endpoint — used when the EPP
+// binds a fixed ZMQ SUB socket and simulators connect to it.
+//
+// When bind is true, the publisher listens on endpoint (e.g. "tcp://*:5557") — used in
+// discoverPods mode where the EPP discovers pods and connects to each simulator's local socket.
+func NewPublisher(ctx context.Context, endpoint string, bind bool) (*Publisher, error) {
 	socket := zmq4.NewPub(ctx,
 		// -1 means try forever
 		zmq4.WithDialerMaxRetries(-1),
@@ -87,20 +91,24 @@ func NewPublisher(ctx context.Context, endpoint string) (*Publisher, error) {
 		zmq4.WithDialerRetry(time.Second),
 	)
 
-	// 2. Push Dial into a background goroutine
-	go func() {
-		// wait until the listener is ready
-		err := socket.Dial(endpoint)
-		if err != nil {
-			// Context cancellation during shutdown is expected — don't treat it as an error.
-			if ctx.Err() != nil {
-				return
-			}
-			log.FromContext(ctx).Error(err, "ZMQ dialer exited", "endpoint", endpoint)
-		} else {
-			log.FromContext(ctx).Info("ZMQ dialer connected", "endpoint", endpoint)
+	if bind {
+		if err := socket.Listen(endpoint); err != nil {
+			return nil, fmt.Errorf("ZMQ publisher failed to listen on %s: %w", endpoint, err)
 		}
-	}()
+		log.FromContext(ctx).Info("ZMQ publisher listening", "endpoint", endpoint)
+	} else {
+		go func() {
+			err := socket.Dial(endpoint)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				log.FromContext(ctx).Error(err, "ZMQ dialer exited", "endpoint", endpoint)
+			} else {
+				log.FromContext(ctx).Info("ZMQ dialer connected", "endpoint", endpoint)
+			}
+		}()
+	}
 
 	return &Publisher{
 		socket:   socket,

--- a/pkg/common/publisher_test.go
+++ b/pkg/common/publisher_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Publisher", func() {
 
 		time.Sleep(100 * time.Millisecond)
 
-		pub, err := NewPublisher(ctx, endpoint)
+		pub, err := NewPublisher(ctx, endpoint, false)
 		Expect(err).NotTo(HaveOccurred())
 
 		go func() {
@@ -77,6 +77,47 @@ var _ = Describe("Publisher", func() {
 		Expect(payload).To(Equal(data))
 	})
 
+	It("should bind and receive message when bind=true", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		freePort, err := FreeTCPPort()
+		Expect(err).NotTo(HaveOccurred())
+		endpoint := fmt.Sprintf("tcp://127.0.0.1:%d", freePort)
+
+		pub, err := NewPublisher(ctx, endpoint, true)
+		Expect(err).NotTo(HaveOccurred())
+		// nolint
+		defer pub.Close()
+
+		sub := zmq4.NewSub(ctx)
+		// nolint
+		defer sub.Close()
+		err = sub.Dial(endpoint)
+		Expect(err).NotTo(HaveOccurred())
+		err = sub.SetOption(zmq4.OptionSubscribe, topic)
+		Expect(err).NotTo(HaveOccurred())
+
+		time.Sleep(100 * time.Millisecond)
+
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			_, _, err := pub.PublishEvent(ctx, topic, data)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		msg, err := sub.Recv()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(msg.Frames).To(HaveLen(3))
+		Expect(string(msg.Frames[0])).To(Equal(topic))
+		seq := binary.BigEndian.Uint64(msg.Frames[1])
+		Expect(seq).To(Equal(uint64(1)))
+		var payload string
+		err = msgpack.Unmarshal(msg.Frames[2], &payload)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(payload).To(Equal(data))
+	})
+
 	It("should connect to zmq listener after delay", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -86,7 +127,7 @@ var _ = Describe("Publisher", func() {
 		endpoint := fmt.Sprintf("tcp://127.0.0.1:%d", freePort)
 
 		// create publisher - it will try to connect to the listener, but the listener is not started yet
-		pub, err := NewPublisher(ctx, endpoint)
+		pub, err := NewPublisher(ctx, endpoint, false)
 		Expect(err).NotTo(HaveOccurred())
 		// nolint
 		defer pub.Close()

--- a/pkg/kv-cache/block_cache.go
+++ b/pkg/kv-cache/block_cache.go
@@ -80,7 +80,7 @@ func newBlockCache(ctx context.Context, config *common.Configuration, logger log
 	var publisher *common.Publisher
 	var err error
 	if config.ZMQEndpoint != "" {
-		publisher, err = common.NewPublisher(ctx, config.ZMQEndpoint)
+		publisher, err = common.NewPublisher(ctx, config.ZMQEndpoint, config.ZMQBind)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION

## What does this PR do?

Adds a `--zmq-bind` flag that switches the ZMQ publisher from dial mode to bind (listen) mode.

## Why is this change needed?

In `discoverPods` deployment mode (precise prefix cache aware routing), the EPP connects to each simulator individually rather than all simulators dialing a shared EPP endpoint. The publisher must listen on a local address in this topology.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

None
