### PR TITLE
Decouple pkg/communication from pkg/simulator via a Processor interface

### DIFF
--- a/cmd/llm-d-inference-sim/main.go
+++ b/cmd/llm-d-inference-sim/main.go
@@ -58,7 +58,7 @@ func main() {
 	g := new(errgroup.Group)
 	for _, sim := range simulators {
 		g.Go(func() error {
-			return communication.Start(ctx, logger, sim)
+			return communication.Start(ctx, logger, sim, &sim.Context)
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/pkg/communication/communication.go
+++ b/pkg/communication/communication.go
@@ -28,17 +28,16 @@ import (
 	"github.com/llm-d/llm-d-inference-sim/pkg/common/logging"
 	"github.com/llm-d/llm-d-inference-sim/pkg/communication/grpc/pb"
 	"github.com/llm-d/llm-d-inference-sim/pkg/endpoint"
-	"github.com/llm-d/llm-d-inference-sim/pkg/simulator"
 	"github.com/soheilhy/cmux"
 	"google.golang.org/grpc"
 )
 
 type Communication struct {
 	logger logr.Logger
-	// simulator is used only for the queue/lifecycle operations that don't
-	// belong on endpoint.Runtime: HandleRequest, OpenRequests, Stop. Every
-	// other access to the simulator engine goes through runtime.
-	simulator *simulator.Simulator
+	// processor submits requests to the simulator's queue and controls its
+	// lifecycle. runtime covers everything else the transport layer needs
+	// from the simulator engine.
+	processor Processor
 	runtime   endpoint.Runtime
 
 	// set to 1 during graceful shutdown; new requests are rejected while draining
@@ -52,12 +51,12 @@ type Communication struct {
 	startTime time.Time
 }
 
-func New(logger logr.Logger, simulator *simulator.Simulator) *Communication {
-	return &Communication{logger: logger, simulator: simulator, runtime: &simulator.Context, startTime: time.Now()}
+func New(logger logr.Logger, processor Processor, runtime endpoint.Runtime) *Communication {
+	return &Communication{logger: logger, processor: processor, runtime: runtime, startTime: time.Now()}
 }
 
-func Start(ctx context.Context, logger logr.Logger, simulator *simulator.Simulator) error {
-	c := Communication{logger: logger, simulator: simulator, runtime: &simulator.Context, startTime: time.Now()}
+func Start(ctx context.Context, logger logr.Logger, processor Processor, runtime endpoint.Runtime) error {
+	c := Communication{logger: logger, processor: processor, runtime: runtime, startTime: time.Now()}
 	c.logger.V(logging.INFO).Info("Starting communication layer")
 	return c.start(ctx)
 }
@@ -125,15 +124,15 @@ func (c *Communication) start(ctx context.Context) error {
 		const drainTimeout = 30 * time.Second
 		drainDeadline := time.Now().Add(drainTimeout)
 		c.logger.V(logging.INFO).Info("Waiting for all in-flight requests to finish")
-		for c.simulator.OpenRequests() > 0 {
+		for c.processor.OpenRequests() > 0 {
 			if time.Now().After(drainDeadline) {
 				c.logger.V(logging.INFO).Info("Drain timed out, proceeding with shutdown",
-					"open_requests", c.simulator.OpenRequests())
+					"open_requests", c.processor.OpenRequests())
 				break
 			}
 			time.Sleep(10 * time.Millisecond)
 		}
-		c.simulator.Stop()
+		c.processor.Stop()
 
 		// Shut down HTTP first: grpcServer.Stop() closes grpcL which causes cmux to stop
 		// routing to httpL, making the HTTP server's Serve() return and set s.ln = nil.

--- a/pkg/communication/grpc.go
+++ b/pkg/communication/grpc.go
@@ -40,7 +40,7 @@ func (c *Communication) Generate(in *pb.GenerateRequest, out grpc.ServerStreamin
 
 	req := c.pbRequestToRequest(in)
 	respBuilder := &generationGRPCRespBuilder{}
-	_, _, channel, err, _ := c.simulator.HandleRequest(req)
+	_, _, channel, err, _ := c.processor.HandleRequest(req)
 	if err != nil {
 		return status.Errorf(extractGRPCCode(err), err.Message, err)
 	}

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -82,7 +82,7 @@ func (c *Communication) startHTTPServer(ctx context.Context, listener net.Listen
 	r.POST("/v1/load_lora_adapter", c.HandleLoadLora)
 	r.POST("/v1/unload_lora_adapter", c.HandleUnloadLora)
 	// supports /metrics prometheus API
-	r.GET("/metrics", fasthttpadaptor.NewFastHTTPHandler(promhttp.HandlerFor(c.simulator.Context.MetricsRegistry(), promhttp.HandlerOpts{})))
+	r.GET("/metrics", fasthttpadaptor.NewFastHTTPHandler(promhttp.HandlerFor(c.processor.MetricsRegistry(), promhttp.HandlerOpts{})))
 	r.POST("/fake_metrics", c.HandleFakeMetrics)
 	// supports standard Kubernetes health and readiness checks
 	r.GET("/health", c.HandleHealth)
@@ -266,7 +266,7 @@ func (c *Communication) handleHTTP(req endpoint.Request, respBuilder responseBui
 	headerOverride, _ := strconv.ParseBool(string(ctx.Request.Header.Peek(XSendImageHeader)))
 	req.SetSendImage(c.runtime.ShouldSendImage(headerOverride))
 
-	numChoices, isStream, channel, err, errInjected := c.simulator.HandleRequest(req)
+	numChoices, isStream, channel, err, errInjected := c.processor.HandleRequest(req)
 	if err != nil {
 		c.sendError(ctx, err, errInjected)
 		return
@@ -732,7 +732,7 @@ func (c *Communication) HandleTokenize(ctx *fasthttp.RequestCtx) {
 
 func (c *Communication) HandleLoadLora(ctx *fasthttp.RequestCtx) {
 	c.logger.V(logging.DEBUG).Info("Load lora request received")
-	if err := c.simulator.Context.LoadLoraAdaptor(ctx.Request.Body()); err != nil {
+	if err := c.processor.LoadLoraAdaptor(ctx.Request.Body()); err != nil {
 		errToSend := api.NewError(err.Error(), fasthttp.StatusBadRequest, nil)
 		c.sendError(ctx, &errToSend, false)
 	}
@@ -740,7 +740,7 @@ func (c *Communication) HandleLoadLora(ctx *fasthttp.RequestCtx) {
 
 func (c *Communication) HandleUnloadLora(ctx *fasthttp.RequestCtx) {
 	c.logger.V(logging.DEBUG).Info("Unload lora request received")
-	if err := c.simulator.Context.UnloadLoraAdaptor(ctx.Request.Body()); err != nil {
+	if err := c.processor.UnloadLoraAdaptor(ctx.Request.Body()); err != nil {
 		errToSend := api.NewError(err.Error(), fasthttp.StatusBadRequest, nil)
 		c.sendError(ctx, &errToSend, false)
 	}

--- a/pkg/communication/processor.go
+++ b/pkg/communication/processor.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package communication
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/api"
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+	"github.com/llm-d/llm-d-inference-sim/pkg/endpoint"
+)
+
+// Processor is the seam through which the transport layer submits requests
+// to the simulator's queue, controls its lifecycle, and reaches its
+// admin/metrics surface. It is satisfied implicitly by *simulator.Simulator,
+// which keeps this package free of any dependency on the simulator package.
+type Processor interface {
+	// HandleRequest submits req to the simulator's worker queue.
+	HandleRequest(req endpoint.Request) (numChoices int, isStream bool,
+		channel *common.Channel[*endpoint.ResponseInfo], err *api.Error, errInjected bool)
+	// OpenRequests reports the number of requests currently in flight.
+	OpenRequests() int64
+	// Stop cancels the simulator's processing loop.
+	Stop()
+	// MetricsRegistry returns the simulator's Prometheus registry.
+	MetricsRegistry() *prometheus.Registry
+	// LoadLoraAdaptor loads a LoRA adapter described by body.
+	LoadLoraAdaptor(body []byte) error
+	// UnloadLoraAdaptor unloads a LoRA adapter described by body.
+	UnloadLoraAdaptor(body []byte) error
+}

--- a/pkg/simulator/lora.go
+++ b/pkg/simulator/lora.go
@@ -85,6 +85,16 @@ func (s *SimContext) UnloadLoraAdaptor(body []byte) error {
 	return nil
 }
 
+// LoadLoraAdaptor loads a LoRA adapter described by body.
+func (s *Simulator) LoadLoraAdaptor(body []byte) error {
+	return s.Context.LoadLoraAdaptor(body)
+}
+
+// UnloadLoraAdaptor unloads a LoRA adapter described by body.
+func (s *Simulator) UnloadLoraAdaptor(body []byte) error {
+	return s.Context.UnloadLoraAdaptor(body)
+}
+
 // Checks if the LoRA adaptor is loaded
 func (s *SimContext) loraIsLoaded(model string) bool {
 	if !s.isLora(model) {

--- a/pkg/simulator/metrics.go
+++ b/pkg/simulator/metrics.go
@@ -173,6 +173,11 @@ func (s *SimContext) MetricsRegistry() *prometheus.Registry {
 	return s.metrics.registry
 }
 
+// MetricsRegistry returns the simulator's Prometheus registry.
+func (s *Simulator) MetricsRegistry() *prometheus.Registry {
+	return s.Context.MetricsRegistry()
+}
+
 // createAndRegisterPrometheus creates and registers prometheus metrics used by vLLM simulator
 func (s *SimContext) createAndRegisterPrometheus(ctx context.Context) error {
 	maxNumberOfRequests := (s.Config().MaxNumSeqs + s.Config().MaxWaitingQueueLength) * 2

--- a/pkg/tests/test_utils_test.go
+++ b/pkg/tests/test_utils_test.go
@@ -172,7 +172,7 @@ func startServerHelper(ctx context.Context, mode string, args []string, envs map
 	}
 
 	listener := fasthttputil.NewInmemoryListener()
-	comm := communication.New(logger, s)
+	comm := communication.New(logger, s, &s.Context)
 
 	ginkgo.DeferCleanup(func() {
 		listener.Close() //nolint:errcheck
@@ -236,7 +236,7 @@ func startDataParallelServers(ctx context.Context, args []string, envs ...map[st
 	clients := make([]*http.Client, len(sims))
 	for rank, sim := range sims {
 		listener := fasthttputil.NewInmemoryListener()
-		comm := communication.New(logger, sim)
+		comm := communication.New(logger, sim, &sim.Context)
 
 		ginkgo.DeferCleanup(func() {
 			listener.Close() //nolint:errcheck


### PR DESCRIPTION
 Introduces `communication.Processor`, so Communication depends only on `Processor` and` endpoint.Runtime` instead of a concrete `*simulator.Simulator`. `pkg/communication` no longer imports `pkg/simulator `at all. `*simulator.Simulator` satisfies `Processor` via a couple of thin delegators to its `SimContext` for the admin methods.