### PR TITLE
fix prefix cache metrics names to match vllm

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,8 +154,8 @@ For a detailed explanation of how the simulator models inference time and what e
     - `request-success-total` - number of successful requests per finish reason, key: finish-reason (stop, length, etc.).
     - `total-prompt-tokens` - initial value for the `vllm:prompt_tokens_total` counter (total number of prompt tokens processed).
     - `total-generation-tokens` - initial value for the `vllm:generation_tokens_total` counter (total number of generated tokens).
-    - `prefix-cache-hits` - initial value for the `vllm:prefix_cache_hits` counter (in tokens).
-    - `prefix-cache-queries` - initial value for the `vllm:prefix_cache_queries` counter (in tokens).
+    - `prefix-cache-hits` - initial value for the `vllm:prefix_cache_hits_total` counter (in tokens).
+    - `prefix-cache-queries` - initial value for the `vllm:prefix_cache_queries_total` counter (in tokens).
     <br>
     **Example:**<br>
       --fake-metrics '{"running-requests":"oscillate:0:10:5s","waiting-requests":30,"kv-cache-usage":0.4,"loras":[{"running":"lora4,lora2","waiting":"lora3","timestamp":1257894567},{"running":"lora4,lora3","waiting":"","timestamp":1257894569}]}'

--- a/docs/kv-cache.md
+++ b/docs/kv-cache.md
@@ -7,7 +7,7 @@ The simulator includes a prefix-cache subsystem that mimics vLLM's KV cache beha
 - **Prefix cache tracking**: incoming prompts are tokenized and split into fixed-size blocks. Blocks already present in the cache are counted as cache hits and do not need to be prefilled.
 - **ZMQ event emission**: `BlockStored`, `BlockRemoved`, and `AllBlocksCleared` events are published over ZMQ so that external consumers (e.g., the llm-d KV cache router) can maintain an accurate view of which blocks each pod holds.
 - **Latency simulation**: when `prefill-time-per-token` is configured, cache hits reduce the simulated TTFT proportionally — only non-cached tokens contribute to prefill time.
-- **Prometheus metrics**: `vllm:kv_cache_usage_perc`, `vllm:prefix_cache_hits`, and `vllm:prefix_cache_queries` are reported.
+- **Prometheus metrics**: `vllm:kv_cache_usage_perc`, `vllm:prefix_cache_hits_total`, and `vllm:prefix_cache_queries_total` are reported.
 
 ## Enabling KV cache
 
@@ -266,11 +266,11 @@ When KV cache is enabled, the response `usage` object includes cached token info
 | Metric | Description |
 |--------|-------------|
 | `vllm:kv_cache_usage_perc` | Fraction of KV cache blocks currently in use (0–1). Updated after each request starts and finishes. |
-| `vllm:prefix_cache_hits` | Cumulative number of prompt tokens served from cache across all requests |
-| `vllm:prefix_cache_queries` | Cumulative number of prompt tokens checked against the cache across all requests |
+| `vllm:prefix_cache_hits_total` | Cumulative number of prompt tokens served from cache across all requests |
+| `vllm:prefix_cache_queries_total` | Cumulative number of prompt tokens checked against the cache across all requests |
 | `vllm:cache_config_info` | Static info gauge with labels `cache_dtype`, `num_gpu_blocks`, `num_cpu_blocks`, `block_size` |
 
-The hit rate at any point is `prefix_cache_hits / prefix_cache_queries`.
+The hit rate at any point is `prefix_cache_hits_total / prefix_cache_queries_total`.
 
 ## Sleep mode integration
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -26,5 +26,5 @@ Currently supported are the following metrics:
 | vllm:lora_requests_info | Running stats on LoRA requests |
 | vllm:kv_cache_usage_perc | The fraction of KV-cache blocks currently in use (from 0 to 1) |
 | vllm:cache_config_info | Information of the LLMEngine CacheConfig |
-| vllm:prefix_cache_hits | Prefix cache hits, in terms of number of cached tokens |
-| vllm:prefix_cache_queries | Prefix cache queries, in terms of number of queried tokens |
+| vllm:prefix_cache_hits_total | Prefix cache hits, in terms of number of cached tokens |
+| vllm:prefix_cache_queries_total | Prefix cache queries, in terms of number of queried tokens |

