### PR TITLE
Include serving port in ZMQ kv-events topic

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,7 +198,7 @@ In addition, as we are using klog, the following parameters are available:
 - `VLLM_SERVER_DEV_MODE`: when set to `1`, enables vLLM development mode. Currently used as an additional gate for the `/sleep` endpoint: even with `--enable-sleep-mode`, `/sleep` is a no-op unless `VLLM_SERVER_DEV_MODE=1` is set in the simulator's environment.
 - `POD_NAME`: the simulator pod name. If defined, the response will contain the HTTP header `x-inference-pod` with this value, and the HTTP header `x-inference-port` with the port that the request was received on 
 - `POD_NAMESPACE`: the simulator pod namespace. If defined, the response will contain the HTTP header `x-inference-namespace` with this value
-- `POD_IP`: the simulator pod IP address. Used in kv-events topic name.
+- `POD_IP`: the simulator pod IP address. Used together with the serving port (`--port`) to build the kv-events topic `kv@<ip>:<port>@<model>` (see [KV cache](kv-cache.md#topic-format)).
 Example of definition in yaml: 
   ```yaml
   env:

--- a/docs/kv-cache.md
+++ b/docs/kv-cache.md
@@ -104,12 +104,14 @@ When `enable-kvcache` is true and `zmq-endpoint` is set, the simulator publishes
 ### Topic format
 
 ```
-kv@<POD_IP>@<model-name>
+kv@<POD_IP>:<serving-port>@<model-name>
 ```
 
-Example: `kv@10.0.0.1@Qwen/Qwen2.5-1.5B-Instruct`
+Example: `kv@10.0.0.1:8000@Qwen/Qwen2.5-1.5B-Instruct`
 
 The model name used is the base model name (`--model`), not a served-model-name alias.
+
+The `<ip>:<port>` pair matches how the EPP prefix-cache scorer addresses pods (as `<Address>:<Port>`), so the block index can look up the pod that owns a cached block. The serving port is the port each simulator instance serves on, so each data-parallel rank publishes on its own topic.
 
 ### Message format
 

--- a/manifests/zmq-listener/README.md
+++ b/manifests/zmq-listener/README.md
@@ -86,7 +86,7 @@ The vLLM deployment configures event publishing via:
   \"enable_kv_cache_events\":true,
   \"publisher\":\"zmq\",
   \"endpoint\":\"tcp://zmq-listener-service:5557\",
-  \"topic\":\"kv@${POD_IP}@Qwen/Qwen3-0.6B\"
+  \"topic\":\"kv@${POD_IP}:8000@Qwen/Qwen3-0.6B\"
 }"
 ```
 

--- a/manifests/zmq-listener/deploy_vllm.yaml
+++ b/manifests/zmq-listener/deploy_vllm.yaml
@@ -28,7 +28,7 @@ spec:
               --block-size 16 \
               --prefix-caching-hash-algo sha256_cbor \
               --kv-transfer-config '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}' \
-              --kv-events-config "{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://zmq-listener-service:5557\",\"topic\":\"kv@${POD_IP}@Qwen/Qwen3-0.6B\"}"
+              --kv-events-config "{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://zmq-listener-service:5557\",\"topic\":\"kv@${POD_IP}:8000@Qwen/Qwen3-0.6B\"}"
           env:
           - name: NAMESPACE
             valueFrom:

--- a/pkg/kv-cache/block_cache.go
+++ b/pkg/kv-cache/block_cache.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -86,7 +87,7 @@ func newBlockCache(ctx context.Context, config *common.Configuration, logger log
 		}
 	}
 
-	topic := CreateKVEventsTopic(config.IP, config.Model)
+	topic := CreateKVEventsTopic(config.IP, config.Port, config.Model)
 
 	var replayer *kvEventsReplayer
 	if config.KVEventsReplayEndpoint != "" {
@@ -454,7 +455,15 @@ func (bc *blockCache) setModelUnloaded(model string) {
 	delete(bc.loadedModels, model)
 }
 
-// ZMQ topic format is: kv@<pod-ip>@<model-name>
-func CreateKVEventsTopic(ip string, model string) string {
-	return topicNamePrefix + topicNameSeparator + ip + topicNameSeparator + model
+// CreateKVEventsTopic builds the ZMQ topic used to publish KV-cache events.
+//
+// The format is: kv@<pod-ip>:<serving-port>@<model-name>
+//
+// The <ip>:<port> pair matches how the EPP prefix-cache scorer addresses pods
+// (as <Address>:<Port>), so the block index can look up the pod that owns a
+// cached block. The serving port is the port each simulator instance serves on
+// (config.Port, offset per rank when one process hosts multiple ranks), so
+// each data-parallel rank publishes on its own topic.
+func CreateKVEventsTopic(ip string, port int, model string) string {
+	return topicNamePrefix + topicNameSeparator + ip + ":" + strconv.Itoa(port) + topicNameSeparator + model
 }

--- a/pkg/kv-cache/kv_cache_test.go
+++ b/pkg/kv-cache/kv_cache_test.go
@@ -151,6 +151,23 @@ func bothFormats(name string, tc testCase) []any {
 	}
 }
 
+var _ = Describe("CreateKVEventsTopic", func() {
+	It("embeds the ip, serving port and model in the topic", func() {
+		Expect(CreateKVEventsTopic("10.0.0.1", 8000, "Qwen/Qwen2.5-1.5B-Instruct")).
+			To(Equal("kv@10.0.0.1:8000@Qwen/Qwen2.5-1.5B-Instruct"))
+	})
+
+	It("uses a distinct topic per data-parallel rank serving port", func() {
+		model := "Qwen/Qwen2.5-1.5B-Instruct"
+		topic0 := CreateKVEventsTopic("10.0.0.1", 8000, model)
+		topic1 := CreateKVEventsTopic("10.0.0.1", 8001, model)
+		topic2 := CreateKVEventsTopic("10.0.0.1", 8002, model)
+		Expect(topic0).NotTo(Equal(topic1))
+		Expect(topic0).NotTo(Equal(topic2))
+		Expect(topic1).NotTo(Equal(topic2))
+	})
+})
+
 var _ = Describe("KV cache", Ordered, func() {
 	random := common.NewRandom(time.Now().UnixNano(), 8080)
 
@@ -242,7 +259,7 @@ var _ = Describe("KV cache", Ordered, func() {
 			UseVllmMapEventFormat: useMapFormat,
 		}
 
-		topic := CreateKVEventsTopic(localhost, config.Model)
+		topic := CreateKVEventsTopic(localhost, config.Port, config.Model)
 		sub, endpoint := common.CreateSub(ctx, topic)
 		config.ZMQEndpoint = endpoint
 		//nolint
@@ -347,7 +364,7 @@ var _ = Describe("KV cache", Ordered, func() {
 				UseVllmMapEventFormat: useMapFormat,
 			}
 
-			topic := CreateKVEventsTopic(localhost, config.Model)
+			topic := CreateKVEventsTopic(localhost, config.Port, config.Model)
 			sub, endpoint := common.CreateSub(ctx, topic)
 			config.ZMQEndpoint = endpoint
 			//nolint
@@ -447,7 +464,7 @@ var _ = Describe("KV cache", Ordered, func() {
 				UseVllmMapEventFormat: useMapFormat,
 			}
 
-			topic := CreateKVEventsTopic(localhost, config.Model)
+			topic := CreateKVEventsTopic(localhost, config.Port, config.Model)
 			sub, endpoint := common.CreateSub(ctx, topic)
 			config.ZMQEndpoint = endpoint
 			//nolint
@@ -836,7 +853,7 @@ var _ = Describe("KV cache", Ordered, func() {
 				UseVllmMapEventFormat: useMapFormat,
 			}
 
-			topic := CreateKVEventsTopic(localhost, config.Model)
+			topic := CreateKVEventsTopic(localhost, config.Port, config.Model)
 			sub, endpoint := common.CreateSub(ctx, topic)
 			config.ZMQEndpoint = endpoint
 			//nolint
@@ -927,7 +944,7 @@ var _ = Describe("KV cache", Ordered, func() {
 				UseVllmMapEventFormat: useMapFormat,
 			}
 
-			topic := CreateKVEventsTopic(localhost, config.Model)
+			topic := CreateKVEventsTopic(localhost, config.Port, config.Model)
 			sub, endpoint := common.CreateSub(ctx, topic)
 			config.ZMQEndpoint = endpoint
 			//nolint

--- a/pkg/llm-d-inference-sim/simulator.go
+++ b/pkg/llm-d-inference-sim/simulator.go
@@ -131,6 +131,10 @@ func Start(ctx context.Context, config *common.Configuration, logger logr.Logger
 		if err != nil {
 			return nil, err
 		}
+		// Offset the serving port per rank only in --data-parallel-size mode
+		// (all ranks share one pod IP, so they must differ by port). In
+		// --data-parallel-rank mode each rank is a separate pod (distinct IP),
+		// so the serving port stays at --port as started.
 		if dpRank > 0 {
 			rankConfig.Port = config.Port + dpRank
 		}

--- a/pkg/tests/data_parallel_test.go
+++ b/pkg/tests/data_parallel_test.go
@@ -67,24 +67,31 @@ var _ = Describe("Data Parallel", func() {
 		model := common.QwenModelName
 		longPrompt := "This is a test message for kv cache events, has to be long enough to be tokenized into multiple blocks."
 
-		// Rank 0 gets a random port; ranks 1 and 2 get port+1 and port+2 respectively
-		// (the simulator calls common.OffsetEndpointPort(base, rank) for ranks > 0).
-		topic := kvcache.CreateKVEventsTopic("localhost", model)
-		sub0, zmqEndpoint := common.CreateSub(ctx, topic)
+		// Each data-parallel rank serves on its own port (baseServingPort + rank)
+		// and therefore publishes KV events on a per-rank topic
+		// kv@<ip>:<port>@<model>, so the EPP block index can distinguish ranks.
+		// Rank 0's ZMQ PUB endpoint gets a random port; ranks 1 and 2 get port+1
+		// and port+2 respectively (the simulator calls
+		// common.OffsetEndpointPort(base, rank) for ranks > 0).
+		const baseServingPort = 8000
+		topic0 := kvcache.CreateKVEventsTopic("localhost", baseServingPort, model)
+		sub0, zmqEndpoint := common.CreateSub(ctx, topic0)
 		defer sub0.Close() //nolint:errcheck
 
-		// Derive fixed endpoints for rank 1 and rank 2 from rank 0's port.
+		// Derive fixed ZMQ endpoints for rank 1 and rank 2 from rank 0's port.
 		lastColon := strings.LastIndex(zmqEndpoint, ":")
 		Expect(lastColon).To(BeNumerically(">", 0))
-		basePort, err := strconv.Atoi(zmqEndpoint[lastColon+1:])
+		baseZMQPort, err := strconv.Atoi(zmqEndpoint[lastColon+1:])
 		Expect(err).NotTo(HaveOccurred())
 
+		topic1 := kvcache.CreateKVEventsTopic("localhost", baseServingPort+1, model)
 		sub1 := common.NewSub(ctx)
-		common.StartSub(sub1, fmt.Sprintf("tcp://*:%d", basePort+1), topic)
+		common.StartSub(sub1, fmt.Sprintf("tcp://*:%d", baseZMQPort+1), topic1)
 		defer sub1.Close() //nolint:errcheck
 
+		topic2 := kvcache.CreateKVEventsTopic("localhost", baseServingPort+2, model)
 		sub2 := common.NewSub(ctx)
-		common.StartSub(sub2, fmt.Sprintf("tcp://*:%d", basePort+2), topic)
+		common.StartSub(sub2, fmt.Sprintf("tcp://*:%d", baseZMQPort+2), topic2)
 		defer sub2.Close() //nolint:errcheck
 
 		clients, err := startDataParallelServers(ctx, []string{
@@ -92,6 +99,7 @@ var _ = Describe("Data Parallel", func() {
 			"--model", model,
 			"--mode", common.ModeRandom,
 			"--data-parallel-size", "3",
+			"--port", strconv.Itoa(baseServingPort),
 			"--force-dummy-tokenizer",
 			"--enable-kvcache", "true", "--kv-cache-size", "16", "--block-size", "8",
 			"--event-batch-size", "1", "--zmq-endpoint", zmqEndpoint,
@@ -119,12 +127,14 @@ var _ = Describe("Data Parallel", func() {
 			}()
 		}
 
-		// Assert that each rank published at least one store event on its own endpoint,
-		// and that the DataParallelRank embedded in the batch matches the rank index.
+		// Assert that each rank published at least one store event on its own
+		// per-rank topic, and that the DataParallelRank embedded in the batch
+		// matches the rank index.
+		rankTopics := []string{topic0, topic1, topic2}
 		for expectedRank, sub := range []zmq4.Socket{sub0, sub1, sub2} {
 			msg, err := sub.Recv()
 			Expect(err).NotTo(HaveOccurred())
-			storedCount, removedCount, _ := kvcache.CountKVEventBlocks(msg.Frames, topic, 1)
+			storedCount, removedCount, _ := kvcache.CountKVEventBlocks(msg.Frames, rankTopics[expectedRank], 1)
 			Expect(storedCount).To(BeNumerically(">", 0), "expected store events from rank %d", expectedRank)
 			Expect(removedCount).To(Equal(0))
 			Expect(kvcache.ParseKVBatchRank(msg.Frames)).To(Equal(expectedRank),

--- a/pkg/tests/http_server_test.go
+++ b/pkg/tests/http_server_test.go
@@ -498,7 +498,7 @@ var _ = Describe("Server", func() {
 		It("Should enter sleep mode and wake up", func() {
 			ctx := context.TODO()
 
-			topic := kvcache.CreateKVEventsTopic("localhost", common.QwenModelName)
+			topic := kvcache.CreateKVEventsTopic("localhost", 8000, common.QwenModelName)
 			sub, endpoint := common.CreateSub(ctx, topic)
 
 			client, err := startServerWithArgsAndEnv(ctx, common.ModeRandom,

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -1006,7 +1006,7 @@ var _ = Describe("Simulator", func() {
 
 		It("chat completions", func() {
 			// create kv events listener
-			topic := kvcache.CreateKVEventsTopic("localhost", model)
+			topic := kvcache.CreateKVEventsTopic("localhost", 8000, model)
 			sub, zmqEndpoint := common.CreateSub(ctx, topic)
 			//nolint
 			defer sub.Close()
@@ -1037,7 +1037,7 @@ var _ = Describe("Simulator", func() {
 
 		It("completions", func() {
 			// create kv events listener
-			topic := kvcache.CreateKVEventsTopic("localhost", model)
+			topic := kvcache.CreateKVEventsTopic("localhost", 8000, model)
 			sub, zmqEndpoint := common.CreateSub(ctx, topic)
 			//nolint
 			defer sub.Close()
@@ -1075,7 +1075,7 @@ var _ = Describe("Simulator", func() {
 				// (ParentHash == 0 / EmptyBlockHash). The second extends the prompt by one
 				// extra block; its store event must carry the hash of the last block from
 				// the first request as parent.
-				topic := kvcache.CreateKVEventsTopic("localhost", model)
+				topic := kvcache.CreateKVEventsTopic("localhost", 8000, model)
 				sub, zmqEndpoint := common.CreateSub(ctx, topic)
 				//nolint
 				defer sub.Close()
@@ -1239,7 +1239,7 @@ force-dummy-tokenizer: false
 		// Returns the HTTP client, the PUB subscriber (for watching live events),
 		// the topic, and the replay endpoint the simulator was told to bind.
 		setupReplayServer := func(ctx context.Context) (*http.Client, zmq4.Socket, string, string) {
-			topic := kvcache.CreateKVEventsTopic("localhost", replayModel)
+			topic := kvcache.CreateKVEventsTopic("localhost", 8000, replayModel)
 			sub, zmqEndpoint := common.CreateSub(ctx, topic)
 
 			replayPort, err := common.FreeTCPPort()
@@ -1271,7 +1271,7 @@ force-dummy-tokenizer: false
 					break
 				}
 				seq := binary.BigEndian.Uint64(msg.Frames[1])
-				stored, _, _ := kvcache.CountKVEventBlocks(msg.Frames, kvcache.CreateKVEventsTopic("localhost", replayModel), seq)
+				stored, _, _ := kvcache.CountKVEventBlocks(msg.Frames, kvcache.CreateKVEventsTopic("localhost", 8000, replayModel), seq)
 				totalStored += stored
 				lastSeq = seq
 			}


### PR DESCRIPTION
## What does this PR do?

Builds the ZMQ KV-event topic as `kv@<ip>:<port>@<model>` by including the
simulator's serving port, instead of the previous `kv@<ip>@<model>`. The port is
taken from the per-rank configuration (the port each simulator instance serves
on), so each data-parallel rank publishes on its own topic.

## Why is this change needed?

Bug fix for cache-aware (prefix-cache) routing between `llm-d-inference-sim` and
the EPP prefix-cache scorer:

- The simulator emitted KV-cache events on topic `kv@<ip>@<model>`, keyed by the
  pod IP from `POD_IP`.
- The EPP prefix-cache scorer looks up pods by `<Address>:<Port>`
  ([llm-d-router](https://github.com/llm-d/llm-d-router/blob/dd65342ee538ab76d4b9f7e1efb5d8e95385d06e/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go#L379)).
- The mismatch (`<ip>` vs `<ip>:<port>`) meant the block index never matched, so
  the scorer reported no cache hits and cache-aware routing was effectively
  disabled.

Including the serving port makes the topic match the scorer's addressing, so the
block index can find the pod that owns a cached block. This also keeps the
simulator in sync with real vLLM, which configures the same `<ip>:<port>` topic
via `--kv-events-config`.

For data-parallel deployments, the serving port is the port each rank's
simulator instance serves on:

- `--data-parallel-size N` (all ranks in one process): ranks 1..N-1 serve on
  `--port+1`..`--port+N-1`, so each gets a distinct `<ip>:<port>` topic under
  the shared pod IP.
- `--data-parallel-rank R` (one process per rank, each its own pod): each rank
  serves on its own `--port` and has a distinct `POD_IP`, so topics already
  differ and the serving port needs no offset.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [x] Manual testing performed

### Manual Testing

#### Logs without fix applied

Prepare the dev environment from dd72f043, using the llm-d-router dev environment from https://github.com/llm-d/llm-d-router/pull/2426:

```sh
# In llm-d-inference-sim
$ git checkout dd72f043
$ SIM_TAG=dd72f043 make image-build
# In llm-d-router
$ VLLM_SIMULATOR_TAG=dd72f043 VLLM_REPLICA_COUNT_D=2 KV_CACHE_ENABLED=true make env-dev-kind
```

Send the prompt:

```sh
$ PREFIX="Prefix to make the prompt large enough (16 tokens by default) to force hit cache in next attempt."
$ curl -s http://localhost:30080/v1/completions -d "{\"model\":\"TinyLlama/TinyLlama-1.1B-Chat-v1.0\",\"prompt\":\"${PREFIX} Say hello.\",\"max_tokens\":10,\"temperature\":0}" | jq
```

See logs

```sh
$ kubectl logs -f deployments/tinyllama-1-1b-chat-v1-0-endpoint-picker
{"level":"debug","ts":1787003362.3830872,"caller":"scheduling/scheduler_profile.go:217","msg":"Calculated score","x-request-id":"e5c3fbb1-af88-4242-a59a-8ac0ba920172","objectiveKey":"","incomingModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","targetModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","priority":0,"plugin":"prefix-cache-scorer/prefix-cache-scorer","endpoint":{"name":"vllm-d-c54d97cc4-rnpbb-rank-0","namespace":"default"},"score":0}
{"level":"debug","ts":1787003362.3830957,"caller":"scheduling/scheduler_profile.go:217","msg":"Calculated score","x-request-id":"e5c3fbb1-af88-4242-a59a-8ac0ba920172","objectiveKey":"","incomingModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","targetModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","priority":0,"plugin":"prefix-cache-scorer/prefix-cache-scorer","endpoint":{"name":"vllm-d-c54d97cc4-hgkl4-rank-0","namespace":"default"},"score":0}
```

Even if we repeat the prompt, the scores remain 0.

#### Logs with fix applied

```sh
# In llm-d-inference-sim
$ git checkout b10e054c
$ SIM_TAG=dev make image-build
# In llm-d-router
$ VLLM_SIMULATOR_TAG=dev VLLM_REPLICA_COUNT_D=2 KV_CACHE_ENABLED=true make env-dev-kind
```

Send the prompt twice:

```sh
$ PREFIX="Prefix to make the prompt large enough (16 tokens by default) to force hit cache in next attempt."
$ curl -s http://localhost:30080/v1/completions -d "{\"model\":\"TinyLlama/TinyLlama-1.1B-Chat-v1.0\",\"prompt\":\"${PREFIX} Say hello.\",\"max_tokens\":10,\"temperature\":0}" | jq
$ curl -s http://localhost:30080/v1/completions -d "{\"model\":\"TinyLlama/TinyLlama-1.1B-Chat-v1.0\",\"prompt\":\"${PREFIX} Say hello.\",\"max_tokens\":10,\"temperature\":0}" | jq
```

See logs

```sh
$ kubectl logs -f deployments/tinyllama-1-1b-chat-v1-0-endpoint-picker
{"level":"debug","ts":1787071620.7134564,"caller":"scheduling/scheduler_profile.go:217","msg":"Calculated score","x-request-id":"a491b43b-53cb-4b9d-ab8e-cd82fcd7b682","objectiveKey":"","incomingModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","targetModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","priority":0,"plugin":"prefix-cache-scorer/prefix-cache-scorer","endpoint":{"name":"vllm-d-999bcd8d5-j2kq5-rank-0","namespace":"default"},"score":0}
{"level":"debug","ts":1787071620.713466,"caller":"scheduling/scheduler_profile.go:217","msg":"Calculated score","x-request-id":"a491b43b-53cb-4b9d-ab8e-cd82fcd7b682","objectiveKey":"","incomingModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","targetModelName":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","priority":0,"plugin":"prefix-cache-scorer/prefix-cache-scorer","endpoint":{"name":"vllm-d-999bcd8d5-97gnh-rank-0","namespace":"default"},"score":1}
```

After the second request, the pod that cached the prefix scores 1 while the other stays 0, so the scorer routes to it.


## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [X] Tests pass locally (`make test`)
- [X] Linters pass (`make lint`)
- [X] Documentation updated (if applicable)

## Related Issues

