### PR TITLE
ci: trigger lint-and-test on workflow file changes

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -27,6 +27,7 @@ jobs:
               - Dockerfile.sidecar
               - Makefile*
               - go.mod  
+              - .github/workflows/**
   lint-and-test:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.src == 'true' }}    


### PR DESCRIPTION
Following up on Nili's comment from #606, this PR adds `.github/workflows/**` to the `check-changes` path filter in ci-pr-checks.yaml, so edits to CI workflow files mark `src=true`  and trigger the `lint-and-test` job, same as Go source/Dockerfiles/Makefile/go.mod changes do today.
