### PR TITLE
fix: normalize JSON Schema type in the tool argument generator

### DIFF
--- a/pkg/llm-d-inference-sim/tools_arg_type_test.go
+++ b/pkg/llm-d-inference-sim/tools_arg_type_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmdinferencesim
+
+import (
+	"encoding/json"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("createArgument type normalization", func() {
+	var (
+		config *common.Configuration
+		random *common.Random
+	)
+
+	BeforeEach(func() {
+		config = &common.Configuration{
+			Model:                                     "test",
+			ServedModelNames:                          []string{"test"},
+			MinToolCallArrayParamLength:               1,
+			MaxToolCallArrayParamLength:               3,
+			MinToolCallIntegerParam:                   0,
+			MaxToolCallIntegerParam:                   10,
+			MinToolCallNumberParam:                    0,
+			MaxToolCallNumberParam:                    10,
+			ObjectToolCallNotRequiredParamProbability: 100,
+		}
+		random = common.NewRandom(0, 0)
+	})
+
+	// property unmarshals a JSON schema fragment the way production code receives it.
+	property := func(schemaJSON string) any {
+		var value any
+		Expect(json.Unmarshal([]byte(schemaJSON), &value)).To(Succeed())
+		return value
+	}
+
+	It("treats a property with no type as a string", func() {
+		arg, err := createArgument(property(`{"description": "a field"}`), config, random)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arg).To(BeAssignableToTypeOf(""))
+	})
+
+	It("resolves a nullable object union to its object branch", func() {
+		arg, err := createArgument(
+			property(`{"type": ["null", "object"], "properties": {"city": {"type": "string"}}, "required": ["city"]}`),
+			config, random)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arg).To(HaveKey("city"))
+	})
+
+	It("resolves a nullable array union to its array branch", func() {
+		arg, err := createArgument(
+			property(`{"type": ["null", "array"], "items": {"type": "string"}}`),
+			config, random)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arg).To(BeAssignableToTypeOf([]any{}))
+		Expect(arg).NotTo(BeEmpty())
+	})
+
+	It("resolves a union to its first non-null branch regardless of position", func() {
+		arg, err := createArgument(property(`{"type": ["string", "null"]}`), config, random)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arg).To(BeAssignableToTypeOf(""))
+	})
+
+	It("generates null for a property typed only null", func() {
+		arg, err := createArgument(property(`{"type": "null"}`), config, random)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(arg).To(BeNil())
+	})
+
+	It("still rejects a genuinely unsupported type", func() {
+		_, err := createArgument(property(`{"type": "wombat"}`), config, random)
+
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/llm-d-inference-sim/tools_utils.go
+++ b/pkg/llm-d-inference-sim/tools_utils.go
@@ -34,6 +34,10 @@ const (
 	toolChoiceRequired = "required"
 )
 
+// paramTypeNull is the JSON Schema type keyword for a property whose only
+// permitted value is null.
+const paramTypeNull = "null"
+
 var fakeStringArguments = []string{
 	`testing`,
 	`hello`,
@@ -271,9 +275,29 @@ func getRequiredAsMap(property map[string]any) map[string]struct{} {
 	return required
 }
 
+// resolveParamType normalizes the JSON Schema type keyword, which may be a single
+// string, a union of strings, or absent, into the one type the generator handles.
+// A union resolves to its first non-null member, matching the value a model would
+// most likely produce for an optional field.
+func resolveParamType(paramType any) any {
+	switch typeValue := paramType.(type) {
+	case nil:
+		return "string"
+	case []any:
+		for _, member := range typeValue {
+			if name, ok := member.(string); ok && name != paramTypeNull {
+				return name
+			}
+		}
+		return paramTypeNull
+	default:
+		return paramType
+	}
+}
+
 func createArgument(property any, config *common.Configuration, random *common.Random) (any, error) {
 	propertyMap, _ := property.(map[string]any)
-	paramType := propertyMap["type"]
+	paramType := resolveParamType(propertyMap["type"])
 
 	// If there is an enum, choose from it
 	enum, ok := propertyMap["enum"]
@@ -294,6 +318,8 @@ func createArgument(property any, config *common.Configuration, random *common.R
 		return random.RandomFloat(config.MinToolCallNumberParam, config.MaxToolCallNumberParam), nil
 	case "boolean":
 		return random.FlipCoin(), nil
+	case paramTypeNull:
+		return nil, nil
 	case "array":
 		items := propertyMap["items"]
 		itemsMap := items.(map[string]any)


### PR DESCRIPTION
## What does this PR do?

Resolves the JSON Schema `type` keyword before `createArgument` switches on it. A union takes its first non-null member, an absent `type` defaults to `string`, and a property typed only `null` generates JSON null.

## Why is this change needed?

The generator switched on the raw keyword as a single concrete string, so schemas that JSON Schema permits and real vLLM accepts were rejected:

```
err="tool parameters of type %!s(<nil>) are not supported"
err="tool parameters of type [null object] are not supported"
err="tool parameters of type [null array] are not supported"
```

Nullable unions are how tool definitions commonly express an optional field, so this blocks load tests against representative tool suites.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual testing performed

New unit tests cover each normalization branch: an absent `type` yields a string, a nullable union resolves to its object and array branches, a union resolves to its first non-null member regardless of position, a null-only type yields JSON null, and a genuinely unsupported type still returns an error. Every test was confirmed to fail with the errors above before the change.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

`make presubmit` and `make test` both pass locally: all 8 suites green. No user-facing behavior or flags change, so no documentation update applies.

## Related Issues

Fixes #638

Branched from `main` rather than from #639 so the two can merge in either order. Both edit `createArgument`, so whichever lands second will need a small rebase - happy to do that whenever it is useful.
