### PR TITLE
implement vllm:request_time_per_output_token_seconds metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -20,6 +20,7 @@ Currently supported are the following metrics:
 | vllm:request_queue_time_seconds | Histogram of time spent in WAITING phase for request |
 | vllm:request_prefill_time_seconds | Histogram of time spent in PREFILL phase for request |
 | vllm:request_decode_time_seconds | Histogram of time spent in DECODE phase for request |
+| vllm:request_time_per_output_token_seconds | Histogram of time_per_output_token_seconds per request |
 | vllm:time_to_first_token_seconds | Histogram of time to first token in seconds |
 | vllm:time_per_output_token_seconds | Histogram of time per output token in seconds |
 | vllm:inter_token_latency_seconds | Histogram of inter-token latency in seconds |

--- a/pkg/common/config_fake_metrics.go
+++ b/pkg/common/config_fake_metrics.go
@@ -107,6 +107,8 @@ type FakeMetrics struct {
 	ReqPrefillTimeBucketValues []int `yaml:"prefill-time-buckets-values" json:"prefill-time-buckets-values"`
 	// ReqDecodeTimeBucketValues is an array of values for request decode time buckets.
 	ReqDecodeTimeBucketValues []int `yaml:"decode-time-buckets-values" json:"decode-time-buckets-values"`
+	// ReqTpotBucketValues is an array of values for request time-per-output-token buckets.
+	ReqTPOTBucketValues []int `yaml:"request-tpot-buckets-values" json:"request-tpot-buckets-values"`
 
 	// PrefixCacheHits is the initial value for the prefix cache hits counter (in tokens)
 	PrefixCacheHits *int64 `yaml:"prefix-cache-hits" json:"prefix-cache-hits,omitempty"`
@@ -341,6 +343,11 @@ func (f *FakeMetrics) validate() error {
 	for _, v := range f.ReqDecodeTimeBucketValues {
 		if v < 0 {
 			return errors.New("fake metrics decode-time-buckets-values cannot contain negative values")
+		}
+	}
+	for _, v := range f.ReqTPOTBucketValues {
+		if v < 0 {
+			return errors.New("fake metrics request-tpot-buckets-values cannot contain negative values")
 		}
 	}
 	if f.PrefixCacheHits != nil && *f.PrefixCacheHits < 0 {

--- a/pkg/llm-d-inference-sim/fake_metrics.go
+++ b/pkg/llm-d-inference-sim/fake_metrics.go
@@ -280,6 +280,16 @@ func (s *SimContext) updateFakeMetrics(update *common.FakeMetrics, old *common.F
 		s.initFakeHistogram(s.metrics.reqDecodeTime, common.RequestLatencyBucketsBoundaries, update.ReqDecodeTimeBucketValues)
 	}
 
+	if update.ReqTPOTBucketValues != nil {
+		if old != nil && old.ReqTPOTBucketValues != nil {
+			s.metrics.registry.Unregister(s.metrics.reqTpot)
+			if err := s.createAndRegisterReqTpotMetric(); err != nil {
+				return err
+			}
+		}
+		s.initFakeHistogram(s.metrics.reqTpot, common.TPOTBucketsBoundaries, update.ReqTPOTBucketValues)
+	}
+
 	buckets := Build125Buckets(s.Config().MaxModelLen)
 
 	if update.RequestParamsMaxTokens != nil {

--- a/pkg/llm-d-inference-sim/metrics.go
+++ b/pkg/llm-d-inference-sim/metrics.go
@@ -41,6 +41,7 @@ const (
 	DecodeTimeMetricName              = "vllm:request_decode_time_seconds"
 	TTFTMetricName                    = "vllm:time_to_first_token_seconds"
 	TPOTMetricName                    = "vllm:time_per_output_token_seconds"
+	ReqTPOTMetricName                 = "vllm:request_time_per_output_token_seconds"
 	InterTokenLatencyMetricName       = "vllm:inter_token_latency_seconds"
 	MaxNumGenerationTokensMetricName  = "vllm:max_num_generation_tokens"
 	GenerationTokensMetricName        = "vllm:request_generation_tokens"
@@ -107,6 +108,8 @@ type metricsData struct {
 	reqPrefillTimeChan common.Channel[float64]
 	// reqDecodeTimeChan is a channel to update request decode time
 	reqDecodeTimeChan common.Channel[float64]
+	// reqTpotChan is a channel to update request TPOT
+	reqTpotChan common.Channel[float64]
 	// kvCacheUsageChan is a channel to update kvCacheUsagePercentage
 	kvCacheUsageChan common.Channel[common.MetricInfo]
 	// registry is a Prometheus registry
@@ -133,6 +136,8 @@ type metricsData struct {
 	reqPrefillTime *prometheus.HistogramVec
 	// reqDecodeTime is prometheus histogram of request decode time in seconds
 	reqDecodeTime *prometheus.HistogramVec
+	// reqtpot is prometheus histogram for time_per_output_token_seconds per request
+	reqTpot *prometheus.HistogramVec
 	// kvCacheUsagePercentage is prometheus gauge
 	kvCacheUsagePercentage *prometheus.GaugeVec
 	// requestPromptTokens is prometheus histogram for number of input (prompt) tokens in request
@@ -299,6 +304,17 @@ func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 		Done:    ctx.Done(),
 	}
 	go s.reqDecodeTimeUpdater(ctx)
+
+	if err := s.createAndRegisterReqTpotMetric(); err != nil {
+		return err
+	}
+
+	s.metrics.reqTpotChan = common.Channel[float64]{
+		Channel: make(chan float64, maxNumberOfRequests),
+		Name:    "metrics.reqTpotChan",
+		Done:    ctx.Done(),
+	}
+	go s.reqTpotUpdater(ctx)
 
 	s.metrics.kvCacheUsagePercentage = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -643,6 +659,18 @@ func (s *SimContext) reqDecodeTimeUpdater(ctx context.Context) {
 	}
 }
 
+// reqTpotUpdater updates the request TPOT metric by listening on the relevant channel
+func (s *SimContext) reqTpotUpdater(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case value := <-s.metrics.reqTpotChan.Channel:
+			s.reportHistogramValue(s.metrics.reqTpot, value)
+		}
+	}
+}
+
 // lorasUpdater updates the running loras metric by listening on the relevant channel
 // one function updates both waiting and running loras since they a part of the same prometheus gauge
 func (s *SimContext) lorasUpdater(ctx context.Context) {
@@ -964,6 +992,23 @@ func (s *SimContext) createAndRegisterReqDecodeTimeMetric() error {
 	)
 	if err := s.metrics.registry.Register(s.metrics.reqDecodeTime); err != nil {
 		s.logger.Error(err, "prometheus request decode time histogram register failed")
+		return err
+	}
+	return nil
+}
+
+func (s *SimContext) createAndRegisterReqTpotMetric() error {
+	s.metrics.reqTpot = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: "",
+			Name:      ReqTPOTMetricName,
+			Help:      "Histogram of time_per_output_token_seconds per request.",
+			Buckets:   common.TPOTBucketsBoundaries,
+		},
+		[]string{api.PromLabelModelName},
+	)
+	if err := s.metrics.registry.Register(s.metrics.reqTpot); err != nil {
+		s.logger.Error(err, "prometheus time_per_output_token_seconds per request histogram register failed")
 		return err
 	}
 	return nil

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -445,6 +445,7 @@ func (s *VllmSimulator) simulateResponseProcessing(respCtx ResponseContext) {
 			&ResponseInfo{RespCtx: respCtx, Status: ResponseStatusCreated, ChoiceIdx: choiceIdx},
 			s.Context.logger)
 
+		nTokens := 0
 		startDecode := time.Now()
 		if respIsEmpty(respCtx) {
 			common.WriteToChannel(reqCtx.responseChannel(),
@@ -454,6 +455,7 @@ func (s *VllmSimulator) simulateResponseProcessing(respCtx ResponseContext) {
 				for i, token := range respCtx.responseTokens().Tokens {
 					if i != 0 {
 						s.Context.simulateInterTokenLatency()
+						nTokens++
 					}
 
 					tokens := &api.Tokenized{
@@ -478,6 +480,7 @@ func (s *VllmSimulator) simulateResponseProcessing(respCtx ResponseContext) {
 					for i, token := range args.Tokens {
 						if i != 0 {
 							s.Context.simulateInterTokenLatency()
+							nTokens++
 						}
 						respInfo := ResponseInfo{
 							Tokens:    &api.Tokenized{Tokens: []uint32{token}, Strings: []string{args.Strings[i]}},
@@ -493,7 +496,13 @@ func (s *VllmSimulator) simulateResponseProcessing(respCtx ResponseContext) {
 				}
 			}
 		}
-		common.WriteToChannel(s.Context.metrics.reqDecodeTimeChan, time.Since(startDecode).Seconds(), s.Context.logger)
+		decodeTime := time.Since(startDecode).Seconds()
+		meanTPOT := 0.0
+		if nTokens > 0 {
+			meanTPOT = decodeTime / float64(nTokens)
+		}
+		common.WriteToChannel(s.Context.metrics.reqTpotChan, meanTPOT, s.Context.logger)
+		common.WriteToChannel(s.Context.metrics.reqDecodeTimeChan, decodeTime, s.Context.logger)
 
 		if reqCtx.request().SendImage() {
 			s.Context.simulateImageGenerationLatency()

--- a/pkg/tests/fake_metrics_test.go
+++ b/pkg/tests/fake_metrics_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Fake metrics", Ordered, func() {
 					`"request-generation-tokens":[10,20,30],` +
 					`"request-max-generation-tokens":[10,20,30],` +
 					`"request-params-max-tokens":[10,20,30],` +
+					`"request-tpot-buckets-values":[0,2,4,6,8],` +
 					`"ttft-buckets-values":[1,2,3],` +
 					`"tpot-buckets-values":[0,0,1,2,3],` +
 					`"prefix-cache-hits":750,` +
@@ -107,6 +108,13 @@ var _ = Describe("Fake metrics", Ordered, func() {
 			Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, vllmsim.InterTokenLatencyMetricName, 0.075, 3)))
 			Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, vllmsim.InterTokenLatencyMetricName, 0.1, 6)))
 			Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, vllmsim.InterTokenLatencyMetricName, 0.15, 6)))
+
+			Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, vllmsim.ReqTPOTMetricName, 0.01, 0)))
+			Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, vllmsim.ReqTPOTMetricName, 0.025, 2)))
+			Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, vllmsim.ReqTPOTMetricName, 0.05, 6)))
+			Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, vllmsim.ReqTPOTMetricName, 0.075, 12)))
+			Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, vllmsim.ReqTPOTMetricName, 0.1, 20)))
+			Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, vllmsim.ReqTPOTMetricName, 0.15, 20)))
 
 			buckets := vllmsim.Build125Buckets(1024)
 			var expectedCount int

