### PR TITLE
fix: tolerate tool schemas that omit properties or items

### DIFF
--- a/pkg/llm-d-inference-sim/tools_arg_generator_test.go
+++ b/pkg/llm-d-inference-sim/tools_arg_generator_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmdinferencesim
+
+import (
+	"encoding/json"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("createArgument with under-specified schemas", func() {
+	var (
+		config *common.Configuration
+		random *common.Random
+	)
+
+	BeforeEach(func() {
+		config = &common.Configuration{
+			Model:                                     "test",
+			ServedModelNames:                          []string{"test"},
+			MinToolCallArrayParamLength:               1,
+			MaxToolCallArrayParamLength:               5,
+			MinToolCallIntegerParam:                   0,
+			MaxToolCallIntegerParam:                   10,
+			MinToolCallNumberParam:                    0,
+			MaxToolCallNumberParam:                    10,
+			ObjectToolCallNotRequiredParamProbability: 100,
+		}
+		random = common.NewRandom(0, 0)
+	})
+
+	// property unmarshals a JSON schema fragment the way production code receives it.
+	property := func(schemaJSON string) any {
+		var value any
+		Expect(json.Unmarshal([]byte(schemaJSON), &value)).To(Succeed())
+		return value
+	}
+
+	It("generates an empty array when an array property omits items", func() {
+		arg, err := createArgument(property(`{"type": "array"}`), config, random)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arg).To(BeAssignableToTypeOf([]any{}))
+		Expect(arg).To(BeEmpty())
+	})
+
+	It("generates an empty object when an object property omits properties", func() {
+		arg, err := createArgument(property(`{"type": "object"}`), config, random)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arg).To(BeAssignableToTypeOf(map[string]any{}))
+		Expect(arg).To(BeEmpty())
+	})
+
+	It("still generates nested values when properties are present", func() {
+		arg, err := createArgument(
+			property(`{"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}`),
+			config, random)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arg).To(HaveKey("city"))
+	})
+})

--- a/pkg/llm-d-inference-sim/tools_utils.go
+++ b/pkg/llm-d-inference-sim/tools_utils.go
@@ -295,8 +295,11 @@ func createArgument(property any, config *common.Configuration, random *common.R
 	case "boolean":
 		return random.FlipCoin(), nil
 	case "array":
-		items := propertyMap["items"]
-		itemsMap := items.(map[string]any)
+		// A schema may omit items; there is no element shape to generate from.
+		itemsMap, ok := propertyMap["items"].(map[string]any)
+		if !ok {
+			return []any{}, nil
+		}
 		minItems := config.MinToolCallArrayParamLength
 		maxItems := config.MaxToolCallArrayParamLength
 		if value, ok := propertyMap["minItems"]; ok {
@@ -320,7 +323,11 @@ func createArgument(property any, config *common.Configuration, random *common.R
 		return array, nil
 	case "object":
 		required := getRequiredAsMap(propertyMap)
-		objectProperties := propertyMap["properties"].(map[string]any)
+		// A schema may omit properties; there are no fields to generate.
+		objectProperties, ok := propertyMap["properties"].(map[string]any)
+		if !ok {
+			return map[string]any{}, nil
+		}
 		object := make(map[string]interface{})
 		for fieldName, fieldProperties := range objectProperties {
 			_, fieldIsRequired := required[fieldName]


### PR DESCRIPTION
## What does this PR do?

Makes the tool-call argument generator tolerate schemas that declare an array or object without describing its contents. `createArgument` asserted `propertyMap["items"]` and `propertyMap["properties"]` unconditionally; both are now comma-ok, yielding an empty array and an empty object respectively.

## Why is this change needed?

Both assertions panic when the field is absent:

```
interface conversion: interface {} is nil, not map[string]interface {}
```

`"type": "object"` with no `properties` and `"type": "array"` with no `items` are valid JSON Schema, and real vLLM accepts them because it forwards the schema to the model instead of synthesizing arguments. The sim crashes the request instead, which blocks load tests against representative tool suites.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual testing performed

New unit tests cover the generator's handling of under-specified schemas: an array property with no `items` produces an empty array, an object property with no `properties` produces an empty object, and an object that does declare `properties` still generates its nested values. Each test was confirmed to panic at the two call sites before the fix.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

`make presubmit` and `make test` both pass locally: all 8 suites green. No user-facing behavior or flags change, so no documentation update applies.

## Related Issues

Fixes #636
