### PR TITLE
fix: add startupProbe to vllm-render sidecar to gate simulator startup

### DIFF
--- a/deploy/deployments.yaml
+++ b/deploy/deployments.yaml
@@ -15,7 +15,7 @@ spec:
       initContainers:
       # vLLM render sidecar - handles tokenization via HTTP (vllm launch render)
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
-      # vllm-sim will not start until this container's readinessProbe passes
+      # vllm-sim will not start until this container's startupProbe succeeds
       - name: vllm-render
         image: ${VLLM_RENDER_IMAGE}
         imagePullPolicy: IfNotPresent
@@ -28,6 +28,12 @@ spec:
         ports:
         - name: http
           containerPort: 8082
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          periodSeconds: 2
+          failureThreshold: 150
         livenessProbe:
           httpGet:
             path: /health

--- a/helm/llm-d-inference-sim/templates/deployment.yaml
+++ b/helm/llm-d-inference-sim/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       initContainers:
       # vLLM render sidecar - handles tokenization via HTTP (vllm launch render)
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
-      # the simulator will not start until this container's readinessProbe passes
+      # the simulator will not start until this container's startupProbe succeeds
       - name: vllm-render
         image: {{ .Values.vllmRender.image }}
         imagePullPolicy: {{ .Values.vllmRender.imagePullPolicy }}
@@ -43,6 +43,12 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.vllmRender.port }}
+        startupProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.vllmRender.port }}
+          periodSeconds: 2
+          failureThreshold: 150
         livenessProbe:
           httpGet:
             path: /health

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       initContainers:
       # vLLM render sidecar - handles tokenization via HTTP (vllm launch render)
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
-      # the simulator will not start until this container's readinessProbe passes
+      # the simulator will not start until this container's startupProbe succeeds
       - name: vllm-render
         image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
@@ -28,6 +28,12 @@ spec:
         ports:
         - name: http
           containerPort: 8082
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          periodSeconds: 2
+          failureThreshold: 150
         livenessProbe:
           httpGet:
             path: /health

--- a/manifests/deployment_kvcache.yaml
+++ b/manifests/deployment_kvcache.yaml
@@ -15,7 +15,7 @@ spec:
       initContainers:
       # vLLM render sidecar - handles tokenization via HTTP (vllm launch render)
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
-      # vllm-sim will not start until this container's readinessProbe passes
+      # vllm-sim will not start until this container's startupProbe succeeds
       - name: vllm-render
         image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
@@ -25,6 +25,12 @@ spec:
         ports:
         - name: http
           containerPort: 8082
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          periodSeconds: 2
+          failureThreshold: 150
         livenessProbe:
           httpGet:
             path: /health

--- a/manifests/disaggregation/vllm-sim-pd.yaml
+++ b/manifests/disaggregation/vllm-sim-pd.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       # vLLM render sidecar - handles tokenization via HTTP (vllm launch render)
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
-      # vllm-prefill will not start until this container's readinessProbe passes
+      # vllm-prefill will not start until this container's startupProbe succeeds
       - name: vllm-render
         image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
@@ -27,6 +27,12 @@ spec:
         ports:
         - name: http
           containerPort: 8082
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          periodSeconds: 2
+          failureThreshold: 150
         livenessProbe:
           httpGet:
             path: /health
@@ -72,7 +78,7 @@ spec:
       initContainers:
       # vLLM render sidecar - handles tokenization via HTTP (vllm launch render)
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
-      # vllm-decode will not start until this container's readinessProbe passes
+      # vllm-decode will not start until this container's startupProbe succeeds
       - name: vllm-render
         image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
@@ -82,6 +88,12 @@ spec:
         ports:
         - name: http
           containerPort: 8082
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          periodSeconds: 2
+          failureThreshold: 150
         livenessProbe:
           httpGet:
             path: /health

--- a/manifests/zmq-listener/deploy_simulator.yaml
+++ b/manifests/zmq-listener/deploy_simulator.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       # vLLM render sidecar - handles tokenization via HTTP (vllm launch render)
       # restartPolicy: Always makes this a native sidecar (K8s 1.29+):
-      # sim will not start until this container's readinessProbe passes
+      # sim will not start until this container's startupProbe succeeds
       - name: vllm-render
         image: vllm/vllm-openai-cpu:v0.21.0
         imagePullPolicy: IfNotPresent
@@ -27,6 +27,12 @@ spec:
         ports:
         - name: http
           containerPort: 8082
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8082
+          periodSeconds: 2
+          failureThreshold: 150
         livenessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
Fixes #616

## Problem

The `vllm-render` native sidecar (initContainer with `restartPolicy: Always`) defines liveness and readiness probes but no `startupProbe`. For native sidecars, Kubernetes gates the start of subsequent containers on **startupProbe** completion, not readiness. The simulator container could therefore start while the render service was still coming up, fail tokenizer initialization with `dial tcp [::1]:8082: connect: connection refused`, and enter a restart loop, as shown in the issue logs.

## Change

* Add a `startupProbe` on `GET /health` to every `vllm-render` sidecar definition: `deploy/deployments.yaml`, `manifests/deployment.yaml`, `manifests/deployment_kvcache.yaml`, `manifests/zmq-listener/deploy_simulator.yaml`, both deployments in `manifests/disaggregation/vllm-sim-pd.yaml`, and the Helm chart template.
* Probe settings: `periodSeconds: 2`, `failureThreshold: 150` (up to 5 minutes, matching the 300s deployment wait in `kind-deploy.sh`), so slow tokenizer downloads do not fail startup.
* Correct the manifest comments that claimed the readinessProbe provided this startup ordering.

## Validation

* `kubectl kustomize deploy` renders the probe correctly.
* `helm template helm/llm-d-inference-sim` renders the probe correctly.
