### PR TITLE
Add Engine abstraction selected via --engine

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
   pull_request:
     branches:
       - main
+      - 'release-*'
 
 jobs:
   check-changes:

--- a/cmd/llm-d-inference-sim/main.go
+++ b/cmd/llm-d-inference-sim/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
 	"github.com/llm-d/llm-d-inference-sim/pkg/communication"
+	"github.com/llm-d/llm-d-inference-sim/pkg/engine"
 	"github.com/llm-d/llm-d-inference-sim/pkg/simulator"
 )
 
@@ -36,10 +37,18 @@ func main() {
 	ctx := klog.NewContext(context.Background(), logger)
 	ctx = signals.SetupSignalHandler(ctx)
 
-	logger.V(logging.INFO).Info("Starting inference simulator")
+	// the engine must be resolved before the rest of the configuration, since it
+	// determines which configuration defaults apply
+	eng, err := engine.Resolve()
+	if err != nil {
+		logger.Error(err, "failed to resolve engine")
+		return
+	}
+
+	logger.V(logging.INFO).Info("Starting inference simulator", "engine", eng.Name())
 
 	// parse command line parameters
-	config, err := common.ParseCommandParamsAndLoadConfig()
+	config, err := common.ParseCommandParamsAndLoadConfig(eng.NewConfiguration())
 	if err != nil {
 		logger.Error(err, "failed to read configuration")
 		return
@@ -49,7 +58,7 @@ func main() {
 		return
 	}
 
-	simulators, err := simulator.Start(ctx, config, logger)
+	simulators, err := simulator.Start(ctx, eng, config, logger)
 	if err != nil {
 		logger.Error(err, "failed to create inference simulator")
 		return

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ For a setting that can come from a YAML file, an environment variable, and comma
 Some environment variables (for example `POD_NAME`, `POD_NAMESPACE`) are not overrides of a YAML field in this sense; they populate separate runtime fields after parsing.
 
 ## General
+- `engine`: the inference engine to simulate; determines which configuration defaults apply. Currently the only supported value is `vllm` (the default when omitted). Unlike other settings, `engine` is resolved before the rest of the configuration: a command-line `--engine` wins, otherwise the `engine` key of the `--config` file (if any) is used, otherwise the default applies. This still follows the normal [configuration precedence](#configuration-precedence); it is just resolved earlier because it decides which defaults get built in the first place.
 - `config`: the path to a yaml configuration file that can contain the simulator's command line parameters. If a parameter is defined in both the config file and the command line, the command line value overwrites the configuration file value. An example configuration file can be found at [manifests/config.yaml](../manifests/config.yaml)
 - `port`: the port the simulator listens on, default is 8000
 - `max-request-body-size-mb`: maximum allowed size of an HTTP request body in megabytes, optional, default is 4 (matching the fasthttp built-in default). Must be between 1 and 512.

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -352,6 +352,10 @@ type Configuration struct {
 	// MaxRequestBodySizeMB sets the maximum allowed request body size in megabytes for the HTTP server.
 	// Default is 4 (matching the fasthttp built-in default). Must be between 1 and 512.
 	MaxRequestBodySizeMB int `yaml:"max-request-body-size-mb" json:"max-request-body-size-mb"`
+
+	// Engine identifies the inference engine being simulated, selected via --engine or
+	// the YAML config file's "engine" key. Currently always "vllm".
+	Engine string `yaml:"engine" json:"engine"`
 }
 
 type LoraModule struct {
@@ -363,7 +367,9 @@ type LoraModule struct {
 	BaseModelName string `json:"base_model_name"`
 }
 
-func newConfig() *Configuration {
+// NewConfiguration returns a Configuration populated with the simulator's built-in
+// defaults, before any engine-specific, YAML, or command-line overrides are applied.
+func NewConfiguration() *Configuration {
 	return &Configuration{
 		IP:                                  os.Getenv(podIPEnv),
 		Port:                                8000,
@@ -416,6 +422,25 @@ func (c *Configuration) load(configFile string) error {
 	}
 
 	return nil
+}
+
+// PeekEngineFromFile reads just the "engine" key out of a YAML configuration file,
+// without requiring the rest of the Configuration schema. Used to resolve which engine
+// to use before its defaults have been constructed. Returns "" if the file has no
+// "engine" key.
+func PeekEngineFromFile(path string) (string, error) {
+	configBytes, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read configuration file: %s", err)
+	}
+
+	var probe struct {
+		Engine string `yaml:"engine"`
+	}
+	if err := yaml.Unmarshal(configBytes, &probe); err != nil {
+		return "", fmt.Errorf("failed to unmarshal configuration: %s", err)
+	}
+	return probe.Engine, nil
 }
 
 func (c *Configuration) validate() error {

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -32,11 +32,11 @@ func createSimConfig(args []string) (*Configuration, error) {
 	}()
 	os.Args = args
 
-	return ParseCommandParamsAndLoadConfig()
+	return ParseCommandParamsAndLoadConfig(NewConfiguration())
 }
 
 func createConfigWithModel(model string, servedModelNames []string) *Configuration {
-	c := newConfig()
+	c := NewConfiguration()
 
 	c.Model = model
 	if len(servedModelNames) > 0 {

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -95,20 +95,24 @@ func addToggle(f *pflag.FlagSet, ptr *bool, name, nameUsage, noNameUsage string)
 
 // ParseCommandParamsAndLoadConfig loads configuration, parses command line parameters, merges the values
 // (command line overwrites the config file; see documentation for configuration precedence involving environment variables),
-// and validates the configuration.
-func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
-	config := newConfig()
+// and validates the configuration. config must already carry the engine-specific defaults
+// (see engine.Engine.NewConfiguration) to build on top of.
+func ParseCommandParamsAndLoadConfig(config *Configuration) (*Configuration, error) {
+	// The engine was already resolved (and its defaults applied to config) before this
+	// function runs. A YAML file loaded below could carry its own "engine" key that
+	// disagrees with that resolution; keep the originally-resolved value authoritative.
+	resolvedEngine := config.Engine
 
-	configFileValues := getParamValueFromArgs("config")
+	configFileValues := GetParamValueFromArgs("config")
 	if len(configFileValues) == 1 {
 		if err := config.load(configFileValues[0]); err != nil {
 			return nil, err
 		}
 	}
 
-	servedModelNames := getParamValueFromArgs("served-model-name")
-	loraModuleNames := getParamValueFromArgs("lora-modules")
-	fakeMetrics := getParamValueFromArgs("fake-metrics")
+	servedModelNames := GetParamValueFromArgs("served-model-name")
+	loraModuleNames := GetParamValueFromArgs("lora-modules")
+	fakeMetrics := GetParamValueFromArgs("fake-metrics")
 
 	f := pflag.NewFlagSet("llm-d-inference-sim flags", pflag.ContinueOnError)
 
@@ -182,7 +186,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.BoolVar(&config.SkipToolValidation, "skip-tool-validation", config.SkipToolValidation, "Skip the built-in validation of incoming tool schemas, matching real vLLM which forwards them to the model verbatim")
 
 	f.IntVar(&config.FailureInjectionRate, "failure-injection-rate", config.FailureInjectionRate, "Probability (0-100) of injecting failures")
-	failureTypes := getParamValueFromArgs("failure-types")
+	failureTypes := GetParamValueFromArgs("failure-types")
 	var dummyFailureTypes multiString
 	failureTypesDescription := fmt.Sprintf("List of specific failure types to inject (%s, %s, %s, %s, %s, %s)",
 		FailureTypeRateLimit, FailureTypeInvalidAPIKey, FailureTypeContextLength, FailureTypeServerError, FailureTypeInvalidRequest,
@@ -220,9 +224,11 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 		"enable-prefix-caching", "Enable prefix caching, ignored", "Disable prefix caching, ignored")
 	f.IntVar(&config.TPSize, "tensor-parallel-size", config.TPSize, "Number of tensor parallel replicas, ignored")
 
-	// These values were manually parsed above in getParamValueFromArgs, we leave this in order to get these flags in --help
+	// These values were manually parsed above in GetParamValueFromArgs, we leave this in order to get these flags in --help
 	var dummyString string
 	f.StringVar(&dummyString, "config", "", "The path to a yaml configuration file. The command line values overwrite the configuration file values")
+	var dummyEngine string
+	f.StringVar(&dummyEngine, "engine", "", "The inference engine to simulate; determines which configuration defaults apply. Currently the only supported value is 'vllm' (the default). Read before any other flag, so it also accepts the config file's 'engine' key")
 	var dummyMultiString multiString
 	f.Var(&dummyMultiString, "served-model-name", "Model names exposed by the API (a list of space-separated strings)")
 	f.Var(&dummyMultiString, "lora-modules", "List of LoRA adapters (a list of space-separated JSON strings)")
@@ -289,6 +295,8 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 		}
 	}
 
+	config.Engine = resolvedEngine
+
 	if err := config.validate(); err != nil {
 		return nil, err
 	}
@@ -296,7 +304,10 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	return config, nil
 }
 
-func getParamValueFromArgs(param string) []string {
+// GetParamValueFromArgs hand-reads a flag's value(s) directly from os.Args, ahead of
+// the full pflag.FlagSet, for settings (like --config and --engine) that must be known
+// before the rest of the configuration can be built.
+func GetParamValueFromArgs(param string) []string {
 	var values []string
 	var readValues bool
 	for _, arg := range os.Args[1:] {

--- a/pkg/communication/http_server_test.go
+++ b/pkg/communication/http_server_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Server", func() {
 			}()
 
 			os.Args = []string{"cmd", "--model", common.TestModelName, "--ssl-certfile", certFile, "--ssl-keyfile", keyFile}
-			config, err := common.ParseCommandParamsAndLoadConfig()
+			config, err := common.ParseCommandParamsAndLoadConfig(common.NewConfiguration())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config.SSLEnabled()).To(BeTrue())
 			Expect(config.SSLCertFile).To(Equal(certFile))
@@ -53,7 +53,7 @@ var _ = Describe("Server", func() {
 			}()
 
 			os.Args = []string{"cmd", "--model", common.TestModelName, "--self-signed-certs"}
-			config, err := common.ParseCommandParamsAndLoadConfig()
+			config, err := common.ParseCommandParamsAndLoadConfig(common.NewConfiguration())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config.SSLEnabled()).To(BeTrue())
 			Expect(config.SelfSignedCerts).To(BeTrue())
@@ -78,7 +78,7 @@ var _ = Describe("Server", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			os.Args = []string{"cmd", "--model", common.TestModelName, "--ssl-certfile", certFile}
-			_, err = common.ParseCommandParamsAndLoadConfig()
+			_, err = common.ParseCommandParamsAndLoadConfig(common.NewConfiguration())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("both ssl-certfile and ssl-keyfile must be provided together"))
 
@@ -86,7 +86,7 @@ var _ = Describe("Server", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			os.Args = []string{"cmd", "--model", common.TestModelName, "--ssl-keyfile", keyFile}
-			_, err = common.ParseCommandParamsAndLoadConfig()
+			_, err = common.ParseCommandParamsAndLoadConfig(common.NewConfiguration())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("both ssl-certfile and ssl-keyfile must be provided together"))
 		})

--- a/pkg/communication/send_response_test.go
+++ b/pkg/communication/send_response_test.go
@@ -41,7 +41,7 @@ func newRunningSim(ctx context.Context) *simulator.Simulator {
 	defer func() { os.Args = oldArgs }()
 	os.Args = []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeEcho}
 
-	config, err := common.ParseCommandParamsAndLoadConfig()
+	config, err := common.ParseCommandParamsAndLoadConfig(common.NewConfiguration())
 	Expect(err).NotTo(HaveOccurred())
 
 	sim, err := simulator.New(klog.Background())

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -42,9 +42,9 @@ type Engine interface {
 	NewConfiguration() *common.Configuration
 }
 
-// Get returns the Engine identified by name, or an error listing the valid values if
-// name is not recognized.
-func Get(name string) (Engine, error) {
+// New creates the Engine identified by name, or returns an error listing the valid
+// values if name is not recognized.
+func New(name string) (Engine, error) {
 	switch name {
 	case VLLM:
 		return vllmEngine{}, nil
@@ -72,5 +72,5 @@ func Resolve() (Engine, error) {
 			name = fileEngine
 		}
 	}
-	return Get(name)
+	return New(name)
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package engine identifies which inference engine the simulator is simulating.
+package engine
+
+import (
+	"fmt"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+)
+
+const (
+	// VLLM identifies the vLLM engine, the only engine currently supported.
+	VLLM = "vllm"
+
+	// DefaultEngine is used when neither --engine nor the config file's "engine" key is set.
+	DefaultEngine = VLLM
+)
+
+// Engine identifies the inference engine being simulated. It determines how the
+// simulator's configuration is constructed and is available throughout the simulator's
+// runtime for engine-specific behavior.
+type Engine interface {
+	// Name returns the engine's identifier, the value accepted by --engine.
+	Name() string
+	// NewConfiguration returns a Configuration populated with this engine's defaults,
+	// before any YAML or command-line overrides are applied.
+	NewConfiguration() *common.Configuration
+}
+
+// Get returns the Engine identified by name, or an error listing the valid values if
+// name is not recognized.
+func Get(name string) (Engine, error) {
+	switch name {
+	case VLLM:
+		return vllmEngine{}, nil
+	default:
+		return nil, fmt.Errorf("unknown engine %q, valid values are: %s", name, VLLM)
+	}
+}
+
+// Resolve determines which Engine to use, following the same precedence as every other
+// setting: a --engine flag wins; otherwise, if --config points at a YAML file, its
+// top-level "engine" key is peeked (without loading the full Configuration schema, since
+// the engine isn't known yet); otherwise DefaultEngine applies. Both --engine and --config
+// are hand-read from the command line here, before the full flag set exists, mirroring how
+// common.ParseCommandParamsAndLoadConfig hand-reads --config.
+func Resolve() (Engine, error) {
+	name := DefaultEngine
+	if values := common.GetParamValueFromArgs("engine"); len(values) == 1 {
+		name = values[0]
+	} else if configFiles := common.GetParamValueFromArgs("config"); len(configFiles) == 1 {
+		fileEngine, err := common.PeekEngineFromFile(configFiles[0])
+		if err != nil {
+			return nil, err
+		}
+		if fileEngine != "" {
+			name = fileEngine
+		}
+	}
+	return Get(name)
+}

--- a/pkg/engine/engine_suite_test.go
+++ b/pkg/engine/engine_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEngine(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Engine Suite")
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func withArgs(args []string, f func()) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = args
+	f()
+}
+
+var _ = Describe("Get", func() {
+	It("returns the vllm engine", func() {
+		e, err := Get(VLLM)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(e.Name()).To(Equal(VLLM))
+	})
+
+	It("errors on an unknown engine", func() {
+		_, err := Get("bogus")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("Resolve", func() {
+	It("defaults to vllm when --engine is absent and there is no config file", func() {
+		withArgs([]string{"cmd"}, func() {
+			e, err := Resolve()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(e.Name()).To(Equal(VLLM))
+		})
+	})
+
+	It("uses --engine when present", func() {
+		withArgs([]string{"cmd", "--engine", "vllm"}, func() {
+			e, err := Resolve()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(e.Name()).To(Equal(VLLM))
+		})
+	})
+
+	It("errors on an unknown --engine value", func() {
+		withArgs([]string{"cmd", "--engine", "bogus"}, func() {
+			_, err := Resolve()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	It("falls back to the config file's engine key when --engine is absent", func() {
+		path := writeConfigFile("engine: vllm\n")
+		withArgs([]string{"cmd", "--config", path}, func() {
+			e, err := Resolve()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(e.Name()).To(Equal(VLLM))
+		})
+	})
+
+	It("defaults to vllm when the config file has no engine key", func() {
+		path := writeConfigFile("model: some-model\n")
+		withArgs([]string{"cmd", "--config", path}, func() {
+			e, err := Resolve()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(e.Name()).To(Equal(VLLM))
+		})
+	})
+
+	It("errors on an unknown engine value in the config file", func() {
+		path := writeConfigFile("engine: bogus\n")
+		withArgs([]string{"cmd", "--config", path}, func() {
+			_, err := Resolve()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	It("prefers --engine over the config file's engine key", func() {
+		path := writeConfigFile("engine: bogus\n")
+		withArgs([]string{"cmd", "--engine", "vllm", "--config", path}, func() {
+			e, err := Resolve()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(e.Name()).To(Equal(VLLM))
+		})
+	})
+})
+
+func writeConfigFile(content string) string {
+	path := filepath.Join(GinkgoT().TempDir(), "config.yaml")
+	Expect(os.WriteFile(path, []byte(content), 0o600)).To(Succeed())
+	return path
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -31,15 +31,15 @@ func withArgs(args []string, f func()) {
 	f()
 }
 
-var _ = Describe("Get", func() {
+var _ = Describe("New", func() {
 	It("returns the vllm engine", func() {
-		e, err := Get(VLLM)
+		e, err := New(VLLM)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(e.Name()).To(Equal(VLLM))
 	})
 
 	It("errors on an unknown engine", func() {
-		_, err := Get("bogus")
+		_, err := New("bogus")
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/engine/vllm.go
+++ b/pkg/engine/vllm.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import "github.com/llm-d/llm-d-inference-sim/pkg/common"
+
+type vllmEngine struct{}
+
+func (vllmEngine) Name() string {
+	return VLLM
+}
+
+func (vllmEngine) NewConfiguration() *common.Configuration {
+	cfg := common.NewConfiguration()
+	cfg.Engine = VLLM
+	return cfg
+}

--- a/pkg/simulator/context.go
+++ b/pkg/simulator/context.go
@@ -30,6 +30,7 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
 	"github.com/llm-d/llm-d-inference-sim/pkg/dataset"
+	"github.com/llm-d/llm-d-inference-sim/pkg/engine"
 	"github.com/llm-d/llm-d-inference-sim/pkg/kvcache"
 	"github.com/llm-d/llm-d-inference-sim/pkg/tokenizer"
 )
@@ -55,6 +56,9 @@ type SimContext struct {
 	// config holds the simulator's configuration as an atomic pointer so that
 	// admin updates can swap it under concurrent readers. Access via Config()/SetConfig().
 	config atomic.Pointer[common.Configuration]
+	// engine identifies the inference engine this simulator is simulating. Set once at
+	// startup and never changes at runtime. Access via Engine().
+	engine engine.Engine
 	// adminMu serializes admin-config updates so two concurrent updates can't
 	// each load-then-store with a stale value.
 	adminMu sync.Mutex
@@ -114,6 +118,11 @@ func (s *SimContext) Config() *common.Configuration {
 // SetConfig atomically replaces the configuration pointer.
 func (s *SimContext) SetConfig(c *common.Configuration) {
 	s.config.Store(c)
+}
+
+// Engine returns the inference engine this simulator is simulating.
+func (s *SimContext) Engine() engine.Engine {
+	return s.engine
 }
 
 // ApplyConfigUpdate validates the partial JSON body against the current

--- a/pkg/simulator/handle_request_test.go
+++ b/pkg/simulator/handle_request_test.go
@@ -44,7 +44,7 @@ func newHandleRequestTestSim(ctx context.Context, newRequestsCapacity int, extra
 	defer func() { os.Args = oldArgs }()
 	os.Args = append([]string{"cmd", "--model", common.TestModelName, "--mode", common.ModeEcho}, extraArgs...)
 
-	config, err := common.ParseCommandParamsAndLoadConfig()
+	config, err := common.ParseCommandParamsAndLoadConfig(common.NewConfiguration())
 	Expect(err).NotTo(HaveOccurred())
 
 	sim, err := New(klog.Background())

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -32,6 +32,7 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
 	"github.com/llm-d/llm-d-inference-sim/pkg/dataset"
+	"github.com/llm-d/llm-d-inference-sim/pkg/engine"
 	"github.com/llm-d/llm-d-inference-sim/pkg/tokenizer"
 )
 
@@ -96,7 +97,7 @@ func New(logger logr.Logger) (*Simulator, error) {
 	return sim, nil
 }
 
-func Start(ctx context.Context, config *common.Configuration, logger logr.Logger) ([]*Simulator, error) {
+func Start(ctx context.Context, eng engine.Engine, config *common.Configuration, logger logr.Logger) ([]*Simulator, error) {
 	if config.MMEncoderOnly && config.Mode == common.ModeEcho {
 		logger.V(logging.WARN).Info("MM encoder-only mode: ignoring echo mode")
 	}
@@ -171,6 +172,7 @@ func Start(ctx context.Context, config *common.Configuration, logger logr.Logger
 			return nil, err
 		}
 		sim.Context.SetConfig(rankConfig)
+		sim.Context.engine = eng
 		// use the same tokenizer in all ranks
 		sim.Context.Tokenizer = tokenizer
 		sims[dpRank] = sim

--- a/pkg/tests/test_utils_test.go
+++ b/pkg/tests/test_utils_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/api"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	"github.com/llm-d/llm-d-inference-sim/pkg/communication"
+	"github.com/llm-d/llm-d-inference-sim/pkg/engine"
 	"github.com/llm-d/llm-d-inference-sim/pkg/simulator"
 	"github.com/llm-d/llm-d-inference-sim/pkg/tokenizer"
 	"github.com/openai/openai-go/v3"
@@ -126,7 +127,7 @@ func startServerHelper(ctx context.Context, mode string, args []string, envs map
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	config, err := common.ParseCommandParamsAndLoadConfig()
+	config, err := common.ParseCommandParamsAndLoadConfig(common.NewConfiguration())
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -221,14 +222,19 @@ func startDataParallelServers(ctx context.Context, args []string, envs ...map[st
 		}()
 	}
 
-	config, err := common.ParseCommandParamsAndLoadConfig()
+	config, err := common.ParseCommandParamsAndLoadConfig(common.NewConfiguration())
 	if err != nil {
 		return nil, err
 	}
 
 	logger := klog.Background()
 
-	sims, err := simulator.Start(ctx, config, logger)
+	eng, err := engine.Get(engine.VLLM)
+	if err != nil {
+		return nil, err
+	}
+
+	sims, err := simulator.Start(ctx, eng, config, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tests/test_utils_test.go
+++ b/pkg/tests/test_utils_test.go
@@ -229,7 +229,7 @@ func startDataParallelServers(ctx context.Context, args []string, envs ...map[st
 
 	logger := klog.Background()
 
-	eng, err := engine.Get(engine.VLLM)
+	eng, err := engine.New(engine.VLLM)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


Introduces an Engine interface (pkg/engine) that determines how the simulator's
configuration is constructed. The engine is selected via a new --engine flag (or the
engine key in a --config YAML file), resolved before the rest of the configuration is
built. Only one engine exists today, vllm, and it produces exactly the existing
configuration and behavior - this is a seam for future engines, not a behavior change.