--- a/pkg/llm-d-inference-sim/fake_metrics.go
+++ b/pkg/llm-d-inference-sim/fake_metrics.go
@@ -338,22 +338,22 @@ func (s *SimContext) updateFakeMetrics(update *common.FakeMetrics, old *common.F
 
 	if update.PrefixCacheQueries != nil {
 		if oldPrefixCacheQueries != nil {
-			s.metrics.registry.Unregister(s.metrics.prefixCacheQueries)
-			if err := s.createAndRegisterPrefixCacheQueriesMetric(); err != nil {
+			s.metrics.registry.Unregister(s.metrics.prefixCacheQueriesTotal)
+			if err := s.createAndRegisterPrefixCacheQueriesTotalMetric(); err != nil {
 				return err
 			}
 		}
-		s.metrics.prefixCacheQueries.WithLabelValues(s.Config().DisplayModelName).Add(float64(*update.PrefixCacheQueries))
+		s.metrics.prefixCacheQueriesTotal.WithLabelValues(s.Config().DisplayModelName).Add(float64(*update.PrefixCacheQueries))
 	}
 
 	if update.PrefixCacheHits != nil {
 		if oldPrefixCacheHits != nil {
-			s.metrics.registry.Unregister(s.metrics.prefixCacheHits)
-			if err := s.createAndRegisterPrefixCacheHitsMetric(); err != nil {
+			s.metrics.registry.Unregister(s.metrics.prefixCacheHitsTotal)
+			if err := s.createAndRegisterPrefixCacheHitsTotalMetric(); err != nil {
 				return err
 			}
 		}
-		s.metrics.prefixCacheHits.WithLabelValues(s.Config().DisplayModelName).Add(float64(*update.PrefixCacheHits))
+		s.metrics.prefixCacheHitsTotal.WithLabelValues(s.Config().DisplayModelName).Add(float64(*update.PrefixCacheHits))
 	}
 
 	if update.RequestSuccessTotal != nil {

--- a/pkg/llm-d-inference-sim/metrics.go
+++ b/pkg/llm-d-inference-sim/metrics.go
@@ -34,28 +34,28 @@ import (
 )
 
 const (
-	E2EReqLatencyMetricName          = "vllm:e2e_request_latency_seconds"
-	ReqQueueTimeMetricName           = "vllm:request_queue_time_seconds"
-	ReqInferenceTimeMetricName       = "vllm:request_inference_time_seconds"
-	PrefillTimeMetricName            = "vllm:request_prefill_time_seconds"
-	DecodeTimeMetricName             = "vllm:request_decode_time_seconds"
-	TTFTMetricName                   = "vllm:time_to_first_token_seconds"
-	TPOTMetricName                   = "vllm:time_per_output_token_seconds"
-	InterTokenLatencyMetricName      = "vllm:inter_token_latency_seconds"
-	MaxNumGenerationTokensMetricName = "vllm:max_num_generation_tokens"
-	GenerationTokensMetricName       = "vllm:request_generation_tokens"
-	ParamMaxTokensMetricName         = "vllm:request_params_max_tokens"
-	PromptTokensMetricName           = "vllm:request_prompt_tokens"
-	GenerationTokensTotalMetricName  = "vllm:generation_tokens_total"
-	PromptTokensTotalMetricName      = "vllm:prompt_tokens_total"
-	SuccessTotalMetricName           = "vllm:request_success_total"
-	LoRARequestsMetricName           = "vllm:lora_requests_info"
-	ReqRunningMetricName             = "vllm:num_requests_running"
-	ReqWaitingMetricName             = "vllm:num_requests_waiting"
-	KVCacheUsageMetricName           = "vllm:kv_cache_usage_perc"
-	CacheConfigName                  = "vllm:cache_config_info"
-	PrefixCacheHitsMetricName        = "vllm:prefix_cache_hits"
-	PrefixCacheQueriesMetricName     = "vllm:prefix_cache_queries"
+	E2EReqLatencyMetricName           = "vllm:e2e_request_latency_seconds"
+	ReqQueueTimeMetricName            = "vllm:request_queue_time_seconds"
+	ReqInferenceTimeMetricName        = "vllm:request_inference_time_seconds"
+	PrefillTimeMetricName             = "vllm:request_prefill_time_seconds"
+	DecodeTimeMetricName              = "vllm:request_decode_time_seconds"
+	TTFTMetricName                    = "vllm:time_to_first_token_seconds"
+	TPOTMetricName                    = "vllm:time_per_output_token_seconds"
+	InterTokenLatencyMetricName       = "vllm:inter_token_latency_seconds"
+	MaxNumGenerationTokensMetricName  = "vllm:max_num_generation_tokens"
+	GenerationTokensMetricName        = "vllm:request_generation_tokens"
+	ParamMaxTokensMetricName          = "vllm:request_params_max_tokens"
+	PromptTokensMetricName            = "vllm:request_prompt_tokens"
+	GenerationTokensTotalMetricName   = "vllm:generation_tokens_total"
+	PromptTokensTotalMetricName       = "vllm:prompt_tokens_total"
+	SuccessTotalMetricName            = "vllm:request_success_total"
+	LoRARequestsMetricName            = "vllm:lora_requests_info"
+	ReqRunningMetricName              = "vllm:num_requests_running"
+	ReqWaitingMetricName              = "vllm:num_requests_waiting"
+	KVCacheUsageMetricName            = "vllm:kv_cache_usage_perc"
+	CacheConfigName                   = "vllm:cache_config_info"
+	PrefixCacheHitsTotalMetricName    = "vllm:prefix_cache_hits_total"
+	PrefixCacheQueriesTotalMetricName = "vllm:prefix_cache_queries_total"
 )
 
 const (
@@ -149,10 +149,10 @@ type metricsData struct {
 	requestParamsMaxTokens *prometheus.HistogramVec
 	// requestSuccessTotal is prometheus counter for total number of successful requests
 	requestSuccessTotal *prometheus.CounterVec
-	// prefixCacheHits is prometheus counter for total cached tokens (prefix cache hits)
-	prefixCacheHits *prometheus.CounterVec
-	// prefixCacheQueries is prometheus counter for total queried tokens (prefix cache queries)
-	prefixCacheQueries *prometheus.CounterVec
+	// prefixCacheHitsTotal is prometheus counter for total cached tokens (prefix cache hits)
+	prefixCacheHitsTotal *prometheus.CounterVec
+	// prefixCacheQueriesTotal is prometheus counter for total queried tokens (prefix cache queries)
+	prefixCacheQueriesTotal *prometheus.CounterVec
 	// prefixCacheStatsChan is a channel to update prefix cache hit/query counters
 	prefixCacheStatsChan common.Channel[kvcache.PrefixCacheStats]
 
@@ -321,11 +321,11 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	}
 	go s.kvCacheUsageUpdater(ctx)
 
-	if err := s.createAndRegisterPrefixCacheHitsMetric(); err != nil {
+	if err := s.createAndRegisterPrefixCacheHitsTotalMetric(); err != nil {
 		return err
 	}
 
-	if err := s.createAndRegisterPrefixCacheQueriesMetric(); err != nil {
+	if err := s.createAndRegisterPrefixCacheQueriesTotalMetric(); err != nil {
 		return err
 	}
 
@@ -550,11 +550,11 @@ func (s *SimContext) reportPrefixCacheStats(stats kvcache.PrefixCacheStats) {
 		return
 	}
 
-	if s.metrics.prefixCacheQueries != nil {
-		s.metrics.prefixCacheQueries.WithLabelValues(s.Config().DisplayModelName).Add(float64(stats.QueriedTokens))
+	if s.metrics.prefixCacheQueriesTotal != nil {
+		s.metrics.prefixCacheQueriesTotal.WithLabelValues(s.Config().DisplayModelName).Add(float64(stats.QueriedTokens))
 	}
-	if s.metrics.prefixCacheHits != nil {
-		s.metrics.prefixCacheHits.WithLabelValues(s.Config().DisplayModelName).Add(float64(stats.CachedTokens))
+	if s.metrics.prefixCacheHitsTotal != nil {
+		s.metrics.prefixCacheHitsTotal.WithLabelValues(s.Config().DisplayModelName).Add(float64(stats.CachedTokens))
 	}
 }
 
@@ -1031,30 +1031,30 @@ func (s *SimContext) createAndRegisterRequestSuccessTotalMetric() error {
 	return nil
 }
 
-func (s *SimContext) createAndRegisterPrefixCacheHitsMetric() error {
-	s.metrics.prefixCacheHits = prometheus.NewCounterVec(
+func (s *SimContext) createAndRegisterPrefixCacheHitsTotalMetric() error {
+	s.metrics.prefixCacheHitsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: PrefixCacheHitsMetricName,
+			Name: PrefixCacheHitsTotalMetricName,
 			Help: "Prefix cache hits, in terms of number of cached tokens.",
 		},
 		[]string{api.PromLabelModelName},
 	)
-	if err := s.metrics.registry.Register(s.metrics.prefixCacheHits); err != nil {
+	if err := s.metrics.registry.Register(s.metrics.prefixCacheHitsTotal); err != nil {
 		s.logger.Error(err, "prometheus prefix_cache_hits counter register failed")
 		return err
 	}
 	return nil
 }
 
-func (s *SimContext) createAndRegisterPrefixCacheQueriesMetric() error {
-	s.metrics.prefixCacheQueries = prometheus.NewCounterVec(
+func (s *SimContext) createAndRegisterPrefixCacheQueriesTotalMetric() error {
+	s.metrics.prefixCacheQueriesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: PrefixCacheQueriesMetricName,
+			Name: PrefixCacheQueriesTotalMetricName,
 			Help: "Prefix cache queries, in terms of number of queried tokens.",
 		},
 		[]string{api.PromLabelModelName},
 	)
-	if err := s.metrics.registry.Register(s.metrics.prefixCacheQueries); err != nil {
+	if err := s.metrics.registry.Register(s.metrics.prefixCacheQueriesTotal); err != nil {
 		s.logger.Error(err, "prometheus prefix_cache_queries counter register failed")
 		return err
 	}

--- a/pkg/tests/fake_metrics_test.go
+++ b/pkg/tests/fake_metrics_test.go
@@ -138,8 +138,8 @@ var _ = Describe("Fake metrics", Ordered, func() {
 			Expect(metrics).To(ContainSubstring(fmt.Sprintf(`vllm:request_success_total{finish_reason="stop",model_name="%s"} 20`, common.TestModelName)))
 			Expect(metrics).To(ContainSubstring(fmt.Sprintf(`vllm:request_success_total{finish_reason="tool_calls",model_name="%s"} 0`, common.TestModelName)))
 
-			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheHitsMetricName, 750)))
-			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheQueriesMetricName, 2000)))
+			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheHitsTotalMetricName, 750)))
+			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheQueriesTotalMetricName, 2000)))
 		})
 
 		It("Should generate correct fake metrics using functions", func() {
@@ -283,8 +283,8 @@ var _ = Describe("Fake metrics", Ordered, func() {
 			data, err := io.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			metrics := string(data)
-			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheQueriesMetricName, 1000)))
-			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheHitsMetricName, 500)))
+			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheQueriesTotalMetricName, 1000)))
+			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheHitsTotalMetricName, 500)))
 		})
 
 		It("Should not update prefix cache counters from real requests when fake metrics are set", func() {
@@ -321,8 +321,8 @@ var _ = Describe("Fake metrics", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			metrics := string(data)
 			// Fake values should be unchanged — reportPrefixCacheStats returns early when FakeMetrics is set
-			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.QwenModelName, vllmsim.PrefixCacheQueriesMetricName, 200)))
-			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.QwenModelName, vllmsim.PrefixCacheHitsMetricName, 100)))
+			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.QwenModelName, vllmsim.PrefixCacheQueriesTotalMetricName, 200)))
+			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.QwenModelName, vllmsim.PrefixCacheHitsTotalMetricName, 100)))
 		})
 	})
 
