### PR TITLE
feat: accept --tensor-parallel-size as an ignored flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,6 +169,7 @@ The following command line parameters are ignored by the simulator:
 - `ec-transfer-config` - configuration for distributed EC cache transfer, ignored
 - `enforce-eager`, `no-enforce-eager` - controls whether PyTorch eager mode is always enforced, ignored
 - `enable-prefix-caching`, `no-enable-prefix-caching` - enable or disable prefix caching, ignored, behaves as enable-prefix-caching=true
+- `tensor-parallel-size` - number of tensor parallel replicas, ignored
 
 ## Klog
 In addition, as we are using klog, the following parameters are available:

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -341,6 +341,9 @@ type Configuration struct {
 	// EnablePrefixCaching defines whether to enable prefix caching.
 	// Ignored in the simulator.
 	EnablePrefixCaching bool `yaml:"enable-prefix-caching" json:"enable-prefix-caching"`
+	// TPSize defines the number of tensor parallel replicas.
+	// Ignored in the simulator.
+	TPSize int `yaml:"tensor-parallel-size" json:"tensor-parallel-size"`
 	// MaxRequestBodySizeMB sets the maximum allowed request body size in megabytes for the HTTP server.
 	// Default is 4 (matching the fasthttp built-in default). Must be between 1 and 512.
 	MaxRequestBodySizeMB int `yaml:"max-request-body-size-mb" json:"max-request-body-size-mb"`

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -357,6 +357,18 @@ var _ = Describe("Simulator configuration", func() {
 	}
 	tests = append(tests, test)
 
+	// tensor-parallel-size is accepted for vLLM command line compatibility and ignored
+	c = createConfigWithModel(TestModelName, nil)
+	c.MaxCPULoras = 1
+	c.Seed = 100
+	c.TPSize = 2
+	test = testCase{
+		name:           "tensor-parallel-size",
+		args:           []string{"cmd", "--model", TestModelName, "--seed", "100", "--tensor-parallel-size", "2"},
+		expectedConfig: c,
+	}
+	tests = append(tests, test)
+
 	// zmq-endpoint and kv-events-replay-endpoint ports far enough apart that
 	// they don't collide even once each rank's offset (0..data-parallel-size-1) is applied
 	c = createConfigWithModel(TestModelName, nil)

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -217,6 +217,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 		"enforce-eager", "Always use eager-mode PyTorch, ignored", "Don't always use eager-mode PyTorch, ignored")
 	addToggle(f, &config.EnablePrefixCaching,
 		"enable-prefix-caching", "Enable prefix caching, ignored", "Disable prefix caching, ignored")
+	f.IntVar(&config.TPSize, "tensor-parallel-size", config.TPSize, "Number of tensor parallel replicas, ignored")
 
 	// These values were manually parsed above in getParamValueFromArgs, we leave this in order to get these flags in --help
 	var dummyString string


### PR DESCRIPTION
## What does this PR do?

Registers `--tensor-parallel-size` as an accepted-and-ignored flag, alongside the existing `mm-processor-kwargs`, `ec-transfer-config`, `enforce-eager` and `enable-prefix-caching`.

## Why is this change needed?

The flag is currently rejected as unknown, so the simulator exits before it starts serving.

Controllers that render a vLLM command line emit `--tensor-parallel-size` with the value derived from the target node's GPU count. The engine image is not visible to the code assembling the arguments, so the flag is emitted whether the image is vLLM or the simulator. Because the failure happens at process start, it is not reachable through the API surface.

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual testing performed

A case in `pkg/common/config_test.go` asserts the flag parses into the configuration.

Built an image from this branch and ran it with `--tensor-parallel-size 4`: the simulator starts and reports `"tensor-parallel-size": 4` in its configuration dump. Also ran it in a Kubernetes deployment where the flag is supplied by a controller — the container previously crashlooped on the unknown flag, and now reaches ready.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (`docs/configuration.md`, "Ignored parameters")

## Related Issues

Closes #617
