### PR TITLE
Make tests could pass in restricted networks via leveraging proxy env

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ To run the vLLM simulator in a standalone test environment with a real model:
    ./bin/llm-d-inference-sim --model Qwen/Qwen2.5-0.5B-Instruct --port 8000 --render-url http://localhost:8082
    ```
 
-**Note:** If the model is not a real HuggingFace model, there is no need to run the vLLM render server.
+**Note:** If you do not pass `--render-url`, the simulator uses the simulated tokenizer and no vLLM render server is required.
 
 ## Testing locally
 ### Prerequisites
@@ -174,6 +174,8 @@ Note:
 
 
 Verify socket accessibility with docker info. Adjust DOCKER_HOST based on your Docker provider.
+
+If your host uses `HF_ENDPOINT`, `HF_TOKEN`, or `HTTP(S)_PROXY`/`NO_PROXY` to reach HuggingFace, those variables are forwarded into the render container. The addresses they resolve to must be reachable from *inside* the container: a proxy bound to host `127.0.0.1` will not work; use `host.docker.internal` or the container-bridge IP instead.
 
 ### Running Tests
 ```bash

--- a/docs/tokenization.md
+++ b/docs/tokenization.md
@@ -1,19 +1,18 @@
 # Tokenization
 
-The simulator offers flexible tokenization to balance **accuracy** vs. **performance**. The mode is automatically selected based on the model name provided in the `--model` argument: at startup the simulator queries `https://huggingface.co/api/models/<model>` and, if the model exists on HuggingFace, switches to **HuggingFace Mode**; otherwise it falls back to **Simulated Mode**.
+The simulator offers flexible tokenization to balance **accuracy** vs. **performance**. The mode is selected by the `--render-url` flag: if a URL is provided the simulator uses **HuggingFace Mode**, otherwise it uses **Simulated Mode**.
 
 ## HuggingFace Mode (Real Models)
-This mode is activated when the `--model` parameter specifies a model ID that is reachable on HuggingFace (e.g., `meta-llama/Llama-3.1-8B-Instruct` or `Qwen/Qwen2.5-1.5B-Instruct`).
+This mode is activated when `--render-url` points at a running vLLM render service. Typical usage is a real model such as `meta-llama/Llama-3.1-8B-Instruct` or `Qwen/Qwen2.5-1.5B-Instruct` served by that render service.
 
 * **Behavior:** The simulator does **not** load a tokenizer in-process. Instead, every tokenization call is forwarded over HTTP to an external **vLLM render service** (vLLM running with `vllm launch render`). The simulator POSTs to `<render-url>/render` and consumes the returned token IDs and string tokens.
 * **Accuracy:** Ensures exact token counts and boundaries — tokenization is performed by a real vLLM/HuggingFace tokenizer in the render service.
 * **Requirements:**