@@ -760,8 +760,8 @@ var _ = Describe("Fake metrics", Ordered, func() {
 
 			Expect(metrics).To(ContainSubstring(fmt.Sprintf(`vllm:request_success_total{finish_reason="stop",model_name="%s"} 20`, common.TestModelName)))
 			Expect(metrics).To(ContainSubstring(fmt.Sprintf(`vllm:request_success_total{finish_reason="length",model_name="%s"} 5`, common.TestModelName)))
-			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheHitsMetricName, 500)))
-			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheQueriesMetricName, 1000)))
+			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheHitsTotalMetricName, 500)))
+			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheQueriesTotalMetricName, 1000)))
 
 			// Update all three
 			reqBody := `{
@@ -790,8 +790,8 @@ var _ = Describe("Fake metrics", Ordered, func() {
 			Expect(metrics).To(ContainSubstring(fmt.Sprintf(`vllm:request_success_total{finish_reason="length",model_name="%s"} 50`, common.TestModelName)))
 			Expect(metrics).To(ContainSubstring(fmt.Sprintf(`vllm:request_success_total{finish_reason="tool_calls",model_name="%s"} 10`, common.TestModelName)))
 			Expect(metrics).To(ContainSubstring(fmt.Sprintf(`vllm:request_success_total{finish_reason="remote_decode",model_name="%s"} 5`, common.TestModelName)))
-			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheHitsMetricName, 750)))
-			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheQueriesMetricName, 2000)))
+			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheHitsTotalMetricName, 750)))
+			Expect(metrics).To(ContainSubstring(getCountMetricLine(common.TestModelName, vllmsim.PrefixCacheQueriesTotalMetricName, 2000)))
 		})
 
 		It("Should update fake lora metrics correctly", func() {

--- a/pkg/tests/metrics_test.go
+++ b/pkg/tests/metrics_test.go
@@ -793,12 +793,12 @@ var _ = Describe("Simulator metrics", Ordered, func() {
 			metricsLines := strings.Split(string(data), "\n")
 
 			// prefix_cache_queries should reflect total prompt tokens across both requests
-			queries := findIntMetric(metricsLines, getCountMetricPrefix(common.QwenModelName, vllmsim.PrefixCacheQueriesMetricName))
+			queries := findIntMetric(metricsLines, getCountMetricPrefix(common.QwenModelName, vllmsim.PrefixCacheQueriesTotalMetricName))
 			Expect(queries).NotTo(BeNil())
 			Expect(*queries).To(BeNumerically(">", 0))
 
 			// The second request shares a prefix with the first, so hits should be non-zero
-			hits := findIntMetric(metricsLines, getCountMetricPrefix(common.QwenModelName, vllmsim.PrefixCacheHitsMetricName))
+			hits := findIntMetric(metricsLines, getCountMetricPrefix(common.QwenModelName, vllmsim.PrefixCacheHitsTotalMetricName))
 			Expect(hits).NotTo(BeNil())
 			Expect(*hits).To(BeNumerically(">", 0))
 
@@ -901,12 +901,12 @@ var _ = Describe("Simulator metrics", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			metricsLines := strings.Split(string(data), "\n")
 
-			queries := findIntMetric(metricsLines, getCountMetricPrefix(common.QwenModelName, vllmsim.PrefixCacheQueriesMetricName))
+			queries := findIntMetric(metricsLines, getCountMetricPrefix(common.QwenModelName, vllmsim.PrefixCacheQueriesTotalMetricName))
 			Expect(queries).NotTo(BeNil())
 			Expect(*queries).To(BeNumerically(">", 0))
 
 			// The second request shares a prefix with the first, so hits should be non-zero
-			hits := findIntMetric(metricsLines, getCountMetricPrefix(common.QwenModelName, vllmsim.PrefixCacheHitsMetricName))
+			hits := findIntMetric(metricsLines, getCountMetricPrefix(common.QwenModelName, vllmsim.PrefixCacheHitsTotalMetricName))
 			Expect(hits).NotTo(BeNil())
 			Expect(*hits).To(BeNumerically(">", 0))
 


### PR DESCRIPTION
## What does this PR do?

fix prefix cache metrics names to match vllm

vllm:prefix_cache_hits    -> vllm:prefix_cache_hits_total
vllm:prefix_cache_queries -> vllm:prefix_cache_queries_total

cf. https://github.com/vllm-project/vllm/pull/51670

## Why is this change needed?

vllm compatibility

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
