### PR TITLE
Add audio content

### DIFF
--- a/docs/http-endpoints.md
+++ b/docs/http-endpoints.md
@@ -14,9 +14,16 @@ Structure of requests/responses
         - messages
             - role
             - content (string, or array of content blocks)
-              - type (`text` or `image_url`)
+              - type (`text`, `image_url`, `audio_url`, `input_audio`, or `video_url`)
               - text
               - image_url
+                - url
+              - audio_url
+                - url
+              - input_audio
+                - data (base64-encoded audio data)
+                - format (e.g. `wav`, `mp3`)
+              - video_url
                 - url
             - tool_calls
               - function
@@ -207,11 +214,11 @@ Structure of requests/responses
 - `/v1/chat/completions/render`
     - **request** — same shape as `/v1/chat/completions`; only `model` and `messages` are inspected
         - model
-        - messages (same structure as `/v1/chat/completions`, including `image_url` content blocks)
+        - messages (same structure as `/v1/chat/completions`, including `image_url`, `audio_url`, `input_audio`, and `video_url` content blocks)
     - **response** — single JSON object
         - token_ids
-        - features (present only when at least one message contains an `image_url` block)
-            - mm_hashes (map keyed by modality, e.g. `image`, to an array of opaque hash strings)
+        - features (present only when at least one message contains an `image_url`, `audio_url`, `input_audio`, or `video_url` block)
+            - mm_hashes (map keyed by modality — `image`, `audio`, or `video` — to an array of opaque hash strings)
             - mm_placeholders (map keyed by modality to an array of placeholder regions)
                 - offset (token index where the multimodal region begins)
                 - length (number of tokens the region spans)