-    * **Network access** at startup to `https://huggingface.co/api/models/<model>` so the simulator can detect that the model is a real HuggingFace model.
-    * **A running vLLM render service** reachable at `--render-url`. See the [README](../README.md#standalone-testing) for instructions on starting the render container, or use the `make run-render` helper. Without this service the simulator will start, but tokenization requests will fail.
+    * **A running vLLM render service** reachable at `--render-url`. See the [README](../README.md#standalone-testing) for instructions on starting the render container, or use the `make run-render` helper.
 * **Performance:** Each tokenization call is a network round-trip to the render service.
 
 ## Simulated Mode (Dummy Models)
-This mode is activated when the `--model` parameter specifies a name that does not exist on HuggingFace (e.g., `my-fake-model`, `test-cluster-1`, `gpt-4-turbo-sim`).
+This mode is activated when `--render-url` is not set.
 
 * **Behavior:** Uses an in-process regex-based tokenizer to split text and generates token hashes using the FNV-32a algorithm. No external service or network access is needed.
 * **Accuracy:** Approximate. Token boundaries will not match real models.
@@ -22,21 +21,22 @@ This mode is activated when the `--model` parameter specifies a name that does n
     * **High throughput:** Ideal for infrastructure testing where exact token boundaries are irrelevant.
     * **No network dependency:** Works completely offline.
 
+When `--render-url` is not set but the model name looks like a HuggingFace repo id (contains `/`), the simulator logs a WARN and still falls back to the simulated tokenizer. This surfaces the fact that token ids will be pseudo-hashes and will not match a real vLLM tokenizer — a mismatch that breaks KV-cache block hashing and prefix-cache-aware routing.
+
 ## Performance Considerations
 **Important:** If you want to avoid the cost and operational overhead of running the render service:
-- Use a "fake" or non-existent model name (e.g., `--model fake-model`)
-- Or use the `--force-dummy-tokenizer` flag with any model name
+- Omit `--render-url`
 - This is recommended for testing scenarios where exact tokenization accuracy is not required
 - The render service is only required when you need accurate token counts matching actual HuggingFace models
 
 ## Configuration
 | Parameter | Description | Default |
 |---|---|---|
-| `--model` | The model name. Determines the tokenization mode. (Mandatory) | |
-| `--render-url` | URL of the vLLM render service. Used only in HuggingFace Mode. | `http://localhost:8082` |
+| `--model` | The model name. (Mandatory) | |
+| `--render-url` | URL of the vLLM render service. When set, HuggingFace Mode is used; when unset, Simulated Mode is used. | (empty) |
 | `--render-timeout` | Timeout for tokenizer render requests (Go duration, e.g. `30s`). | `30s` |
 | `--mm-render-timeout` | Timeout for multi-modal tokenizer render requests. | `60s` |
-| `--force-dummy-tokenizer` | Force the use of dummy tokenizer even if a real model name is provided | `false` |
+| `--force-dummy-tokenizer` | (deprecated) Force the simulated tokenizer even when `--render-url` is set. Omit `--render-url` instead. | `false` |
 
 
 ## Examples
@@ -52,7 +52,3 @@ Running with simulated tokenization (no render service required):
 ./bin/llm-d-inference-sim --model test-sim-model
 ```
 
-Running with simulated tokenization (forcing dummy tokenizer with a real model name):
-```bash
-./bin/llm-d-inference-sim --model meta-llama/Llama-3.1-8B-Instruct --force-dummy-tokenizer
-```

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -288,13 +288,16 @@ type Configuration struct {
 	// DatasetTableName defines custom SQLite dataset table name
 	DatasetTableName string `yaml:"dataset-table-name" json:"dataset-table-name"`
 
-	// RenderURL is the URL of the tokenizer render service
+	// RenderURL is the URL of the tokenizer render service. When set, the
+	// simulator uses a HuggingFace tokenizer served over HTTP. When empty,
+	// the simulator uses the in-process simulated tokenizer.
 	RenderURL string `yaml:"render-url" json:"render-url"`
 	// RenderTimeout is the timeout for tokenizer render requests
 	RenderTimeout time.Duration `yaml:"render-timeout" json:"render-timeout"`
 	// MMRenderTimeout is the timeout for multi-modal tokenizer render requests
 	MMRenderTimeout time.Duration `yaml:"mm-render-timeout" json:"mm-render-timeout"`
-	// ForceDummyTokenizer forces the use of the dummy tokenizer even if a real model name is provided
+	// ForceDummyTokenizer forces the use of the dummy tokenizer even if a real model name is provided.
+	// This flag is retained for backward compatibility; omit --render-url to use the simulated tokenizer.
 	ForceDummyTokenizer bool `yaml:"force-dummy-tokenizer" json:"force-dummy-tokenizer"`
 
 	// StartupDuration defines how long /health/ready returns 503 to simulate GPU model loading.
@@ -392,7 +395,7 @@ func newConfig() *Configuration {
 		DefaultEmbeddingDimensions:                384,
 		FakeMetricsRefreshInterval:                100 * time.Millisecond,
 		MaxRequestBodySizeMB:                      4,
-		RenderURL:                                 "http://localhost:8082",
+		RenderURL:                                 "",
 		RenderTimeout:                             30 * time.Second,
 		MMRenderTimeout:                           60 * time.Second,
 	}

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -168,10 +168,10 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 	f.BoolVar(&config.DatasetInMemory, "dataset-in-memory", config.DatasetInMemory, "Load the entire dataset into memory for faster access")
 	f.StringVar(&config.DatasetTableName, "dataset-table-name", config.DatasetTableName, "Table name for custom dataset, default is 'llmd'")
 
-	f.StringVar(&config.RenderURL, "render-url", config.RenderURL, "URL of the tokenizer render service")
+	f.StringVar(&config.RenderURL, "render-url", config.RenderURL, "URL of the tokenizer render service; when unset the simulated tokenizer is used")
 	f.DurationVar(&config.RenderTimeout, "render-timeout", config.RenderTimeout, "Timeout for tokenizer render requests (e.g. 30s)")
 	f.DurationVar(&config.MMRenderTimeout, "mm-render-timeout", config.MMRenderTimeout, "Timeout for multi-modal tokenizer render requests (e.g. 60s)")
-	f.BoolVar(&config.ForceDummyTokenizer, "force-dummy-tokenizer", config.ForceDummyTokenizer, "Force the use of dummy tokenizer even if a real model name is provided")
+	f.BoolVar(&config.ForceDummyTokenizer, "force-dummy-tokenizer", config.ForceDummyTokenizer, "(deprecated) Force the use of dummy tokenizer even if a real model name is provided; omit --render-url instead")
 
 	f.DurationVar(&config.StartupDuration, "startup-duration", config.StartupDuration,
 		"Duration to return 503 on /health/ready to simulate GPU loading (e.g. 30s). Default is 0 (immediately ready)")

--- a/pkg/tokenizer/test_utils.go
+++ b/pkg/tokenizer/test_utils.go
@@ -19,6 +19,7 @@ package tokenizer
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -29,6 +30,29 @@ import (
 	testcontainers "github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
+
+// hostNetworkEnvKeys are host environment variables forwarded into the render
+// container so HuggingFace mirrors and proxies configured on the host reach
+// the tokenizer download inside the container.
+var hostNetworkEnvKeys = []string{
+	"HF_ENDPOINT",
+	"HF_TOKEN",
+	"HF_HUB_ENDPOINT",
+	"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+	"http_proxy", "https_proxy", "no_proxy",
+}
+
+// collectHostNetworkEnv returns the subset of hostNetworkEnvKeys that are set
+// on the host, suitable for testcontainers.WithEnv.
+func collectHostNetworkEnv() map[string]string {
+	env := map[string]string{}
+	for _, key := range hostNetworkEnvKeys {
+		if v := os.Getenv(key); v != "" {
+			env[key] = v
+		}
+	}
+	return env
+}
 
 type TokenizerManager struct {
 	testTokenizer Tokenizer
@@ -75,14 +99,14 @@ func (tm *TokenizerManager) Init(ctx context.Context, logger logr.Logger) error 
 	// var err error
 	// create tokenizer for Qwen model
 	// Use longer timeout (30s) for render requests as the container may need time to fully initialize
-	tm.qwenTokenizer, err = tm.newTokenizer(ctx, logger, renderURL, common.QwenModelName, 30*time.Second, 60*time.Second)
+	tm.qwenTokenizer, err = tm.newHFTokenizer(ctx, logger, renderURL, common.QwenModelName, 30*time.Second, 60*time.Second)
 	if err != nil {
 		cleanup()
 		return err
 	}
 
 	// create tokenizer for multimodal model
-	tm.mmTokenizer, err = tm.newTokenizer(ctx, logger, renderURL, common.QwenModelName, 30*time.Second, 60*time.Second)
+	tm.mmTokenizer, err = tm.newHFTokenizer(ctx, logger, renderURL, common.QwenModelName, 30*time.Second, 60*time.Second)
 	if err != nil {
 		cleanup()
 		return err
@@ -106,6 +130,7 @@ func (tm *TokenizerManager) startRenderContainer(ctx context.Context, model stri
 		testcontainers.WithEntrypoint("vllm"),
 		testcontainers.WithCmd("launch", "render", model, "--port=8000"),
 		testcontainers.WithTmpfs(map[string]string{"/.cache": "rw"}),
+		testcontainers.WithEnv(collectHostNetworkEnv()),
 		testcontainers.WithWaitStrategy(
 			wait.ForHTTP("/health").
 				WithPort("8000/tcp").
@@ -140,17 +165,6 @@ func (tm *TokenizerManager) startRenderContainer(ctx context.Context, model stri
 	}
 
 	return address, cleanup, nil
-}
-
-func (tm *TokenizerManager) newTokenizer(ctx context.Context, logger logr.Logger, renderURL, model string,
-	timeout, mmTimeout time.Duration) (Tokenizer, error) {
-	if modelExists(model) {
-		// for real model create HF tokenizer
-		return tm.newHFTokenizer(ctx, logger, renderURL, model, timeout, mmTimeout)
-	} else {
-		// for dummy model create simple tokenizer
-		return tm.newSimpleTokenizer(model), nil
-	}
 }
 
 // create Simple Tokenizer

--- a/pkg/tokenizer/tokenizer.go
+++ b/pkg/tokenizer/tokenizer.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-inference-sim/pkg/api"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
-	"github.com/valyala/fasthttp"
+	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
 )
 
 const (
@@ -51,18 +51,34 @@ type SimpleTokenizer struct {
 	baseTokenizer
 }
 
+// New builds a Tokenizer based on the simulator configuration.
+//
+// Selection rules:
+//   - --force-dummy-tokenizer (deprecated) always yields SimpleTokenizer.
+//   - A non-empty --render-url yields HFTokenizer backed by the render service.
+//   - Otherwise SimpleTokenizer is used. If the model name looks like a
+//     HuggingFace repo id (contains "/"), the fallback is logged at WARN so
+//     restricted-network deployments do not silently serve pseudo-token ids.
 func New(ctx context.Context, config *common.Configuration, logger logr.Logger) (Tokenizer, error) {
 	var err error
 	var tokenizer Tokenizer
 
 	switch {
 	case config.ForceDummyTokenizer:
-		logger.Info("Force dummy tokenizer flag is set, using simulated tokenizer", "model", config.Model)
+		logger.V(logging.WARN).Info("--force-dummy-tokenizer is deprecated; omit --render-url to use the simulated tokenizer",
+			"model", config.Model)
 		tokenizer = NewSimpleTokenizer()
-	case modelExists(config.Model):
+	case config.RenderURL != "":
 		tokenizer, err = NewHFTokenizer(ctx, logger, config.RenderURL, config.Model, config.RenderTimeout, config.MMRenderTimeout)
 	default:
-		logger.Info("Model is not a real HF model, using simulated tokenizer", "model", config.Model)
+		if strings.Contains(config.Model, "/") {
+			logger.V(logging.WARN).Info(
+				"Model name looks like a HuggingFace repo id but --render-url is not set; falling back to the simulated tokenizer. "+
+					"Token ids will be pseudo-hashes and will not match a real vLLM tokenizer, breaking KV-cache block hashing and prefix-cache routing.",
+				"model", config.Model)
+		} else {
+			logger.V(logging.INFO).Info("--render-url not set, using simulated tokenizer", "model", config.Model)
+		}
 		tokenizer = NewSimpleTokenizer()
 	}
 
@@ -197,17 +213,6 @@ func stubMMFeaturesForMessages(messages []api.Message, totalTokens int) *api.Ren
 		MMPlaceholders: mmPlaceholders,
 		KwargsData:     mmKwargsData,
 	}
-}
-
-func modelExists(model string) bool {
-	url := "https://huggingface.co/api/models/" + model
-
-	statusCode, _, err := fasthttp.Get(nil, url)
-	if err != nil {
-		return false
-	}
-
-	return statusCode == fasthttp.StatusOK
 }
 
 func fnv32(s string) uint32 {

--- a/pkg/tokenizer/tokenizer_test.go
+++ b/pkg/tokenizer/tokenizer_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package tokenizer
 
 import (
+	"context"
 	"encoding/base64"
 	"strings"
+	"time"
 
 	"github.com/llm-d/llm-d-inference-sim/pkg/api"
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -215,6 +219,44 @@ var _ = Describe("tokenizer", func() {
 			a := stubMMFeaturesForMessages(msgs, 100)
 			b := stubMMFeaturesForMessages(msgs, 100)
 			Expect(a.KwargsData).To(Equal(b.KwargsData))
+		})
+	})
+
+	Describe("New tokenizer selection", func() {
+		newConfig := func() *common.Configuration {
+			return &common.Configuration{
+				Model:           common.QwenModelName,
+				RenderTimeout:   30 * time.Second,
+				MMRenderTimeout: 60 * time.Second,
+			}
+		}
+
+		It("returns an HF tokenizer when --render-url is set", func() {
+			cfg := newConfig()
+			cfg.RenderURL = "http://localhost:8082"
+
+			tok, err := New(context.Background(), cfg, klog.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tok).To(BeAssignableToTypeOf(&HFTokenizer{}))
+		})
+
+		It("returns the simulated tokenizer when --render-url is empty", func() {
+			cfg := newConfig()
+			cfg.Model = "my-fake-model"
+
+			tok, err := New(context.Background(), cfg, klog.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tok).To(BeAssignableToTypeOf(&SimpleTokenizer{}))
+		})
+
+		It("still returns the simulated tokenizer when --force-dummy-tokenizer is set", func() {
+			cfg := newConfig()
+			cfg.RenderURL = "http://localhost:8082"
+			cfg.ForceDummyTokenizer = true
+
+			tok, err := New(context.Background(), cfg, klog.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tok).To(BeAssignableToTypeOf(&SimpleTokenizer{}))
 		})
 	})
 


### PR DESCRIPTION
## What does this PR do?

 Two commits, both scoped to the tokenizer path:

  1. **`tokenizer/test_utils`: forward HF and proxy env into the render container.**
     `startRenderContainer` now passes an allowlist of HuggingFace and proxy-related host env (`HF_ENDPOINT`, `HF_TOKEN`, `HF_HUB_ENDPOINT`, and both cases of `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`) into the vLLM render container via `testcontainers.WithEnv`.
  2. **`tokenizer`: select tokenizer by `--render-url` instead of probing `huggingface.co`.** Remove `modelExists()` and its `fasthttp` probe. The simulator now uses `HFTokenizer` when `--render-url` is set, and `SimpleTokenizer` otherwise. When `--render-url` is missing but the model name looks like a HuggingFace repo id (contains `/`), the fallback is logged at WARN so restricted-network deployments do not silently serve pseudo-token ids. 

## Why is this change needed?

On restricted networks (no direct access to `huggingface.co`), the previous
  tokenizer path failed silently in two ways:

  1. The test render container tried to reach `huggingface.co` directly to download `Qwen/Qwen2-VL-2B-Instruct`, so the `pkg/dataset` `BeforeSuite` failed and skipped all 61 specs.
  2. In production, `modelExists()` used `fasthttp.Get` against a hardcoded `https://huggingface.co/api/models/<model>` URL. `fasthttp` does not honor `HTTPS_PROXY` and the URL cannot be pointed at a mirror, so the probe returned `false` for every real model and the caller fell back to `SimpleTokenizer`.

 The selection rule follows the discussion on the issue: real render service is opt-in via `--render-url`; a real-looking repo id without a render URL is a loud WARN, not a silent degradation.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes #643