--- a/pkg/tests/grpc_metrics_test.go
+++ b/pkg/tests/grpc_metrics_test.go
@@ -202,16 +202,20 @@ var _ = Describe("gRPC Metrics", Ordered, func() {
 			}
 			Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, vllmsim.TTFTMetricName, math.Inf(1), 1)))
 
-			// Check TPOT and inter-token latency buckets
-			for _, metricName := range []string{vllmsim.TPOTMetricName, vllmsim.InterTokenLatencyMetricName} {
+			// Check TPOT, inter-token latency and request TPOT buckets
+			for _, metricName := range []string{vllmsim.TPOTMetricName, vllmsim.InterTokenLatencyMetricName, vllmsim.ReqTPOTMetricName} {
 				for _, boundary := range common.TPOTBucketsBoundaries {
 					if boundary < 0.075 {
 						// ensure that values for buckets up to 0.075 have count 0
 						Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, metricName, boundary, 0)))
 					} else {
-						// buckets higher than 0.75 should be greater than 0, we don't know the exact value since it depends on the random response length
+						// buckets higher than 0.075 should be greater than 0, we don't know the exact value since it depends on the random response length
 						count := findIntMetric(metricsLines, getFloatBucketMetricPrefix(common.TestModelName, metricName, boundary))
 						Expect(count).ToNot(BeNil())
+						// note: request TPOT is actually measured. we can't assert the exact timing.
+						if boundary == 0.075 && metricName == vllmsim.ReqTPOTMetricName {
+							continue
+						}
 						Expect(*count).To(BeNumerically(">", 0))
 					}
 				}