@@ -457,4 +464,4 @@ Pre-tokenized prompts on `/v1/completions/render` (a token-id array, or an array
 For everything else, behavior depends on the active tokenizer (selected automatically based on `--model`):
 
 - **HuggingFace tokenizer** (real model): each text prompt and chat-completions request is forwarded to the upstream vLLM render service at `--render-url`. For chat requests, `mm_features` returned by the upstream are passed through.
-- **Simulated tokenizer** (dummy model): the simulator tokenizes locally using its regex-based splitter. For chat requests containing `image_url` blocks, synthetic `mm_features` are produced so multimodal-aware downstream code paths can be exercised without a real renderer.
+- **Simulated tokenizer** (dummy model): the simulator tokenizes locally using its regex-based splitter. For chat requests containing `image_url`, `audio_url`, `input_audio`, or `video_url` blocks, synthetic `mm_features` are produced so multimodal-aware downstream code paths can be exercised without a real renderer.

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -79,7 +79,7 @@ type ChatCompletionsRenderRequest struct {
 func (c *ChatCompletionsRenderRequest) IsMultiModal() bool {
 	for _, msg := range c.Messages {
 		for _, block := range msg.Content.Structured {
-			if block.Type == "image_url" {
+			if block.Type == "image_url" || block.Type == "video_url" || block.Type == "audio_url" {
 				return true
 			}
 		}

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -1396,7 +1396,7 @@ func (m *MessagesRequest) ToChatCompletionsRequest() *ChatCompletionsRequest {
 					}
 					contentBlocks = append(contentBlocks, ChatComplContentBlock{
 						Type:     "image_url",
-						ImageURL: &ChatComplImageBlock{Url: url},
+						ImageURL: &ChatComplURLBlock{Url: url},
 					})
 				}
 			case "tool_use":

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -219,24 +219,21 @@ type ChatComplContent struct {
 }
 
 type ChatComplContentBlock struct {
-	Type       string               `json:"type"`
-	Text       string               `json:"text,omitempty"`
-	ImageURL   *ChatComplImageBlock `json:"image_url,omitempty"`
-	InputAudio *ChatComplAudioBlock `json:"input_audio,omitempty"`
-	VideoURL   *ChatComplVideoBlock `json:"video_url,omitempty"`
+	Type       string                    `json:"type"`
+	Text       string                    `json:"text,omitempty"`
+	ImageURL   *ChatComplURLBlock        `json:"image_url,omitempty"`
+	InputAudio *ChatComplInputAudioBlock `json:"input_audio,omitempty"`
+	AudioURL   *ChatComplURLBlock        `json:"audio_url,omitempty"`
+	VideoURL   *ChatComplURLBlock        `json:"video_url,omitempty"`
 }
 
-type ChatComplImageBlock struct {
+type ChatComplURLBlock struct {
 	Url string `json:"url,omitempty"`
 }
 
-type ChatComplAudioBlock struct {
+type ChatComplInputAudioBlock struct {
 	Data   string `json:"data,omitempty"`
 	Format string `json:"format,omitempty"`
-}
-
-type ChatComplVideoBlock struct {
-	Url string `json:"url,omitempty"`
 }
 
 // UnmarshalJSON allow use both format
@@ -478,7 +475,7 @@ func CreateImageModalityChunk(base baseCompletionsResponse, choiceIdx int, image
 		CreateChatRespChunkChoice(
 			CreateBaseResponseChoice(choiceIdx, nil),
 			Message{Content: ChatComplContent{Structured: []ChatComplContentBlock{
-				{Type: "image_url", ImageURL: &ChatComplImageBlock{Url: "data:image/png;base64," + imageData}},
+				{Type: "image_url", ImageURL: &ChatComplURLBlock{Url: "data:image/png;base64," + imageData}},
 			}}}),
 	})
 	chunk.Modality = "image"

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -194,6 +194,18 @@ func (m *Message) PlainText(includeRole bool) string {
 				if block.ImageURL != nil {
 					parts = append(parts, "image: "+block.ImageURL.Url)
 				}
+			case "audio_url":
+				if block.AudioURL != nil {
+					parts = append(parts, "audio: "+block.AudioURL.Url)
+				}
+			case "input_audio":
+				if block.InputAudio != nil {
+					parts = append(parts, "input_audio: "+block.InputAudio.Format)
+				}
+			case "video_url":
+				if block.VideoURL != nil {
+					parts = append(parts, "video: "+block.VideoURL.Url)
+				}
 			}
 		}
 

--- a/pkg/communication/response_builder.go
+++ b/pkg/communication/response_builder.go
@@ -262,7 +262,7 @@ func (respBuilder *chatComplHTTPRespBuilder) createResponse(respCtxPerChoice []s
 			message.ToolCalls = choiceCtx.ToolCalls()
 			if sendImage {
 				message.Content = api.ChatComplContent{Structured: []api.ChatComplContentBlock{
-					{Type: "image_url", ImageURL: &api.ChatComplImageBlock{Url: "data:image/png;base64," + syntheticImageData}},
+					{Type: "image_url", ImageURL: &api.ChatComplURLBlock{Url: "data:image/png;base64," + syntheticImageData}},
 				}}
 			}
 		} else {
@@ -270,7 +270,7 @@ func (respBuilder *chatComplHTTPRespBuilder) createResponse(respCtxPerChoice []s
 			if sendImage {
 				message.Content = api.ChatComplContent{Structured: []api.ChatComplContentBlock{
 					{Type: "text", Text: respText},
-					{Type: "image_url", ImageURL: &api.ChatComplImageBlock{Url: "data:image/png;base64," + syntheticImageData}},
+					{Type: "image_url", ImageURL: &api.ChatComplURLBlock{Url: "data:image/png;base64," + syntheticImageData}},
 				}}
 			} else {
 				message.Content = api.ChatComplContent{Raw: respText}

--- a/pkg/simulator/responses.go
+++ b/pkg/simulator/responses.go
@@ -126,12 +126,12 @@ func convertInputToMessages(input []api.InputItem) []api.Message {
 					case api.ResponsesInputImage:
 						blocks = append(blocks, api.ChatComplContentBlock{
 							Type:     "image_url",
-							ImageURL: &api.ChatComplImageBlock{Url: content.ImageURL},
+							ImageURL: &api.ChatComplURLBlock{Url: content.ImageURL},
 						})
 					case api.ResponsesInputAudio:
 						blocks = append(blocks, api.ChatComplContentBlock{
 							Type:       "input_audio",
-							InputAudio: &api.ChatComplAudioBlock{Data: content.AudioData, Format: content.AudioFormat},
+							InputAudio: &api.ChatComplInputAudioBlock{Data: content.AudioData, Format: content.AudioFormat},
 						})
 					}
 				}

--- a/pkg/tests/chat_completions_test.go
+++ b/pkg/tests/chat_completions_test.go
@@ -411,7 +411,6 @@ var _ = Describe("Simulator", func() {
 			"messages": [{
 				"role": "user",
 				"content": [
-					{"type": "text", "text": "What is being said in this audio?"},
 					{"type": "audio_url", "audio_url": {"url": "https://example.com/sample.flac"}}
 				]
 			}]

--- a/pkg/tests/chat_completions_test.go
+++ b/pkg/tests/chat_completions_test.go
@@ -400,6 +400,48 @@ var _ = Describe("Simulator", func() {
 		Expect(msg).To(Equal("Describe this\nimage: https://example.com/img.png"))
 	})
 
+	It("Should accept audio_url content in chat completions request", func() {
+		ctx := context.TODO()
+		args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom}
+		client, err := startServerWithArgs(ctx, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		reqBody := fmt.Sprintf(`{
+			"model": "%s",
+			"messages": [{
+				"role": "user",
+				"content": [
+					{"type": "text", "text": "What is being said in this audio?"},
+					{"type": "audio_url", "audio_url": {"url": "https://example.com/sample.flac"}}
+				]
+			}]
+		}`, common.TestModelName)
+
+		resp, err := client.Post("http://localhost/v1/chat/completions", "application/json", strings.NewReader(reqBody))
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			Expect(resp.Body.Close()).To(Succeed())
+		}()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+
+		var respObj map[string]any
+		Expect(json.Unmarshal(body, &respObj)).To(Succeed())
+
+		choices := respObj["choices"].([]any)
+		Expect(choices).NotTo(BeEmpty())
+		message := choices[0].(map[string]any)["message"].(map[string]any)
+		Expect(message["role"]).To(Equal("assistant"))
+		Expect(message["content"]).NotTo(BeEmpty())
+
+		usage := respObj["usage"].(map[string]any)
+		Expect(usage["prompt_tokens"]).To(BeNumerically(">", 0))
+		Expect(usage["completion_tokens"]).To(BeNumerically(">", 0))
+	})
+
 	DescribeTable("streaming chat completions with logprobs",
 		func(mode string, logprobs bool, topLogprobs int) {
 			ctx := context.TODO()

--- a/pkg/tokenizer/tokenizer.go
+++ b/pkg/tokenizer/tokenizer.go
@@ -141,7 +141,7 @@ func (st *SimpleTokenizer) RenderMessages(messages []api.Message) ([]uint32, []s
 }
 
 // stubMMFeaturesForMessages synthesizes per-modality mm_hashes and placeholders
-// for image_url, input_audio, and video_url blocks; nil if none present.
+// for image_url, input_audio, audio_url, and video_url blocks; nil if none present.
 func stubMMFeaturesForMessages(messages []api.Message, totalTokens int) *api.RenderMMFeatures {
 	type item struct {
 		modality, prefix, identifier string
@@ -149,7 +149,7 @@ func stubMMFeaturesForMessages(messages []api.Message, totalTokens int) *api.Ren
 	}
 
 	var items []item
-	var imgIdx, audIdx, inputAudioIdx, vidIdx int
+	var imgIdx, audIdx, vidIdx int
 	for _, msg := range messages {
 		for _, block := range msg.Content.Structured {
 			switch block.Type {
@@ -163,8 +163,8 @@ func stubMMFeaturesForMessages(messages []api.Message, totalTokens int) *api.Ren
 				if block.InputAudio == nil || block.InputAudio.Data == "" {
 					continue
 				}
-				items = append(items, item{mmModalityAudio, "input_audio", block.InputAudio.Data, inputAudioIdx})
-				inputAudioIdx++
+				items = append(items, item{mmModalityAudio, "input_audio", block.InputAudio.Data, audIdx})
+				audIdx++
 			case "audio_url":
 				if block.AudioURL == nil || block.AudioURL.Url == "" {
 					continue

--- a/pkg/tokenizer/tokenizer.go
+++ b/pkg/tokenizer/tokenizer.go
@@ -149,7 +149,7 @@ func stubMMFeaturesForMessages(messages []api.Message, totalTokens int) *api.Ren
 	}
 
 	var items []item
-	var imgIdx, audIdx, vidIdx int
+	var imgIdx, audIdx, inputAudioIdx, vidIdx int
 	for _, msg := range messages {
 		for _, block := range msg.Content.Structured {
 			switch block.Type {
@@ -163,7 +163,13 @@ func stubMMFeaturesForMessages(messages []api.Message, totalTokens int) *api.Ren
 				if block.InputAudio == nil || block.InputAudio.Data == "" {
 					continue
 				}
-				items = append(items, item{mmModalityAudio, "audio", block.InputAudio.Data, audIdx})
+				items = append(items, item{mmModalityAudio, "input_audio", block.InputAudio.Data, inputAudioIdx})
+				inputAudioIdx++
+			case "audio_url":
+				if block.AudioURL == nil || block.AudioURL.Url == "" {
+					continue
+				}
+				items = append(items, item{mmModalityAudio, "audio", block.AudioURL.Url, audIdx})
 				audIdx++
 			case "video_url":
 				if block.VideoURL == nil || block.VideoURL.Url == "" {

--- a/pkg/tokenizer/tokenizer.go
+++ b/pkg/tokenizer/tokenizer.go
@@ -163,7 +163,7 @@ func stubMMFeaturesForMessages(messages []api.Message, totalTokens int) *api.Ren
 				if block.InputAudio == nil || block.InputAudio.Data == "" {
 					continue
 				}
-				items = append(items, item{mmModalityAudio, "input_audio", block.InputAudio.Data, audIdx})
+				items = append(items, item{mmModalityAudio, "audio", block.InputAudio.Data, audIdx})
 				audIdx++
 			case "audio_url":
 				if block.AudioURL == nil || block.AudioURL.Url == "" {

--- a/pkg/tokenizer/tokenizer_test.go
+++ b/pkg/tokenizer/tokenizer_test.go
@@ -81,7 +81,7 @@ var _ = Describe("tokenizer", func() {
 		mmMessages := []api.Message{
 			{Role: api.RoleUser, Content: api.ChatComplContent{
 				Structured: []api.ChatComplContentBlock{
-					{Type: "image_url", ImageURL: &api.ChatComplImageBlock{Url: "http://x/a.jpg"}},
+					{Type: "image_url", ImageURL: &api.ChatComplURLBlock{Url: "http://x/a.jpg"}},
 				},
 			}},
 		}
@@ -111,7 +111,7 @@ var _ = Describe("tokenizer", func() {
 		image := func(url string) api.ChatComplContentBlock {
 			return api.ChatComplContentBlock{
 				Type:     "image_url",
-				ImageURL: &api.ChatComplImageBlock{Url: url},
+				ImageURL: &api.ChatComplURLBlock{Url: url},
 			}
 		}
 		audio := func(data, format string) api.ChatComplContentBlock {
@@ -120,10 +120,16 @@ var _ = Describe("tokenizer", func() {
 				InputAudio: &api.ChatComplInputAudioBlock{Data: data, Format: format},
 			}
 		}
+		audioURL := func(url string) api.ChatComplContentBlock {
+			return api.ChatComplContentBlock{
+				Type:     "audio_url",
+				AudioURL: &api.ChatComplURLBlock{Url: url},
+			}
+		}
 		video := func(url string) api.ChatComplContentBlock {
 			return api.ChatComplContentBlock{
 				Type:     "video_url",
-				VideoURL: &api.ChatComplVideoBlock{Url: url},
+				VideoURL: &api.ChatComplURLBlock{Url: url},
 			}
 		}
 		mkMsg := func(blocks ...api.ChatComplContentBlock) api.Message {
@@ -152,6 +158,15 @@ var _ = Describe("tokenizer", func() {
 			Expect(feats).NotTo(BeNil())
 			Expect(feats.MMHashes).To(HaveKey(mmModalityAudio))
 			Expect(feats.MMHashes[mmModalityAudio][0]).To(HavePrefix("sim_audio_"))
+		})
+
+		It("emits an audio hash for audio_url keyed by audio", func() {
+			feats := stubMMFeaturesForMessages([]api.Message{mkMsg(text("transcribe"), audioURL("http://x/a.flac"))}, 100)
+			Expect(feats).NotTo(BeNil())
+			Expect(feats.MMHashes).To(HaveKey(mmModalityAudio))
+			Expect(feats.MMHashes[mmModalityAudio]).To(HaveLen(1))
+			Expect(feats.MMHashes[mmModalityAudio][0]).To(HavePrefix("sim_audio_"))
+			Expect(feats.MMPlaceholders[mmModalityAudio]).To(HaveLen(1))
 		})
 
 		It("emits a video hash keyed by video", func() {

--- a/pkg/tokenizer/tokenizer_test.go
+++ b/pkg/tokenizer/tokenizer_test.go
@@ -157,7 +157,7 @@ var _ = Describe("tokenizer", func() {
 			feats := stubMMFeaturesForMessages([]api.Message{mkMsg(text("transcribe"), audio("base64data", "wav"))}, 100)
 			Expect(feats).NotTo(BeNil())
 			Expect(feats.MMHashes).To(HaveKey(mmModalityAudio))
-			Expect(feats.MMHashes[mmModalityAudio][0]).To(HavePrefix("sim_audio_"))
+			Expect(feats.MMHashes[mmModalityAudio][0]).To(HavePrefix("sim_input_audio_"))
 		})
 
 		It("emits an audio hash for audio_url keyed by audio", func() {

--- a/pkg/tokenizer/tokenizer_test.go
+++ b/pkg/tokenizer/tokenizer_test.go
@@ -117,7 +117,7 @@ var _ = Describe("tokenizer", func() {
 		audio := func(data, format string) api.ChatComplContentBlock {
 			return api.ChatComplContentBlock{
 				Type:       "input_audio",
-				InputAudio: &api.ChatComplAudioBlock{Data: data, Format: format},
+				InputAudio: &api.ChatComplInputAudioBlock{Data: data, Format: format},
 			}
 		}
 		video := func(url string) api.ChatComplContentBlock {

--- a/pkg/tokenizer/tokenizer_test.go
+++ b/pkg/tokenizer/tokenizer_test.go
@@ -157,7 +157,7 @@ var _ = Describe("tokenizer", func() {
 			feats := stubMMFeaturesForMessages([]api.Message{mkMsg(text("transcribe"), audio("base64data", "wav"))}, 100)
 			Expect(feats).NotTo(BeNil())
 			Expect(feats.MMHashes).To(HaveKey(mmModalityAudio))
-			Expect(feats.MMHashes[mmModalityAudio][0]).To(HavePrefix("sim_input_audio_"))
+			Expect(feats.MMHashes[mmModalityAudio][0]).To(HavePrefix("sim_audio_"))
 		})
 
 		It("emits an audio hash for audio_url keyed by audio", func() {


### PR DESCRIPTION
Adds support for audio_url content type in `/chat/completions` and `chat/completions/render`

Fixes #658 