### PR TITLE
feat: add --skip-tool-validation to bypass tool schema meta-validation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,7 @@ For a detailed explanation of how the simulator models inference time and what e
 - `min-tool-call-array-param-length`: the minimum possible length of array parameters in a tool call, optional, defaults to 1
 - `tool-call-not-required-param-probability`: the probability to add a parameter, that is not required, in a tool call, optional, defaults to 50
 - `object-tool-call-not-required-field-probability`: the probability to add a field, that is not required, in an object in a tool call, optional, defaults to 50
+- `skip-tool-validation`: skip the built-in validation of incoming tool schemas, optional, defaults to `false`. The simulator validates every tool's `function.parameters` against a strict schema that whitelists a small subset of JSON Schema fields. Real vLLM does not meta-validate tool schemas, so a schema using fields outside that whitelist is rejected with a 400 by the simulator but accepted upstream. Enable this to match vLLM's behavior. Note that tool call generation still synthesizes arguments from the schema, so unsupported parameter types fail at generation time rather than at validation time
 
 
 ## KV cache

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -205,6 +205,10 @@ type Configuration struct {
 	// ObjectToolCallNotRequiredParamProbability is the probability to add a field, that is not required,
 	// in an object in a tool call, optional, defaults to 50
 	ObjectToolCallNotRequiredParamProbability int `yaml:"object-tool-call-not-required-field-probability" json:"object-tool-call-not-required-field-probability"`
+	// SkipToolValidation disables the built-in meta-validation of incoming tool schemas.
+	// Real vLLM forwards tool schemas to the model verbatim, so schemas using fields outside
+	// the simulator's whitelist are rejected here but accepted upstream. Optional, defaults to false.
+	SkipToolValidation bool `yaml:"skip-tool-validation" json:"skip-tool-validation"`
 
 	// EnableKVCache defines if kv cache feature will be enabled
 	EnableKVCache bool `yaml:"enable-kvcache" json:"enable-kvcache"`

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -178,6 +178,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	addToggle(f, &config.EnableSleepMode, "enable-sleep-mode", "Enable sleep mode", "Disable sleep mode")
 	f.BoolVar(&config.EnableRequestIDHeaders, "enable-request-id-headers", config.EnableRequestIDHeaders, "Enable including X-Request-Id header in responses")
 	f.BoolVar(&config.LogHTTP, "log-http", config.LogHTTP, "Log full HTTP request and response (method, URI, headers, bodies when buffered, status); streamed bodies are not logged")
+	f.BoolVar(&config.SkipToolValidation, "skip-tool-validation", config.SkipToolValidation, "Skip the built-in validation of incoming tool schemas, matching real vLLM which forwards them to the model verbatim")
 
 	f.IntVar(&config.FailureInjectionRate, "failure-injection-rate", config.FailureInjectionRate, "Probability (0-100) of injecting failures")
 	failureTypes := getParamValueFromArgs("failure-types")

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -77,7 +77,7 @@ func New(logger logr.Logger) (*VllmSimulator, error) {
 		return nil, fmt.Errorf("failed to create tools validator: %s", err)
 	}
 
-	return &VllmSimulator{
+	sim := &VllmSimulator{
 		toolsValidator: toolsValidator,
 		Context: SimContext{
 			logger: logger,
@@ -87,7 +87,15 @@ func New(logger logr.Logger) (*VllmSimulator, error) {
 			kvcacheHelper: nil, // kvcache helper will be created only if required after reading configuration
 		},
 		waitingQueue: list.New(),
-	}, nil
+	}
+	// The configuration is set after construction and may be swapped at runtime by admin
+	// updates, so read it per call rather than capturing the flag here.
+	sim.toolsValidator.skip = func() bool {
+		config := sim.Context.Config()
+		return config != nil && config.SkipToolValidation
+	}
+
+	return sim, nil
 }
 
 func Start(ctx context.Context, config *common.Configuration, logger logr.Logger) ([]*VllmSimulator, error) {

--- a/pkg/llm-d-inference-sim/tools_utils.go
+++ b/pkg/llm-d-inference-sim/tools_utils.go
@@ -67,6 +67,10 @@ func isToolChoiceNone(toolChoice api.ToolChoice) bool {
 
 type toolsValidator struct {
 	schema *jsonschema.Schema
+	// skip reports whether tool schema validation is currently disabled. It is read on
+	// every call so that a configuration swapped in at runtime takes effect immediately.
+	// A nil skip means validation is always performed.
+	skip func() bool
 }
 
 func createToolsValidator() (*toolsValidator, error) {
@@ -78,6 +82,10 @@ func createToolsValidator() (*toolsValidator, error) {
 }
 
 func (v *toolsValidator) validateTool(tool []byte) error {
+	if v.skip != nil && v.skip() {
+		return nil
+	}
+
 	var value interface{}
 	if err := json.Unmarshal(tool, &value); err != nil {
 		return err

--- a/pkg/tests/tools_test.go
+++ b/pkg/tests/tools_test.go
@@ -595,6 +595,69 @@ var _ = Describe("Simulator for request with tools", Ordered, func() {
 		Entry(nil, common.ModeRandom),
 	)
 
+	// A well-formed JSON Schema that the built-in validator rejects only because
+	// "title" is outside its whitelist. Real vLLM forwards such schemas verbatim.
+	unwhitelistedTool := []openai.ChatCompletionToolUnionParam{
+		{
+			OfFunction: &openai.ChatCompletionFunctionToolParam{
+				Function: openai.FunctionDefinitionParam{
+					Name:        functionNameGetWeather,
+					Description: openai.String("Get weather at the given location"),
+					Parameters: openai.FunctionParameters{
+						"type":  "object",
+						"title": "Weather query",
+						"properties": map[string]interface{}{
+							"location": map[string]string{
+								"type": "string",
+							},
+						},
+						"required": []string{"location"},
+					},
+				},
+			},
+		},
+	}
+
+	newToolParams := func() openai.ChatCompletionNewParams {
+		return openai.ChatCompletionNewParams{
+			Messages:   []openai.ChatCompletionMessageParamUnion{openai.UserMessage(testUserMessage)},
+			Model:      model,
+			ToolChoice: openai.ChatCompletionToolChoiceOptionUnionParam{OfAuto: param.NewOpt("required")},
+			Tools:      unwhitelistedTool,
+		}
+	}
+
+	It("should reject a schema with non-whitelisted fields by default", func() {
+		ctx := context.TODO()
+		client, err := startServer(ctx, common.ModeRandom)
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient := openai.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithHTTPClient(client))
+
+		_, err = openaiclient.Chat.Completions.New(ctx, newToolParams())
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should accept a schema with non-whitelisted fields when skip-tool-validation is set", func() {
+		ctx := context.TODO()
+		client, err := startServerWithArgs(ctx, []string{
+			"cmd", "--model", model, "--mode", common.ModeRandom,
+			"--skip-tool-validation",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		openaiclient := openai.NewClient(
+			option.WithBaseURL(baseURL),
+			option.WithHTTPClient(client))
+
+		resp, err := openaiclient.Chat.Completions.New(ctx, newToolParams())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Choices).To(HaveLen(1))
+		Expect(resp.Choices[0].Message.ToolCalls).ToNot(BeEmpty())
+	})
+
 	DescribeTable("array parameter, no streaming",
 		func(mode string, minLength int, maxLength int, min float64, max float64) {
 			ctx := context.TODO()


### PR DESCRIPTION
## What does this PR do?

Adds a `--skip-tool-validation` flag (also settable as `skip-tool-validation: true` in the YAML config) that disables the built-in meta-validation of incoming tool schemas.

The guard lives in `toolsValidator.validateTool`, which is the single point all four request types route through, so no change to the `validate(toolsValidator) *api.Error` interface was needed.

`toolsValidator.skip` is a `func() bool` rather than a plain `bool` because the configuration is set after `New()` and can be swapped at runtime by admin updates (`SimContext.SetConfig`). Capturing the value at construction would make the flag stale after a config update; reading it per call does not. It is wired in `New()` rather than `Start()` so that simulators built directly in tests pick it up too. A nil `skip` means validation is always performed.

## Why is this change needed?

The simulator validates every tool's `function.parameters` against a strict schema in `pkg/llm-d-inference-sim/tools_utils.go` that whitelists a small set of JSON Schema fields. Real vLLM does not meta-validate tool schemas this way — it forwards them to the model. A client sending a schema with fields outside the whitelist (for example `title`) gets a 400 from the simulator while the same request succeeds against real vLLM.

## How was this tested?

Two specs added in `pkg/tests/tools_test.go`, using a well-formed schema whose only problem is a non-whitelisted `title` field:

- it is rejected by default, confirming the fixture really does trip the validator
- it is accepted with `--skip-tool-validation`, and tool calls are returned

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes #607

## One behavior change worth flagging

The existing `invalidTools` test fixture mixes two different kinds of schema: some only violate the whitelist, others are genuinely malformed (for example `"type": "stringstring"`). With validation skipped, the malformed ones reach the tool call generator, which cannot synthesize arguments for them and fails with a 500 rather than a 400.

I have left that as-is since it is outside the scope of #607, and documented it in `docs/configuration.md`. Note that ai-dynamo/dynamo#11377 treated the same 500-vs-400 distinction as a bug and fixed it, so it may be worth mapping generation failures on unsupported parameter types to a 400 here too. Happy to do that in a follow-up if you would like it.
