### PR TITLE
Move sleep/wake-up decisions from communication into SimContext

### DIFF
--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
 	"github.com/llm-d/llm-d-inference-sim/pkg/communication/grpc/pb"
+	"github.com/llm-d/llm-d-inference-sim/pkg/endpoint"
 	"github.com/llm-d/llm-d-inference-sim/pkg/simulator"
 	"github.com/soheilhy/cmux"
 	"google.golang.org/grpc"
@@ -36,12 +37,13 @@ import (
 type Communication struct {
 	logger    logr.Logger
 	simulator *simulator.Simulator
+	// runtime is the seam through which handlers already migrated to
+	// endpoint.Runtime reach the simulator engine; call sites not yet
+	// migrated keep using simulator directly.
+	runtime endpoint.Runtime
 
 	// set to 1 during graceful shutdown; new requests are rejected while draining
 	stopping atomic.Bool
-
-	// a mutex for sleep-wake up
-	sleepMutex sync.RWMutex
 
 	pb.UnimplementedVllmEngineServer
 
@@ -57,11 +59,11 @@ type Communication struct {
 }
 
 func New(logger logr.Logger, simulator *simulator.Simulator) *Communication {
-	return &Communication{logger: logger, simulator: simulator, startTime: time.Now()}
+	return &Communication{logger: logger, simulator: simulator, runtime: &simulator.Context, startTime: time.Now()}
 }
 
 func Start(ctx context.Context, logger logr.Logger, simulator *simulator.Simulator) error {
-	c := Communication{logger: logger, simulator: simulator, startTime: time.Now()}
+	c := Communication{logger: logger, simulator: simulator, runtime: &simulator.Context, startTime: time.Now()}
 	c.logger.V(logging.INFO).Info("Starting communication layer")
 	return c.start(ctx)
 }

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -905,9 +905,7 @@ func (c *Communication) HandleMooncakeQuery(ctx *fasthttp.RequestCtx) {
 func (c *Communication) HandleIsSleeping(ctx *fasthttp.RequestCtx) {
 	c.logger.V(logging.TRACE).Info("/is_sleeping request received")
 
-	c.sleepMutex.RLock()
-	defer c.sleepMutex.RUnlock()
-	data, err := json.Marshal(map[string]bool{"is_sleeping": c.simulator.IsSleeping})
+	data, err := json.Marshal(map[string]bool{"is_sleeping": c.runtime.IsSleeping()})
 	if err != nil {
 		c.logger.Error(err, "failed to marshal isSleeping response")
 		errToSend := api.NewError("Failed to marshal isSleeping response, "+err.Error(), fasthttp.StatusInternalServerError, nil)
@@ -922,16 +920,8 @@ func (c *Communication) HandleIsSleeping(ctx *fasthttp.RequestCtx) {
 
 // HandleSleep http handler for /sleep
 func (c *Communication) HandleSleep(ctx *fasthttp.RequestCtx) {
-	if c.simulator.Context.Config().EnableSleepMode && c.simulator.Context.Config().VllmDevMode {
-		c.logger.V(logging.INFO).Info("Sleep request received")
-		c.sleepMutex.Lock()
-		defer c.sleepMutex.Unlock()
-
-		c.simulator.IsSleeping = true
-		if c.simulator.Context.Config().EnableKVCache {
-			c.simulator.DiscardKVCache()
-		}
-	} else {
+	c.logger.V(logging.INFO).Info("Sleep request received")
+	if !c.runtime.Sleep() {
 		c.logger.V(logging.INFO).Info("Sleep request received, skipped since simulator not in dev mode or sleep support is not enabled")
 	}
 
@@ -952,15 +942,7 @@ func (c *Communication) HandleWakeUp(ctx *fasthttp.RequestCtx) {
 		wakeUpKVCache = true
 	}
 
-	c.sleepMutex.Lock()
-	defer c.sleepMutex.Unlock()
-
-	// Activate the kv cache if either the tags are "kv_cache" or there are no tags
-	if c.simulator.Context.Config().EnableKVCache && wakeUpKVCache {
-		c.simulator.ActivateKVCache()
-	}
-
-	c.simulator.IsSleeping = false
+	c.runtime.WakeUp(wakeUpKVCache)
 
 	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
 }

--- a/pkg/endpoint/runtime.go
+++ b/pkg/endpoint/runtime.go
@@ -49,4 +49,12 @@ type Runtime interface {
 	KVCacheOnRequestStart(req api.Request) (kvcache.PrefixCacheStats, *api.Error)
 	// KVCacheOnRequestEnd records the request's completion in the KV cache, if enabled.
 	KVCacheOnRequestEnd(requestID string)
+	// Sleep transitions the simulator into sleep mode. Returns whether it
+	// actually slept.
+	Sleep() bool
+	// WakeUp wakes the simulator, activating the KV cache when
+	// activateKVCache is true and KV cache support is enabled.
+	WakeUp(activateKVCache bool)
+	// IsSleeping reports whether the simulator is currently sleeping.
+	IsSleeping() bool
 }

--- a/pkg/endpoint/runtime_test.go
+++ b/pkg/endpoint/runtime_test.go
@@ -48,3 +48,6 @@ func (f *fakeRuntime) KVCacheOnRequestStart(req api.Request) (kvcache.PrefixCach
 	return kvcache.PrefixCacheStats{}, nil
 }
 func (f *fakeRuntime) KVCacheOnRequestEnd(requestID string) {}
+func (f *fakeRuntime) Sleep() bool                          { return false }
+func (f *fakeRuntime) WakeUp(activateKVCache bool)          {}
+func (f *fakeRuntime) IsSleeping() bool                     { return false }

--- a/pkg/simulator/context.go
+++ b/pkg/simulator/context.go
@@ -79,6 +79,11 @@ type SimContext struct {
 	latencyCalculator atomic.Pointer[latencyCalcHolder]
 	// Tokenizer used for request tokenization and in /tokenize
 	Tokenizer tokenizer.Tokenizer
+	// isSleeping records whether the simulator is currently sleeping. Guarded
+	// by sleepMutex rather than adminMu since it's read far more often
+	// (/is_sleeping) than it's written.
+	isSleeping bool
+	sleepMutex sync.RWMutex
 }
 
 type latencyCalcHolder struct {
@@ -267,6 +272,41 @@ func (s *SimContext) GetTokenizer() tokenizer.Tokenizer {
 // Logger returns the simulator's logger.
 func (s *SimContext) Logger() logr.Logger {
 	return s.logger
+}
+
+// Sleep transitions the simulator into sleep mode, discarding the KV cache
+// if enabled. It is a no-op, reporting false, unless sleep mode is enabled
+// and the simulator is running in dev mode.
+func (s *SimContext) Sleep() bool {
+	cfg := s.Config()
+	if !cfg.EnableSleepMode || !cfg.VllmDevMode {
+		return false
+	}
+	s.sleepMutex.Lock()
+	defer s.sleepMutex.Unlock()
+	s.isSleeping = true
+	if cfg.EnableKVCache {
+		s.kvcacheHelper.Discard()
+	}
+	return true
+}
+
+// WakeUp wakes the simulator, activating the KV cache when activateKVCache
+// is true and KV cache support is enabled.
+func (s *SimContext) WakeUp(activateKVCache bool) {
+	s.sleepMutex.Lock()
+	defer s.sleepMutex.Unlock()
+	if s.Config().EnableKVCache && activateKVCache {
+		s.kvcacheHelper.Activate()
+	}
+	s.isSleeping = false
+}
+
+// IsSleeping reports whether the simulator is currently sleeping.
+func (s *SimContext) IsSleeping() bool {
+	s.sleepMutex.RLock()
+	defer s.sleepMutex.RUnlock()
+	return s.isSleeping
 }
 
 // RequestStarted records that req has begun processing: increments the

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -50,8 +50,6 @@ type Simulator struct {
 	Context SimContext
 	// schema validator for tools parameters
 	toolsValidator *endpoint.ToolsValidator
-	// indication whether the simulator is sleeping
-	IsSleeping bool
 	// a channel for free workers
 	freeWorkers chan *worker
 	// a channel to indicate that a worker finished working on a request
@@ -551,12 +549,4 @@ func (s *Simulator) OpenRequests() int64 {
 	s.queueLock.Unlock()
 	running := cap(s.freeWorkers) - len(s.freeWorkers)
 	return int64(waiting + running)
-}
-
-func (s *Simulator) DiscardKVCache() {
-	s.Context.kvcacheHelper.Discard()
-}
-
-func (s *Simulator) ActivateKVCache() {
-	s.Context.kvcacheHelper.Activate()
 }


### PR DESCRIPTION
`HandleSleep`/`HandleWakeUp`/`HandleIsSleeping` in `pkg/communication` held simulator decisions inline (sleep-mode gating, KV-cache discard/activate, and the sleeping state itself, with its own mutex). This PR moves that logic onto SimContext, where equivalent engine state already lives, and exposes it through the existing `endpoint.Runtime` seam so `pkg/communication`'s handlers are reduced to plain HTTP plumbing. 

First step of a larger effort to decouple `pkg/communication` from `pkg/simulator`. The rest of that migration is deferred to follow-up PRs.