### PR TITLE
feat: hybrid ZMQ bind/dial

### DIFF
--- a/docs/kv-cache.md
+++ b/docs/kv-cache.md
@@ -33,7 +33,7 @@ All KV cache parameters can be set via CLI flags or the equivalent YAML keys (na
 | `kv-cache-size` | int | `1024` | Maximum number of token blocks the cache can hold |
 | `block-size` | int | `16` | Tokens per block; valid values: `8`, `16`, `32`, `64`, `128` |
 | `hash-seed` | string | value of `PYTHONHASHSEED` env var | Seed for block key hash generation; must match the seed used by real vLLM instances to ensure identical block hashes |
-| `zmq-endpoint` | string | `tcp://127.0.0.1:5557` | ZMQ address to publish events (the simulator dials this address) |
+| `zmq-endpoint` | string | `tcp://127.0.0.1:5557` | ZMQ address to publish events. The simulator either dials (active) or listens on (passive) this address. Addresses with "*", "::", "inproc://", and "ipc://" are assumed passive. |
 | `event-batch-size` | int | `16` | Maximum number of events bundled into a single ZMQ message |
 | `use-vllm-map-event-format` | bool | `false` | Encode events as msgpack maps with named fields (vLLM PR #42892 format) instead of positional arrays. Set to `true` when the consumer expects the named-field schema. |
 | `kv-events-replay-endpoint` | string | `""` (disabled) | ZMQ ROUTER address to bind for KV events replay requests. See [KV events replay](#kv-events-replay). |

--- a/pkg/common/publisher.go
+++ b/pkg/common/publisher.go
@@ -68,6 +68,14 @@ func EncodeSeq(seq uint64) []byte {
 }
 
 // Publisher sends events to a ZMQ endpoint.
+// Mode is auto-detected from the endpoint string:
+//   - "tcp://*:<port>" → bind (server mode, like vLLM's default)
+//   - "tcp://<ip>:<port>" → dial (client mode)
+//
+// Heuristic mirrors vLLM's ZmqEventPublisher._socket_setup:
+// https://github.com/vllm-project/vllm/blob/v0.23.0/vllm/distributed/kv_events.py#L385
+// Bind when the endpoint contains a wildcard (*, ::, ipc://, inproc://),
+// otherwise dial (connect).
 type Publisher struct {
 	socket   zmq4.Socket
 	endpoint string
@@ -75,8 +83,9 @@ type Publisher struct {
 }
 
 // NewPublisher creates a new ZMQ publisher.
-// endpoint is the ZMQ address to bind to (e.g., "tcp://*:5557").
-// retries is the maximum number of connection attempts.
+// endpoint is the ZMQ address:
+//   - "tcp://*:<port>": binds (server mode, like vLLM's default)
+//   - "tcp://<ip>:<port>": dials (client mode)
 func NewPublisher(ctx context.Context, endpoint string) (*Publisher, error) {
 	socket := zmq4.NewPub(ctx,
 		// -1 means try forever
@@ -87,20 +96,34 @@ func NewPublisher(ctx context.Context, endpoint string) (*Publisher, error) {
 		zmq4.WithDialerRetry(time.Second),
 	)
 
-	// 2. Push Dial into a background goroutine
-	go func() {
-		// wait until the listener is ready
-		err := socket.Dial(endpoint)
-		if err != nil {
-			// Context cancellation during shutdown is expected — don't treat it as an error.
-			if ctx.Err() != nil {
-				return
-			}
-			log.FromContext(ctx).Error(err, "ZMQ dialer exited", "endpoint", endpoint)
-		} else {
-			log.FromContext(ctx).Info("ZMQ dialer connected", "endpoint", endpoint)
+	// Bind if wildcard present, otherwise dial (mirrors vLLM)
+	if strings.Contains(endpoint, "*") {
+		log.FromContext(ctx).Info("ZMQ publisher binding", "endpoint", endpoint)
+		if err := socket.Listen(endpoint); err != nil {
+			return nil, fmt.Errorf("failed to bind ZMQ publisher: %w", err)
 		}
-	}()
+		log.FromContext(ctx).Info("ZMQ publisher bound", "endpoint", endpoint)
+
+		// Resolve the wildcard to the actual address
+		addr := socket.Addr()
+		if addr != nil {
+			endpoint = "tcp://" + addr.String()
+		}
+	} else {
+		go func() {
+			log.FromContext(ctx).Info("ZMQ publisher dialing", "endpoint", endpoint)
+			err := socket.Dial(endpoint)
+			if err != nil {
+				// Context cancellation during shutdown is expected — don't treat it as an error.
+				if ctx.Err() != nil {
+					return
+				}
+				log.FromContext(ctx).Error(err, "ZMQ dialer exited", "endpoint", endpoint)
+			} else {
+				log.FromContext(ctx).Info("ZMQ dialer connected", "endpoint", endpoint)
+			}
+		}()
+	}
 
 	return &Publisher{
 		socket:   socket,
@@ -131,6 +154,12 @@ func (p *Publisher) PublishEvent(ctx context.Context, topic string, batch interf
 
 	logger.V(logging.TRACE).Info("Published event batch", "topic", topic, "seq", seq)
 	return seq, payload, nil
+}
+
+// GetEndpoint returns the actual endpoint the publisher is bound to or dialing.
+// For wildcard binds (e.g., "tcp://*:0"), this returns the resolved address.
+func (p *Publisher) GetEndpoint() string {
+	return p.endpoint
 }
 
 // Close closes the publisher and cleans up resources.

--- a/pkg/common/publisher.go
+++ b/pkg/common/publisher.go
@@ -69,8 +69,8 @@ func EncodeSeq(seq uint64) []byte {
 
 // Publisher sends events to a ZMQ endpoint.
 // Mode is auto-detected from the endpoint string:
-//   - "tcp://*:<port>" → bind (server mode, like vLLM's default)
-//   - "tcp://<ip>:<port>" → dial (client mode)
+//   - "tcp://*:<port>" -> bind (server mode, like vLLM's default)
+//   - "tcp://<ip>:<port>" -> dial (client mode)
 //
 // Heuristic mirrors vLLM's ZmqEventPublisher._socket_setup:
 // https://github.com/vllm-project/vllm/blob/v0.23.0/vllm/distributed/kv_events.py#L385

--- a/pkg/common/publisher.go
+++ b/pkg/common/publisher.go
@@ -97,7 +97,8 @@ func NewPublisher(ctx context.Context, endpoint string) (*Publisher, error) {
 	)
 
 	// Bind if wildcard present, otherwise dial (mirrors vLLM)
-	if strings.Contains(endpoint, "*") {
+	if strings.Contains(endpoint, "*") || strings.Contains(endpoint, "::") ||
+		strings.HasPrefix(endpoint, "inproc://") || strings.HasPrefix(endpoint, "ipc://") {
 		log.FromContext(ctx).Info("ZMQ publisher binding", "endpoint", endpoint)
 		if err := socket.Listen(endpoint); err != nil {
 			return nil, fmt.Errorf("failed to bind ZMQ publisher: %w", err)

--- a/pkg/common/publisher.go
+++ b/pkg/common/publisher.go
@@ -103,12 +103,6 @@ func NewPublisher(ctx context.Context, endpoint string) (*Publisher, error) {
 			return nil, fmt.Errorf("failed to bind ZMQ publisher: %w", err)
 		}
 		log.FromContext(ctx).Info("ZMQ publisher bound", "endpoint", endpoint)
-
-		// Resolve the wildcard to the actual address
-		addr := socket.Addr()
-		if addr != nil {
-			endpoint = "tcp://" + addr.String()
-		}
 	} else {
 		go func() {
 			log.FromContext(ctx).Info("ZMQ publisher dialing", "endpoint", endpoint)
@@ -154,12 +148,6 @@ func (p *Publisher) PublishEvent(ctx context.Context, topic string, batch interf
 
 	logger.V(logging.TRACE).Info("Published event batch", "topic", topic, "seq", seq)
 	return seq, payload, nil
-}
-
-// GetEndpoint returns the actual endpoint the publisher is bound to or dialing.
-// For wildcard binds (e.g., "tcp://*:0"), this returns the resolved address.
-func (p *Publisher) GetEndpoint() string {
-	return p.endpoint
 }
 
 // Close closes the publisher and cleans up resources.

--- a/pkg/common/publisher_test.go
+++ b/pkg/common/publisher_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"os"
 
 	"time"
 
@@ -227,9 +226,7 @@ var _ = Describe("Publisher", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		tmpDir, err := os.MkdirTemp("", "zmq")
-		Expect(err).NotTo(HaveOccurred())
-		defer os.RemoveAll(tmpDir)
+		tmpDir := GinkgoT().TempDir()
 		endpoint := "ipc://" + tmpDir + "/foo"
 
 		pub, err := NewPublisher(ctx, endpoint)

--- a/pkg/common/publisher_test.go
+++ b/pkg/common/publisher_test.go
@@ -77,6 +77,55 @@ var _ = Describe("Publisher", func() {
 		Expect(payload).To(Equal(data))
 	})
 
+	It("should publish with passive tcp and receive correct message", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		freePort, err := FreeTCPPort()
+		Expect(err).NotTo(HaveOccurred())
+		endpoint := fmt.Sprintf("tcp://*:%d", freePort)
+
+		pub, err := NewPublisher(ctx, endpoint)
+		Expect(err).NotTo(HaveOccurred())
+
+		time.Sleep(100 * time.Millisecond)
+
+		sub := NewSub(ctx)
+		err = sub.Dial(endpoint)
+		Expect(err).NotTo(HaveOccurred())
+		err = sub.SetOption(zmq4.OptionSubscribe, "")
+		Expect(err).NotTo(HaveOccurred())
+		// nolint
+		defer sub.Close()
+
+		go func() {
+			// Make sure that sub.RecvMessageBytes is called before pub.PublishEvent
+			time.Sleep(time.Second)
+			_, _, err := pub.PublishEvent(ctx, topic, data)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		// The message should be [topic, seq, payload]
+		msg, err := sub.Recv()
+		Expect(err).NotTo(HaveOccurred())
+
+		// message should have 3 frames: topic, sequence, payload
+		Expect(msg.Frames).To(HaveLen(3))
+
+		// check topic
+		Expect(string(msg.Frames[0])).To(Equal(topic))
+
+		// check sequence
+		seq := binary.BigEndian.Uint64(msg.Frames[1])
+		Expect(seq).To(Equal(uint64(1)))
+
+		// check payload
+		var payload string
+		err = msgpack.Unmarshal(msg.Frames[2], &payload)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(payload).To(Equal(data))
+	})
+
 	It("should connect to zmq listener after delay", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/pkg/common/publisher_test.go
+++ b/pkg/common/publisher_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"os"
 
 	"time"
 
@@ -77,13 +78,159 @@ var _ = Describe("Publisher", func() {
 		Expect(payload).To(Equal(data))
 	})
 
-	It("should publish with passive tcp and receive correct message", func() {
+	It("should publish with passive tcp (*) and receive correct message", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		freePort, err := FreeTCPPort()
 		Expect(err).NotTo(HaveOccurred())
 		endpoint := fmt.Sprintf("tcp://*:%d", freePort)
+
+		pub, err := NewPublisher(ctx, endpoint)
+		Expect(err).NotTo(HaveOccurred())
+
+		time.Sleep(100 * time.Millisecond)
+
+		sub := NewSub(ctx)
+		err = sub.Dial(endpoint)
+		Expect(err).NotTo(HaveOccurred())
+		err = sub.SetOption(zmq4.OptionSubscribe, "")
+		Expect(err).NotTo(HaveOccurred())
+		// nolint
+		defer sub.Close()
+
+		go func() {
+			// Make sure that sub.RecvMessageBytes is called before pub.PublishEvent
+			time.Sleep(time.Second)
+			_, _, err := pub.PublishEvent(ctx, topic, data)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		// The message should be [topic, seq, payload]
+		msg, err := sub.Recv()
+		Expect(err).NotTo(HaveOccurred())
+
+		// message should have 3 frames: topic, sequence, payload
+		Expect(msg.Frames).To(HaveLen(3))
+
+		// check topic
+		Expect(string(msg.Frames[0])).To(Equal(topic))
+
+		// check sequence
+		seq := binary.BigEndian.Uint64(msg.Frames[1])
+		Expect(seq).To(Equal(uint64(1)))
+
+		// check payload
+		var payload string
+		err = msgpack.Unmarshal(msg.Frames[2], &payload)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(payload).To(Equal(data))
+	})
+
+	It("should publish with passive tcp ([::]) and receive correct message", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		freePort, err := FreeTCPPort()
+		Expect(err).NotTo(HaveOccurred())
+		endpoint := fmt.Sprintf("tcp://[::]:%d", freePort)
+
+		pub, err := NewPublisher(ctx, endpoint)
+		Expect(err).NotTo(HaveOccurred())
+
+		time.Sleep(100 * time.Millisecond)
+
+		sub := NewSub(ctx)
+		err = sub.Dial(endpoint)
+		Expect(err).NotTo(HaveOccurred())
+		err = sub.SetOption(zmq4.OptionSubscribe, "")
+		Expect(err).NotTo(HaveOccurred())
+		// nolint
+		defer sub.Close()
+
+		go func() {
+			// Make sure that sub.RecvMessageBytes is called before pub.PublishEvent
+			time.Sleep(time.Second)
+			_, _, err := pub.PublishEvent(ctx, topic, data)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		// The message should be [topic, seq, payload]
+		msg, err := sub.Recv()
+		Expect(err).NotTo(HaveOccurred())
+
+		// message should have 3 frames: topic, sequence, payload
+		Expect(msg.Frames).To(HaveLen(3))
+
+		// check topic
+		Expect(string(msg.Frames[0])).To(Equal(topic))
+
+		// check sequence
+		seq := binary.BigEndian.Uint64(msg.Frames[1])
+		Expect(seq).To(Equal(uint64(1)))
+
+		// check payload
+		var payload string
+		err = msgpack.Unmarshal(msg.Frames[2], &payload)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(payload).To(Equal(data))
+	})
+
+	It("should publish with inproc:// and receive correct message", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		endpoint := "inproc://foo"
+
+		pub, err := NewPublisher(ctx, endpoint)
+		Expect(err).NotTo(HaveOccurred())
+
+		time.Sleep(100 * time.Millisecond)
+
+		sub := NewSub(ctx)
+		err = sub.Dial(endpoint)
+		Expect(err).NotTo(HaveOccurred())
+		err = sub.SetOption(zmq4.OptionSubscribe, "")
+		Expect(err).NotTo(HaveOccurred())
+		// nolint
+		defer sub.Close()
+
+		go func() {
+			// Make sure that sub.RecvMessageBytes is called before pub.PublishEvent
+			time.Sleep(time.Second)
+			_, _, err := pub.PublishEvent(ctx, topic, data)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		// The message should be [topic, seq, payload]
+		msg, err := sub.Recv()
+		Expect(err).NotTo(HaveOccurred())
+
+		// message should have 3 frames: topic, sequence, payload
+		Expect(msg.Frames).To(HaveLen(3))
+
+		// check topic
+		Expect(string(msg.Frames[0])).To(Equal(topic))
+
+		// check sequence
+		seq := binary.BigEndian.Uint64(msg.Frames[1])
+		Expect(seq).To(Equal(uint64(1)))
+
+		// check payload
+		var payload string
+		err = msgpack.Unmarshal(msg.Frames[2], &payload)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(payload).To(Equal(data))
+	})
+
+	It("should publish with ipc:// and receive correct message", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		tmpDir, err := os.MkdirTemp("", "zmq")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+		endpoint := "ipc://" + tmpDir + "/foo"
 
 		pub, err := NewPublisher(ctx, endpoint)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/common/test_utils.go
+++ b/pkg/common/test_utils.go
@@ -28,7 +28,7 @@ import (
 const (
 	TestModelName    = "testmodel"
 	QwenModelName    = "Qwen/Qwen2-VL-2B-Instruct"
-	wildcardEndpoint = "tcp://*:*"
+	wildcardEndpoint = "tcp://127.0.0.1:*"
 )
 
 // CreateSub creates a ZMQ sub, subscribes to the provided topic, and returns the

--- a/pkg/tests/simulator_test.go
+++ b/pkg/tests/simulator_test.go
@@ -1238,6 +1238,44 @@ var _ = Describe("Simulator", func() {
 			Expect(removedCount).To(Equal(0))
 		})
 
+		It("passive", func() {
+			// start the server with passive zmq endpoint
+			freePort, err := common.FreeTCPPort()
+			Expect(err).NotTo(HaveOccurred())
+			zmqEndpoint := fmt.Sprintf("tcp://*:%d", freePort)
+			args := []string{"cmd", "--model", model, "--mode", mode,
+				"--enable-kvcache", "true", "--kv-cache-size", "16", "--block-size", "8",
+				"--event-batch-size", "1", "--zmq-endpoint", zmqEndpoint}
+			client, err := startServerWithArgsAndEnv(ctx, mode, args, map[string]string{"POD_IP": "localhost"})
+			Expect(err).NotTo(HaveOccurred())
+
+			// create kv events listener
+			topic := kvcache.CreateKVEventsTopic("localhost", 8000, model)
+			sub := common.NewSub(ctx)
+			err = sub.Dial(zmqEndpoint)
+			Expect(err).NotTo(HaveOccurred())
+			err = sub.SetOption(zmq4.OptionSubscribe, topic)
+			Expect(err).NotTo(HaveOccurred())
+			//nolint
+			defer sub.Close()
+
+			go func() {
+				time.Sleep(200 * time.Millisecond)
+
+				openaiclient, params := getOpenAIClientAndChatParams(client, model, longPrompt, false)
+				resp, err := openaiclient.Chat.Completions.New(ctx, params)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.Choices).ShouldNot(BeEmpty())
+			}()
+
+			// read one event
+			msg, err := sub.Recv()
+			Expect(err).NotTo(HaveOccurred())
+			storedCount, removedCount, _ := kvcache.CountKVEventBlocks(msg.Frames, topic, 1)
+			Expect(storedCount).To(Equal(5))
+			Expect(removedCount).To(Equal(0))
+		})
+
 		// extendedPrompt shares all blocks of longPrompt and adds enough text to push past the next block boundary.
 		extendedPrompt := longPrompt + " This extra sentence pushes it past the next block boundary for the test."
 


### PR DESCRIPTION
## What does this PR do?

add passive tcp support for the zmq endpoint.

## Why is this change needed?

vllm compatibility for certain configurations.

## How was this tested?

tested with EPP precise-prefix-cache-producer's "discoverPods: true".

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
