### PR TITLE
Move engine-specific routing and gRPC registration out of communication

### DIFF
--- a/cmd/llm-d-inference-sim/main.go
+++ b/cmd/llm-d-inference-sim/main.go
@@ -58,7 +58,7 @@ func main() {
 		return
 	}
 
-	simulators, err := simulator.Start(ctx, eng, config, logger)
+	simulators, err := simulator.Start(ctx, config, logger)
 	if err != nil {
 		logger.Error(err, "failed to create inference simulator")
 		return
@@ -67,7 +67,7 @@ func main() {
 	g := new(errgroup.Group)
 	for _, sim := range simulators {
 		g.Go(func() error {
-			return communication.Start(ctx, logger, sim)
+			return communication.Start(ctx, logger, sim, eng.Routes, eng.GRPC())
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -54,14 +54,21 @@ type Communication struct {
 	// they stay stable for the simulator's lifetime
 	mooncakeEnginesOnce sync.Once
 	mooncakeEngines     map[string]map[string]string
+
+	// routes returns the engine-specific HTTP routes to bind, supplied by the active engine.
+	routes RouteProvider
+
+	// grpc registers the engine-specific gRPC service, supplied by the active engine. A nil
+	// value means the engine has no gRPC surface, and the gRPC server is not started at all.
+	grpc GRPCRegistrar
 }
 
-func New(logger logr.Logger, simulator *simulator.Simulator) *Communication {
-	return &Communication{logger: logger, simulator: simulator, startTime: time.Now()}
+func New(logger logr.Logger, simulator *simulator.Simulator, routes RouteProvider, grpc GRPCRegistrar) *Communication {
+	return &Communication{logger: logger, simulator: simulator, startTime: time.Now(), routes: routes, grpc: grpc}
 }
 
-func Start(ctx context.Context, logger logr.Logger, simulator *simulator.Simulator) error {
-	c := Communication{logger: logger, simulator: simulator, startTime: time.Now()}
+func Start(ctx context.Context, logger logr.Logger, simulator *simulator.Simulator, routes RouteProvider, grpc GRPCRegistrar) error {
+	c := New(logger, simulator, routes, grpc)
 	c.logger.V(logging.INFO).Info("Starting communication layer")
 	return c.start(ctx)
 }
@@ -80,7 +87,7 @@ func (c *Communication) start(ctx context.Context) error {
 
 	var grpcServer *grpc.Server
 	var grpcErrCh <-chan error
-	if !c.simulator.Context.Config().MMEncoderOnly {
+	if c.grpc != nil && !c.simulator.Context.Config().MMEncoderOnly {
 		// gRPC uses HTTP/2
 		grpcL := m.Match(cmux.HTTP2())
 		grpcServer, grpcErrCh = c.startGRPC(grpcL)

--- a/pkg/communication/grpc.go
+++ b/pkg/communication/grpc.go
@@ -118,11 +118,16 @@ func (c *Communication) GetServerInfo(ctx context.Context, in *pb.GetServerInfoR
 	return nil, nil
 }
 
+// GRPCRegistrar registers the engine-specific gRPC service onto server, using c to serve
+// requests. Supplied by the active engine (see pkg/engine); a nil value means the engine
+// has no gRPC surface, and the gRPC server is not started at all.
+type GRPCRegistrar func(server *grpc.Server, c *Communication)
+
 // startGRPC starts the gRPC server and returns the server instance and an error channel.
 // It does not handle shutdown — callers are responsible for calling server.Stop().
 func (c *Communication) startGRPC(listener net.Listener) (*grpc.Server, <-chan error) {
 	server := grpc.NewServer()
-	pb.RegisterVllmEngineServer(server, c)
+	c.grpc(server, c)
 	reflection.Register(server)
 	errCh := make(chan error, 1)
 	go func() {

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -63,36 +63,30 @@ func (c *Communication) newListener() (net.Listener, error) {
 func (c *Communication) startHTTPServer(ctx context.Context, listener net.Listener) (*fasthttp.Server, <-chan error, error) {
 	r := fasthttprouter.New()
 
-	// support completion APIs
+	// OpenAI-compatible completion APIs, supported by every engine
 	r.POST("/v1/chat/completions", c.HandleChatCompletions)
 	r.POST("/v1/completions", c.HandleTextCompletions)
-	r.POST("/v1/chat/completions/render", c.HandleChatCompletionsRender)
-	r.POST("/v1/completions/render", c.HandleTextCompletionsRender)
-	r.POST("/v1/responses", c.HandleResponses)
-	r.POST("/v1/messages", c.HandleMessages)
-	r.POST("/inference/v1/generate", c.HandleGenerate)
 	if !c.simulator.Context.Config().MMEncoderOnly {
 		r.POST("/v1/embeddings", c.HandleEmbeddings)
 	}
 	// supports /models API
 	r.GET("/v1/models", c.HandleModels)
-	// support load/unload of lora adapter
-	r.POST("/v1/load_lora_adapter", c.HandleLoadLora)
-	r.POST("/v1/unload_lora_adapter", c.HandleUnloadLora)
-	// supports /metrics prometheus API
+	r.POST("/tokenize", c.HandleTokenize)
+
+	// simulator infra, independent of the simulated engine
 	r.GET("/metrics", fasthttpadaptor.NewFastHTTPHandler(promhttp.HandlerFor(c.simulator.Context.MetricsRegistry(), promhttp.HandlerOpts{})))
 	r.POST("/fake_metrics", c.HandleFakeMetrics)
 	// supports standard Kubernetes health and readiness checks
 	r.GET("/health", c.HandleHealth)
 	r.GET("/health/ready", c.HandleHealthReady)
-	// emulates vLLM's Mooncake bootstrap endpoint on the prefill pod; the routing sidecar queries it to resolve remote engine ids
-	r.GET("/query", c.HandleMooncakeQuery)
-	r.POST("/tokenize", c.HandleTokenize)
-	r.POST("/sleep", c.HandleSleep)
-	r.POST("/wake_up", c.HandleWakeUp)
-	r.GET("/is_sleeping", c.HandleIsSleeping)
 	r.GET("/admin/config", c.HandleGetAdminConfig)
 	r.POST("/admin/config", c.HandlePostAdminConfig)
+
+	// engine-specific HTTP surface; the engine decides which endpoints it
+	// supports and which function on c handles each one
+	for _, route := range c.routes(c) {
+		r.Handle(route.Method, route.Path, route.Handler)
+	}
 
 	handler := r.Handler
 	if c.simulator.Context.Config().LogHTTP {

--- a/pkg/communication/routes.go
+++ b/pkg/communication/routes.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package communication
+
+import "github.com/valyala/fasthttp"
+
+// Route pairs an HTTP method and path with the handler func that serves it.
+type Route struct {
+	Method  string
+	Path    string
+	Handler fasthttp.RequestHandler
+}
+
+// RouteProvider returns the engine-specific HTTP routes to bind once c exists.
+// Supplied by the active engine (see pkg/engine).
+type RouteProvider func(c *Communication) []Route

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	"github.com/llm-d/llm-d-inference-sim/pkg/communication"
 )
 
 const (
@@ -40,6 +41,12 @@ type Engine interface {
 	// NewConfiguration returns a Configuration populated with this engine's defaults,
 	// before any YAML or command-line overrides are applied.
 	NewConfiguration() *common.Configuration
+	// Routes returns this engine's HTTP-visible API surface: the method and path of
+	// each endpoint, paired with the handler func from c that serves it.
+	Routes(c *communication.Communication) []communication.Route
+	// GRPC returns the registrar for this engine's gRPC service, or nil if the engine
+	// has no gRPC surface, in which case the gRPC server is not started at all.
+	GRPC() communication.GRPCRegistrar
 }
 
 // New creates the Engine identified by name, or returns an error listing the valid

--- a/pkg/engine/vllm.go
+++ b/pkg/engine/vllm.go
@@ -16,7 +16,14 @@ limitations under the License.
 
 package engine
 
-import "github.com/llm-d/llm-d-inference-sim/pkg/common"
+import (
+	"github.com/valyala/fasthttp"
+	"google.golang.org/grpc"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	"github.com/llm-d/llm-d-inference-sim/pkg/communication"
+	"github.com/llm-d/llm-d-inference-sim/pkg/communication/grpc/pb"
+)
 
 type vllmEngine struct{}
 
@@ -28,4 +35,32 @@ func (vllmEngine) NewConfiguration() *common.Configuration {
 	cfg := common.NewConfiguration()
 	cfg.Engine = VLLM
 	return cfg
+}
+
+// Routes returns vLLM's HTTP-specific endpoints: the render debug endpoints, the
+// Responses and Messages APIs, the vLLM-specific generate endpoint, LoRA adapter
+// load/unload, the Mooncake bootstrap query, and the sleep/wake_up/is_sleeping
+// dev-mode endpoints.
+func (vllmEngine) Routes(c *communication.Communication) []communication.Route {
+	return []communication.Route{
+		{Method: fasthttp.MethodPost, Path: "/v1/chat/completions/render", Handler: c.HandleChatCompletionsRender},
+		{Method: fasthttp.MethodPost, Path: "/v1/completions/render", Handler: c.HandleTextCompletionsRender},
+		{Method: fasthttp.MethodPost, Path: "/v1/responses", Handler: c.HandleResponses},
+		{Method: fasthttp.MethodPost, Path: "/v1/messages", Handler: c.HandleMessages},
+		{Method: fasthttp.MethodPost, Path: "/inference/v1/generate", Handler: c.HandleGenerate},
+		{Method: fasthttp.MethodPost, Path: "/v1/load_lora_adapter", Handler: c.HandleLoadLora},
+		{Method: fasthttp.MethodPost, Path: "/v1/unload_lora_adapter", Handler: c.HandleUnloadLora},
+		{Method: fasthttp.MethodGet, Path: "/query", Handler: c.HandleMooncakeQuery},
+		{Method: fasthttp.MethodPost, Path: "/sleep", Handler: c.HandleSleep},
+		{Method: fasthttp.MethodPost, Path: "/wake_up", Handler: c.HandleWakeUp},
+		{Method: fasthttp.MethodGet, Path: "/is_sleeping", Handler: c.HandleIsSleeping},
+	}
+}
+
+// GRPC registers vLLM's gRPC engine service (generate, embed, health check, abort,
+// model/server info).
+func (vllmEngine) GRPC() communication.GRPCRegistrar {
+	return func(server *grpc.Server, c *communication.Communication) {
+		pb.RegisterVllmEngineServer(server, c)
+	}
 }

--- a/pkg/engine/vllm.go
+++ b/pkg/engine/vllm.go
@@ -46,10 +46,15 @@ func (vllmEngine) Routes(c *communication.Communication) []communication.Route {
 		{Method: fasthttp.MethodPost, Path: "/v1/chat/completions/render", Handler: c.HandleChatCompletionsRender},
 		{Method: fasthttp.MethodPost, Path: "/v1/completions/render", Handler: c.HandleTextCompletionsRender},
 		{Method: fasthttp.MethodPost, Path: "/v1/responses", Handler: c.HandleResponses},
+		// /v1/messages is Anthropic's API, not vLLM's; vLLM exposes it as a compatibility
+		// surface, which is why it's registered here rather than under its own engine.
 		{Method: fasthttp.MethodPost, Path: "/v1/messages", Handler: c.HandleMessages},
 		{Method: fasthttp.MethodPost, Path: "/inference/v1/generate", Handler: c.HandleGenerate},
 		{Method: fasthttp.MethodPost, Path: "/v1/load_lora_adapter", Handler: c.HandleLoadLora},
 		{Method: fasthttp.MethodPost, Path: "/v1/unload_lora_adapter", Handler: c.HandleUnloadLora},
+		// /query is Mooncake's bootstrap query endpoint, not vLLM's own; vLLM exposes it
+		// for Mooncake-based P/D disaggregation, which is why it's registered here rather
+		// than under its own engine.
 		{Method: fasthttp.MethodGet, Path: "/query", Handler: c.HandleMooncakeQuery},
 		{Method: fasthttp.MethodPost, Path: "/sleep", Handler: c.HandleSleep},
 		{Method: fasthttp.MethodPost, Path: "/wake_up", Handler: c.HandleWakeUp},

--- a/pkg/simulator/context.go
+++ b/pkg/simulator/context.go
@@ -30,7 +30,6 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
 	"github.com/llm-d/llm-d-inference-sim/pkg/dataset"
-	"github.com/llm-d/llm-d-inference-sim/pkg/engine"
 	"github.com/llm-d/llm-d-inference-sim/pkg/kvcache"
 	"github.com/llm-d/llm-d-inference-sim/pkg/tokenizer"
 )
@@ -56,9 +55,6 @@ type SimContext struct {
 	// config holds the simulator's configuration as an atomic pointer so that
 	// admin updates can swap it under concurrent readers. Access via Config()/SetConfig().
 	config atomic.Pointer[common.Configuration]
-	// engine identifies the inference engine this simulator is simulating. Set once at
-	// startup and never changes at runtime. Access via Engine().
-	engine engine.Engine
 	// adminMu serializes admin-config updates so two concurrent updates can't
 	// each load-then-store with a stale value.
 	adminMu sync.Mutex
@@ -118,11 +114,6 @@ func (s *SimContext) Config() *common.Configuration {
 // SetConfig atomically replaces the configuration pointer.
 func (s *SimContext) SetConfig(c *common.Configuration) {
 	s.config.Store(c)
-}
-
-// Engine returns the inference engine this simulator is simulating.
-func (s *SimContext) Engine() engine.Engine {
-	return s.engine
 }
 
 // ApplyConfigUpdate validates the partial JSON body against the current

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -32,7 +32,6 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/common"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
 	"github.com/llm-d/llm-d-inference-sim/pkg/dataset"
-	"github.com/llm-d/llm-d-inference-sim/pkg/engine"
 	"github.com/llm-d/llm-d-inference-sim/pkg/tokenizer"
 )
 
@@ -97,7 +96,7 @@ func New(logger logr.Logger) (*Simulator, error) {
 	return sim, nil
 }
 
-func Start(ctx context.Context, eng engine.Engine, config *common.Configuration, logger logr.Logger) ([]*Simulator, error) {
+func Start(ctx context.Context, config *common.Configuration, logger logr.Logger) ([]*Simulator, error) {
 	if config.MMEncoderOnly && config.Mode == common.ModeEcho {
 		logger.V(logging.WARN).Info("MM encoder-only mode: ignoring echo mode")
 	}
@@ -172,7 +171,6 @@ func Start(ctx context.Context, eng engine.Engine, config *common.Configuration,
 			return nil, err
 		}
 		sim.Context.SetConfig(rankConfig)
-		sim.Context.engine = eng
 		// use the same tokenizer in all ranks
 		sim.Context.Tokenizer = tokenizer
 		sims[dpRank] = sim

--- a/pkg/tests/test_utils_test.go
+++ b/pkg/tests/test_utils_test.go
@@ -172,8 +172,13 @@ func startServerHelper(ctx context.Context, mode string, args []string, envs map
 		return nil, nil, nil, err
 	}
 
+	eng, err := engine.New(engine.VLLM)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	listener := fasthttputil.NewInmemoryListener()
-	comm := communication.New(logger, s)
+	comm := communication.New(logger, s, eng.Routes, eng.GRPC())
 
 	ginkgo.DeferCleanup(func() {
 		listener.Close() //nolint:errcheck
@@ -234,7 +239,7 @@ func startDataParallelServers(ctx context.Context, args []string, envs ...map[st
 		return nil, err
 	}
 
-	sims, err := simulator.Start(ctx, eng, config, logger)
+	sims, err := simulator.Start(ctx, config, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +247,7 @@ func startDataParallelServers(ctx context.Context, args []string, envs ...map[st
 	clients := make([]*http.Client, len(sims))
 	for rank, sim := range sims {
 		listener := fasthttputil.NewInmemoryListener()
-		comm := communication.New(logger, sim)
+		comm := communication.New(logger, sim, eng.Routes, eng.GRPC())
 
 		ginkgo.DeferCleanup(func() {
 			listener.Close() //nolint:errcheck


### PR DESCRIPTION
Moves vLLM-specific wiring out of `pkg/communication`'s hardcoded startup path and into `pkg/engine`, via two new `Engine` methods:
- `Routes(c *communication.Communication) []communication.Route` - vLLM specific endpoints  now come from `vllmEngine.Routes`, bound in `communication`'s `startHTTPServer` via a plain loop instead of being hardcoded there.
- `GRPC() communication.GRPCRegistrar` - vLLM's gRPC service registration also moves to the engine. A nil registrar means the gRPC listener isn't started at all.

`pkg/simulator` no longer imports or stores an `Engine`