### PR TITLE
Move model-validation and image/mooncake decisions from communication into SimContext

### DIFF
--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -51,11 +50,6 @@ type Communication struct {
 
 	// startTime records when the server started, used for startup-duration readiness check
 	startTime time.Time
-
-	// mooncakeEngines holds the per-rank engine ids served by /query, generated once so
-	// they stay stable for the simulator's lifetime
-	mooncakeEnginesOnce sync.Once
-	mooncakeEngines     map[string]map[string]string
 }
 
 func New(logger logr.Logger, simulator *simulator.Simulator) *Communication {

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -184,7 +184,7 @@ func (c *Communication) handleRender(req endpoint.RenderableRequest, respBuilder
 		c.sendError(ctx, err, false)
 		return
 	}
-	if err := c.simulator.ValidateBaseModel(req.GetModel()); err != nil {
+	if err := c.runtime.ValidateBaseModel(req.GetModel()); err != nil {
 		c.sendError(ctx, err, false)
 		return
 	}
@@ -262,17 +262,8 @@ func (c *Communication) handleHTTP(req endpoint.Request, respBuilder responseBui
 		req.SetCacheThresholdFinishReason(parsedValue)
 	}
 
-	cfg := c.simulator.Context.Config()
-	if cfg.Omni {
-		sendImg := false
-		if headerVal, err := strconv.ParseBool(string(ctx.Request.Header.Peek(XSendImageHeader))); err == nil {
-			sendImg = headerVal
-		}
-		if !sendImg && cfg.ImageEmissionRate > 0 {
-			sendImg = c.simulator.Context.Random.RandomInt(1, 100) <= cfg.ImageEmissionRate
-		}
-		req.SetSendImage(sendImg)
-	}
+	headerOverride, _ := strconv.ParseBool(string(ctx.Request.Header.Peek(XSendImageHeader)))
+	req.SetSendImage(c.runtime.ShouldSendImage(headerOverride))
 
 	numChoices, isStream, channel, err, errInjected := c.simulator.HandleRequest(req)
 	if err != nil {
@@ -864,22 +855,6 @@ func (c *Communication) HandleHealthReady(ctx *fasthttp.RequestCtx) {
 	ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
 }
 
-// mooncakeEngineMap returns the dp_rank -> {engine_id} map served by /query, generating
-// it once so the engine ids stay stable for the simulator's lifetime.
-func (c *Communication) mooncakeEngineMap() map[string]map[string]string {
-	c.mooncakeEnginesOnce.Do(func() {
-		dpSize := c.simulator.Context.Config().DPSize
-		engines := make(map[string]map[string]string, dpSize)
-		for rank := 0; rank < dpSize; rank++ {
-			engines[strconv.Itoa(rank)] = map[string]string{
-				"engine_id": c.simulator.Context.Random.GenerateUUIDString(),
-			}
-		}
-		c.mooncakeEngines = engines
-	})
-	return c.mooncakeEngines
-}
-
 // HandleMooncakeQuery emulates vLLM's Mooncake bootstrap endpoint (/query) served on
 // the prefill pod. The routing sidecar calls it to resolve the remote engine id used
 // for KV transfer, receiving a dp_rank -> {engine_id} map. The engine ids are
@@ -888,7 +863,7 @@ func (c *Communication) mooncakeEngineMap() map[string]map[string]string {
 func (c *Communication) HandleMooncakeQuery(ctx *fasthttp.RequestCtx) {
 	c.logger.V(logging.TRACE).Info("/query request received")
 
-	data, err := json.Marshal(c.mooncakeEngineMap())
+	data, err := json.Marshal(c.runtime.MooncakeEngineMap())
 	if err != nil {
 		c.logger.Error(err, "failed to marshal mooncake query response")
 		errToSend := api.NewError("Failed to marshal mooncake query response, "+err.Error(), fasthttp.StatusInternalServerError, nil)

--- a/pkg/endpoint/runtime.go
+++ b/pkg/endpoint/runtime.go
@@ -57,4 +57,14 @@ type Runtime interface {
 	WakeUp(activateKVCache bool)
 	// IsSleeping reports whether the simulator is currently sleeping.
 	IsSleeping() bool
+	// ValidateBaseModel checks that model is a known base model, rejecting
+	// LoRA adapters.
+	ValidateBaseModel(model string) *api.Error
+	// ShouldSendImage decides whether an Omni response should include an
+	// image. headerOverride, when true, forces an image regardless of the
+	// emission rate.
+	ShouldSendImage(headerOverride bool) bool
+	// MooncakeEngineMap returns the dp_rank -> {engine_id} map served by
+	// /query, stable for the simulator's lifetime.
+	MooncakeEngineMap() map[string]map[string]string
 }

--- a/pkg/endpoint/runtime_test.go
+++ b/pkg/endpoint/runtime_test.go
@@ -47,12 +47,10 @@ func (f *fakeRuntime) GetResponseTokens(req api.Request) (*api.Tokenized, string
 func (f *fakeRuntime) KVCacheOnRequestStart(req api.Request) (kvcache.PrefixCacheStats, *api.Error) {
 	return kvcache.PrefixCacheStats{}, nil
 }
-func (f *fakeRuntime) KVCacheOnRequestEnd(requestID string)      {}
-func (f *fakeRuntime) Sleep() bool                               { return false }
-func (f *fakeRuntime) WakeUp(activateKVCache bool)               {}
-func (f *fakeRuntime) IsSleeping() bool                          { return false }
-func (f *fakeRuntime) ValidateBaseModel(model string) *api.Error { return nil }
-func (f *fakeRuntime) ShouldSendImage(headerOverride bool) bool  { return headerOverride }
-func (f *fakeRuntime) MooncakeEngineMap() map[string]map[string]string {
-	return nil
-}
+func (f *fakeRuntime) KVCacheOnRequestEnd(requestID string)            {}
+func (f *fakeRuntime) Sleep() bool                                     { return false }
+func (f *fakeRuntime) WakeUp(activateKVCache bool)                     {}
+func (f *fakeRuntime) IsSleeping() bool                                { return false }
+func (f *fakeRuntime) ValidateBaseModel(model string) *api.Error       { return nil }
+func (f *fakeRuntime) ShouldSendImage(headerOverride bool) bool        { return headerOverride }
+func (f *fakeRuntime) MooncakeEngineMap() map[string]map[string]string { return nil }

--- a/pkg/endpoint/runtime_test.go
+++ b/pkg/endpoint/runtime_test.go
@@ -47,7 +47,12 @@ func (f *fakeRuntime) GetResponseTokens(req api.Request) (*api.Tokenized, string
 func (f *fakeRuntime) KVCacheOnRequestStart(req api.Request) (kvcache.PrefixCacheStats, *api.Error) {
 	return kvcache.PrefixCacheStats{}, nil
 }
-func (f *fakeRuntime) KVCacheOnRequestEnd(requestID string) {}
-func (f *fakeRuntime) Sleep() bool                          { return false }
-func (f *fakeRuntime) WakeUp(activateKVCache bool)          {}
-func (f *fakeRuntime) IsSleeping() bool                     { return false }
+func (f *fakeRuntime) KVCacheOnRequestEnd(requestID string)      {}
+func (f *fakeRuntime) Sleep() bool                               { return false }
+func (f *fakeRuntime) WakeUp(activateKVCache bool)               {}
+func (f *fakeRuntime) IsSleeping() bool                          { return false }
+func (f *fakeRuntime) ValidateBaseModel(model string) *api.Error { return nil }
+func (f *fakeRuntime) ShouldSendImage(headerOverride bool) bool  { return headerOverride }
+func (f *fakeRuntime) MooncakeEngineMap() map[string]map[string]string {
+	return nil
+}

--- a/pkg/simulator/context.go
+++ b/pkg/simulator/context.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -84,6 +85,10 @@ type SimContext struct {
 	// (/is_sleeping) than it's written.
 	isSleeping bool
 	sleepMutex sync.RWMutex
+	// mooncakeEngines holds the per-rank engine ids served by /query, generated once so
+	// they stay stable for the simulator's lifetime
+	mooncakeEnginesOnce sync.Once
+	mooncakeEngines     map[string]map[string]string
 }
 
 type latencyCalcHolder struct {
@@ -307,6 +312,38 @@ func (s *SimContext) IsSleeping() bool {
 	s.sleepMutex.RLock()
 	defer s.sleepMutex.RUnlock()
 	return s.isSleeping
+}
+
+// ShouldSendImage decides whether an Omni response should include an image.
+// headerOverride, when true, forces an image regardless of the emission
+// rate; otherwise the decision is a random roll gated by
+// Configuration.ImageEmissionRate. Always false outside Omni mode.
+func (s *SimContext) ShouldSendImage(headerOverride bool) bool {
+	cfg := s.Config()
+	if !cfg.Omni {
+		return false
+	}
+	if headerOverride {
+		return true
+	}
+	return cfg.ImageEmissionRate > 0 && s.Random.RandomInt(1, 100) <= cfg.ImageEmissionRate
+}
+
+// MooncakeEngineMap returns the dp_rank -> {engine_id} map served by /query,
+// generating it once so the engine ids stay stable for the simulator's
+// lifetime.
+func (s *SimContext) MooncakeEngineMap() map[string]map[string]string {
+	s.mooncakeEnginesOnce.Do(func() {
+		dpSize := s.Config().DPSize
+		engines := make(map[string]map[string]string, dpSize)
+		for rank := 0; rank < dpSize; rank++ {
+			engines[strconv.Itoa(rank)] = map[string]string{
+				"engine_id": s.Random.GenerateUUIDString(),
+			}
+		}
+		s.mooncakeEngines = engines
+	})
+	return s.mooncakeEngines
 }
 
 // RequestStarted records that req has begun processing: increments the

--- a/pkg/simulator/helpers.go
+++ b/pkg/simulator/helpers.go
@@ -24,13 +24,13 @@ import (
 )
 
 // isValidModel checks if the given model is the base model or one of "loaded" LoRAs
-func (s *Simulator) isValidModel(model string) bool {
-	for _, name := range s.Context.Config().ServedModelNames {
+func (s *SimContext) isValidModel(model string) bool {
+	for _, name := range s.Config().ServedModelNames {
 		if model == name {
 			return true
 		}
 	}
-	for _, lora := range s.Context.getLoras() {
+	for _, lora := range s.getLoras() {
 		if model == lora {
 			return true
 		}
@@ -42,13 +42,13 @@ func (s *Simulator) isValidModel(model string) bool {
 // ValidateBaseModel checks that model is a known base model. LoRA adapters
 // are rejected because the render endpoints tokenize against the base model
 // and don't go through the LoRA loading path.
-func (s *Simulator) ValidateBaseModel(model string) *api.Error {
+func (s *SimContext) ValidateBaseModel(model string) *api.Error {
 	if !s.isValidModel(model) {
 		serverErr := api.NewError(fmt.Sprintf("The model `%s` does not exist.", model),
 			fasthttp.StatusNotFound, nil)
 		return &serverErr
 	}
-	if s.Context.isLora(model) {
+	if s.isLora(model) {
 		serverErr := api.NewError(fmt.Sprintf("The model `%s` is a LoRA adapter and is not supported by the render endpoints.",
 			model), fasthttp.StatusBadRequest, nil)
 		return &serverErr

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -354,7 +354,7 @@ func (s *Simulator) HandleRequest(req endpoint.Request) (numChoices int, isStrea
 	}
 
 	// the model defined in the request should be checked here
-	if !s.isValidModel(req.GetModel()) {
+	if !s.Context.isValidModel(req.GetModel()) {
 		serverErr := api.NewError(fmt.Sprintf("The model `%s` does not exist.",
 			req.GetModel()), fasthttp.StatusNotFound, nil)
 		return 0, false, nil, &serverErr, false


### PR DESCRIPTION
`ValidateBaseModel` was misplaced on `Simulator` despite touching only `SimContext` state, and `pkg/communication`'s HTTP layer held two more simulator decisions inline: the Omni image-emission roll and the per-rank Mooncake engine-id map. This PR moves all three onto `SimContext` and exposes them through `endpoint.Runtime`, continuing the same decoupling pattern used for sleep/wake-up (#669).