--- a/pkg/tests/metrics_test.go
+++ b/pkg/tests/metrics_test.go
@@ -587,9 +587,13 @@ var _ = Describe("Simulator metrics", Ordered, func() {
 						// ensure that values for buckets up to 0.075 have count 0
 						Expect(metrics).To(ContainSubstring(getFloatBucketMetricLine(common.TestModelName, metricName, boundary, 0)))
 					} else {
-						// buckets higher than 0.75 should be greater than 0, we don't know the exact value since it depends on the random response length
+						// buckets higher than 0.075 should be greater than 0, we don't know the exact value since it depends on the random response length
 						count := findIntMetric(metricsLines, getFloatBucketMetricPrefix(common.TestModelName, metricName, boundary))
 						Expect(count).ToNot(BeNil())
+						// note: request TPOT is actually measured. we can't assert the exact timing.
+						if boundary == 0.1 && metricName == vllmsim.ReqTPOTMetricName {
+							continue
+						}
 						Expect(*count).To(BeNumerically(">", 0))
 					}
 				}
@@ -603,6 +607,9 @@ var _ = Describe("Simulator metrics", Ordered, func() {
 
 			// validate new inter_token_latency metric
 			validateLatencyMetric(vllmsim.InterTokenLatencyMetricName)
+
+			// validate request tpot metric
+			validateLatencyMetric(vllmsim.ReqTPOTMetricName)
 		}()
 
 		metricsWg.Wait()


### PR DESCRIPTION
## What does this PR do?

implement vllm:request_time_per_output_token_seconds metrics

## Why is this change needed?

vllm compatibility

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
