### PR TITLE
Remove deprecated /fake_metrics endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -30,8 +30,6 @@ In addition, a set of the vLLM HTTP endpoints are supported:
 | /health                 | Standard health check endpoint |
 | /health/ready           | Ensure the GPU is "actually working" before allowing the system to send it live traffic |
 
-> **Deprecated:** the simulator also provides a `POST /fake_metrics` endpoint that accepts a [fake metric](configuration.md#fake-metrics) partial-update body directly (only available when started with a `--fake-metrics` configuration). The body is a JSON object containing the metrics to update; unspecified metrics are left unchanged. This endpoint is preserved for backward compatibility and will be removed in release v0.12.0; new callers should use `POST /admin/config` with a `fake-metrics` field instead.
-
 ### `/admin/config`
 
 The simulator exposes `GET` and `POST` on `/admin/config` for runtime configuration introspection and partial updates. This endpoint is simulator-specific and is intended for adjusting behavior (currently failure injection, fake metrics, and request latencies) during a test run without restarting the process.

--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -45,8 +45,6 @@ type Communication struct {
 
 	pb.UnimplementedVllmEngineServer
 
-	fakeMetricsDeprecatedLogged bool
-
 	// startTime records when the server started, used for startup-duration readiness check
 	startTime time.Time
 

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -81,7 +81,6 @@ func (c *Communication) startHTTPServer(ctx context.Context, listener net.Listen
 	r.POST("/v1/unload_lora_adapter", c.HandleUnloadLora)
 	// supports /metrics prometheus API
 	r.GET("/metrics", fasthttpadaptor.NewFastHTTPHandler(promhttp.HandlerFor(c.simulator.Context.MetricsRegistry(), promhttp.HandlerOpts{})))
-	r.POST("/fake_metrics", c.HandleFakeMetrics)
 	// supports standard Kubernetes health and readiness checks
 	r.GET("/health", c.HandleHealth)
 	r.GET("/health/ready", c.HandleHealthReady)
@@ -1038,9 +1037,8 @@ func (c *Communication) HandleGetAdminConfig(ctx *fasthttp.RequestCtx) {
 
 // HandlePostAdminConfig http handler for POST /admin/config — updates the
 // admin-configurable subset of fields. A "fake-metrics" key in the body is
-// dispatched (by the simulator context) to ApplyFakeMetricsBody, which has
-// the same partial-update semantics as the (deprecated) /fake_metrics
-// endpoint.
+// dispatched (by the simulator context) to ApplyConfigUpdate, which performs
+// a partial fake-metrics update.
 func (c *Communication) HandlePostAdminConfig(ctx *fasthttp.RequestCtx) {
 	c.logger.V(logging.INFO).Info("Update admin config request received")
 
@@ -1063,25 +1061,4 @@ func (c *Communication) writeAdminConfigResponse(ctx *fasthttp.RequestCtx) {
 	ctx.Response.Header.SetContentType("application/json")
 	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
 	ctx.Response.SetBody(data)
-}
-
-// HandleFakeMetrics HTTP handler for /fake_metrics.
-//
-// Deprecated: superseded by POST /admin/config with a "fake-metrics" field;
-// scheduled for removal in release v0.12.0.
-func (c *Communication) HandleFakeMetrics(ctx *fasthttp.RequestCtx) {
-	c.logger.V(logging.INFO).Info("Fake metrics update received")
-
-	if !c.fakeMetricsDeprecatedLogged {
-		c.fakeMetricsDeprecatedLogged = true
-		c.logger.V(logging.INFO).Info("/fake_metrics endpoint is deprecated and will be removed in release v0.12.0; please use POST /admin/config with a 'fake-metrics' field instead")
-	}
-
-	if err := c.simulator.Context.UpdateFakeMetricsFromBody(ctx.Request.Body()); err != nil {
-		errToSend := api.NewError("Failed to update fake metrics: "+err.Error(), fasthttp.StatusInternalServerError, nil)
-		c.sendError(ctx, &errToSend, false)
-		return
-	}
-
-	ctx.Response.Header.SetStatusCode(fasthttp.StatusNoContent)
 }

--- a/pkg/simulator/fake_metrics.go
+++ b/pkg/simulator/fake_metrics.go
@@ -28,17 +28,6 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 )
 
-// UpdateFakeMetricsFromBody applies a partial fake-metrics update parsed from
-// the body of the deprecated /fake_metrics endpoint. The body is the partial
-// itself (not wrapped in {"fake-metrics": ...}); we wrap it and dispatch
-// through ApplyConfigUpdate so it goes through the same validation, atomic
-// config swap, and Prometheus side-effect path as /admin/config.
-// Will be removed in v0.12.
-func (s *SimContext) UpdateFakeMetricsFromBody(body []byte) error {
-	wrapped := append(append([]byte(`{"fake-metrics":`), body...), '}')
-	return s.ApplyConfigUpdate(wrapped)
-}
-
 type generator func(params *common.FunctionInfo, t time.Duration) float64
 
 type generatedFakeMetrics struct {

--- a/pkg/tests/fake_metrics_test.go
+++ b/pkg/tests/fake_metrics_test.go
@@ -412,6 +412,23 @@ var _ = Describe("Fake metrics", Ordered, func() {
 		})
 	})
 
+	Context("removed /fake_metrics endpoint", func() {
+		It("Should return 404 for requests to /fake_metrics", func() {
+			ctx := context.TODO()
+			args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom}
+			client, err := startServerWithArgs(ctx, args)
+			Expect(err).NotTo(HaveOccurred())
+
+			req, err := http.NewRequest("POST", "http://localhost/fake_metrics", strings.NewReader(`{"running-requests":15}`))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			Expect(resp.Body.Close()).To(Succeed())
+		})
+	})
+
 	Context("update fake metrics", func() {
 		It("Should update fake metrics with functions correctly", func() {
 			ctx := context.TODO()
@@ -454,12 +471,9 @@ var _ = Describe("Fake metrics", Ordered, func() {
             "kv-cache-usage":0.9
         }`
 
-			req, err := http.NewRequest("POST", updateFakeMetricsUrl, strings.NewReader(reqBody))
-			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", "application/json")
-			resp, err = client.Do(req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+			resp = postAdminConfig(client, `{"fake-metrics":`+reqBody+`}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Body.Close()).To(Succeed())
 
 			time.Sleep(200 * time.Millisecond)
 
@@ -482,12 +496,9 @@ var _ = Describe("Fake metrics", Ordered, func() {
             "kv-cache-usage":"ramp:0:1:150ms"
         }`
 
-			req, err = http.NewRequest("POST", updateFakeMetricsUrl, strings.NewReader(reqBody))
-			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", "application/json")
-			resp, err = client.Do(req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+			resp = postAdminConfig(client, `{"fake-metrics":`+reqBody+`}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Body.Close()).To(Succeed())
 
 			time.Sleep(400 * time.Millisecond)
 
@@ -597,12 +608,9 @@ var _ = Describe("Fake metrics", Ordered, func() {
 			"tpot-buckets-values":[]
         }`
 
-			req, err := http.NewRequest("POST", updateFakeMetricsUrl, strings.NewReader(reqBody))
-			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", "application/json")
-			resp, err = client.Do(req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+			resp = postAdminConfig(client, `{"fake-metrics":`+reqBody+`}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Body.Close()).To(Succeed())
 
 			resp, err = client.Get(metricsUrl)
 			Expect(err).NotTo(HaveOccurred())
@@ -691,12 +699,9 @@ var _ = Describe("Fake metrics", Ordered, func() {
 				"request-max-generation-tokens":[1,2,3]
 			}`
 
-			req, err := http.NewRequest("POST", updateFakeMetricsUrl, strings.NewReader(reqBody))
-			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", "application/json")
-			resp, err = client.Do(req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+			resp = postAdminConfig(client, `{"fake-metrics":`+reqBody+`}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Body.Close()).To(Succeed())
 
 			resp, err = client.Get(metricsUrl)
 			Expect(err).NotTo(HaveOccurred())
@@ -778,12 +783,9 @@ var _ = Describe("Fake metrics", Ordered, func() {
 				"prefix-cache-queries":2000
 			}`
 
-			req, err := http.NewRequest("POST", updateFakeMetricsUrl, strings.NewReader(reqBody))
-			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", "application/json")
-			resp, err = client.Do(req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+			resp = postAdminConfig(client, `{"fake-metrics":`+reqBody+`}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Body.Close()).To(Succeed())
 
 			resp, err = client.Get(metricsUrl)
 			Expect(err).NotTo(HaveOccurred())
@@ -836,12 +838,9 @@ var _ = Describe("Fake metrics", Ordered, func() {
 				]
 			}`
 
-			req, err := http.NewRequest("POST", updateFakeMetricsUrl, strings.NewReader(reqBody))
-			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", "application/json")
-			resp, err = client.Do(req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+			resp = postAdminConfig(client, `{"fake-metrics":`+reqBody+`}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Body.Close()).To(Succeed())
 
 			resp, err = client.Get(metricsUrl)
 			Expect(err).NotTo(HaveOccurred())
@@ -862,12 +861,9 @@ var _ = Describe("Fake metrics", Ordered, func() {
 				"loras":[]
 			}`
 
-			req, err = http.NewRequest("POST", updateFakeMetricsUrl, strings.NewReader(reqBody))
-			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Content-Type", "application/json")
-			resp, err = client.Do(req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+			resp = postAdminConfig(client, `{"fake-metrics":`+reqBody+`}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Body.Close()).To(Succeed())
 
 			resp, err = client.Get(metricsUrl)
 			Expect(err).NotTo(HaveOccurred())
@@ -892,9 +888,9 @@ var _ = Describe("Fake metrics", Ordered, func() {
 		// Parameters per entry:
 		//   initialMetrics   – JSON for --fake-metrics flag at startup
 		//   initialPrompt/Gen – expected state after startup
-		//   firstUpdate      – JSON body for the first POST to /fake_metrics
+		//   firstUpdate      – JSON body for the first POST to /admin/config
 		//   firstPrompt/Gen  – expected state after first update
-		//   secondUpdate     – JSON body for the second POST
+		//   secondUpdate     – JSON body for the second POST to /admin/config
 		//   secondPrompt/Gen – expected state after second update
 		//
 		// tokenTestPhase.checkBuckets == nil means the histogram metric must be absent.
@@ -923,12 +919,9 @@ var _ = Describe("Fake metrics", Ordered, func() {
 				verifyTokenMetrics(metrics, simulator.GenerationTokensMetricName, simulator.GenerationTokensTotalMetricName, initialGen)
 
 				// First update: POST new fake metrics and verify
-				req, err := http.NewRequest("POST", updateFakeMetricsUrl, strings.NewReader(firstUpdate))
-				Expect(err).NotTo(HaveOccurred())
-				req.Header.Set("Content-Type", "application/json")
-				resp, err = client.Do(req)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+				resp = postAdminConfig(client, `{"fake-metrics":`+firstUpdate+`}`)
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(resp.Body.Close()).To(Succeed())
 
 				resp, err = client.Get(metricsUrl)
 				Expect(err).NotTo(HaveOccurred())
@@ -942,12 +935,9 @@ var _ = Describe("Fake metrics", Ordered, func() {
 				verifyTokenMetrics(metrics, simulator.GenerationTokensMetricName, simulator.GenerationTokensTotalMetricName, firstGen)
 
 				// Second update: POST new fake metrics and verify
-				req, err = http.NewRequest("POST", updateFakeMetricsUrl, strings.NewReader(secondUpdate))
-				Expect(err).NotTo(HaveOccurred())
-				req.Header.Set("Content-Type", "application/json")
-				resp, err = client.Do(req)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+				resp = postAdminConfig(client, `{"fake-metrics":`+secondUpdate+`}`)
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(resp.Body.Close()).To(Succeed())
 
 				resp, err = client.Get(metricsUrl)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/tests/test_utils_test.go
+++ b/pkg/tests/test_utils_test.go
@@ -54,11 +54,10 @@ import (
 )
 
 const (
-	baseURL              = "http://localhost/v1"
-	testUserMessage      = "This is a test."
-	metricsUrl           = "http://localhost/metrics"
-	updateFakeMetricsUrl = "http://localhost/fake_metrics"
-	adminConfigURL       = "http://localhost/admin/config"
+	baseURL         = "http://localhost/v1"
+	testUserMessage = "This is a test."
+	metricsUrl      = "http://localhost/metrics"
+	adminConfigURL  = "http://localhost/admin/config"
 )
 
 var userMsgTokens int64


### PR DESCRIPTION
## What does this PR do?

Removes the deprecated `/fake_metrics` HTTP endpoint scheduled for removal in v0.12.0.

Specifically, this PR:

- removes the `/fake_metrics` route and its handler
- removes code used exclusively by the deprecated endpoint
- migrates fake-metrics runtime update tests to `POST /admin/config`
- adds coverage verifying that `POST /fake_metrics` now returns 404
- removes the deprecated endpoint from the API documentation

The supported fake-metrics update path through `POST /admin/config` remains unchanged.

## Why is this change needed?

`/fake_metrics` was deprecated in v0.10.0 in favor of `POST /admin/config`
with the `fake-metrics` field, and is scheduled for removal in v0.12.0.

This completes the planned removal while preserving the supported runtime
fake-metrics configuration path.

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual testing performed

Local validation:

- `go build ./...`
- `go vet ./...`
- `go test ./pkg/common ./pkg/api ./pkg/simulator ./pkg/communication`
- `golangci-lint run --config=./.golangci.yml --new`
- formatting and module-cleanliness checks
- targeted end-to-end verification that:
  - `POST /fake_metrics` returns 404
  - fake-metrics updates through `POST /admin/config` still take effect

The Docker-dependent `pkg/tests` integration suite could not be run locally
because the WSL environment does not have a working Docker provider.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes #647