### PR TITLE
fix: reject empty messages array on /v1/chat/completions

### DIFF
--- a/pkg/endpoint/chat_completion.go
+++ b/pkg/endpoint/chat_completion.go
@@ -40,10 +40,10 @@ func (c *ChatCompletionsRequest) Unmarshal(data []byte) error {
 	return json.Unmarshal(data, c)
 }
 
-// ValidateBody checks that a /v1/chat/completions/render body has the required
-// chat shape — at minimum, a non-empty messages array. Catches text-shaped
-// bodies (which JSON-unmarshal cleanly into ChatCompletionsRequest with empty
-// Messages because Go ignores unknown fields by default).
+// ValidateBody checks that a chat body has the required chat shape — at
+// minimum, a non-empty messages array. Catches text-shaped bodies (which
+// JSON-unmarshal cleanly into ChatCompletionsRequest with empty Messages
+// because Go ignores unknown fields by default).
 func (c *ChatCompletionsRequest) ValidateBody() *api.Error {
 	if len(c.Messages) == 0 {
 		serverErr := api.NewError("messages must not be empty", fasthttp.StatusBadRequest, nil)
@@ -64,6 +64,9 @@ func (c *ChatCompletionsRequest) Render(tk tokenizer.Tokenizer) ([][]uint32, *ap
 }
 
 func (c *ChatCompletionsRequest) Validate(toolsValidator *ToolsValidator) *api.Error {
+	if err := c.ValidateBody(); err != nil {
+		return err
+	}
 	for _, tool := range c.Tools {
 		toolJson, err := json.Marshal(tool.Function)
 		if err != nil {

--- a/pkg/endpoint/request_test.go
+++ b/pkg/endpoint/request_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/api"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/valyala/fasthttp"
 )
 
 // ptrInt64 and ptrInt return pointers to their argument; small helpers for
@@ -158,6 +159,25 @@ var _ = Describe("convertInputToMessages", func() {
 		// Even single image → structured content (multimodal)
 		Expect(messages[0].Content.Structured).To(HaveLen(1))
 		Expect(messages[0].Content.Structured[0].Type).To(Equal("image_url"))
+	})
+})
+
+var _ = Describe("ChatCompletionsRequest.Validate", func() {
+	It("rejects an empty messages array", func() {
+		req := &ChatCompletionsRequest{}
+		req.Messages = []api.Message{}
+
+		err := req.Validate(nil)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Code).To(Equal(fasthttp.StatusBadRequest))
+		Expect(err.Message).To(Equal("messages must not be empty"))
+	})
+
+	It("accepts a request carrying at least one message", func() {
+		req := &ChatCompletionsRequest{}
+		req.Messages = []api.Message{{Role: api.RoleUser}}
+
+		Expect(req.Validate(nil)).To(BeNil())
 	})
 })
 

--- a/pkg/tests/chat_completions_test.go
+++ b/pkg/tests/chat_completions_test.go
@@ -441,6 +441,27 @@ var _ = Describe("Simulator", func() {
 		Expect(usage["completion_tokens"]).To(BeNumerically(">", 0))
 	})
 
+	It("chat completions with an empty messages array is rejected with 400", func() {
+		ctx := context.TODO()
+		args := []string{"cmd", "--model", common.TestModelName, "--mode", common.ModeEcho}
+		client, err := startServerWithArgs(ctx, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		reqBody := fmt.Sprintf(`{"model": "%s", "messages": []}`, common.TestModelName)
+
+		resp, err := client.Post("http://localhost/v1/chat/completions", "application/json", strings.NewReader(reqBody))
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			Expect(resp.Body.Close()).To(Succeed())
+		}()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(body)).To(ContainSubstring("messages must not be empty"))
+	})
+
 	DescribeTable("streaming chat completions with logprobs",
 		func(mode string, logprobs bool, topLogprobs int) {
 			ctx := context.TODO()


### PR DESCRIPTION
## What does this PR do?

Makes `/v1/chat/completions` return 400 for a body with `"messages": []`, instead of 200 with a generated completion and `prompt_tokens: 0`.

`ChatCompletionsRequest.ValidateBody()` already rejects an empty messages array, but only the render handler calls it (`pkg/communication/http.go`). The main completions path goes through `Validate()` (`pkg/simulator/simulator.go`), which checked tools and nothing else. The check existed and was simply never reachable from this endpoint.

The change calls `ValidateBody()` from `Validate()`, following the pattern the sibling endpoints already use:

- `TextCompletionsParsedRequest.Validate` calls its own `ValidateBody()` first.
- `MessagesRequest.Validate` checks the array inline.

Chat completions was the only one of the three doing neither.

The `ValidateBody` doc comment is also corrected: it described the method as belonging to `/v1/chat/completions/render`, which is no longer accurate now that both paths call it.

## Why is this change needed?

The sim's contract is to behave like vLLM, and real vLLM returns 400 for an empty messages array. A client with a bug (for example an empty conversation array) currently tests green against the sim and fails in production against real vLLM. The sim was also inconsistent with itself: `/v1/messages` and `/v1/completions` already reject the equivalent degenerate input.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual testing performed

Added to `pkg/endpoint/request_test.go`: `Validate` rejects an empty messages array with 400 and the expected message, and still accepts a request carrying at least one message. These pass (39 specs in `pkg/endpoint`), and I confirmed they gate the fix by reverting it and watching the empty-array spec fail specifically.

Added to `pkg/tests/chat_completions_test.go`: an HTTP-level test asserting 400 for `"messages": []`, mirroring the existing empty-prompt test in `text_completions_test.go`.

**I was not able to run the `pkg/tests` suite locally.** Its `BeforeSuite` starts a tokenizer render container via testcontainers, and there is no Docker daemon available on my machine. I verified the assertions against the code instead: `sendError` sets `ctx.SetStatusCode(err.Code)`, and `api.NewError(..., fasthttp.StatusBadRequest, nil)` supplies 400, with the message marshalled into the response body. Flagging it explicitly so CI is the first real execution of that test rather than my say-so.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

`make test` and `make lint` are unticked. `make test` is blocked by the Docker requirement above. `make lint` fails on this machine with a golangci-lint typecheck error against a Go 1.27 toolchain (`cmd/signals/signals.go`, "export data version 4 is greater than maximum supported version 2"); it fails identically on an unmodified `main`, so it looks like a local toolchain mismatch rather than anything in this change. The rest of `make presubmit` passed: branch check, signed-commits, go-mod-check, and format (no changes).

## Related Issues

Fixes #666