### PR TITLE
fix(dataset): bind table-name to the SQLite table

### DIFF
--- a/pkg/dataset/ds_tool_config.go
+++ b/pkg/dataset/ds_tool_config.go
@@ -67,7 +67,7 @@ func (c *DSToolConfiguration) LoadConfig() error {
 	f.StringVar(&c.outputFile, "output-file", "inference-sim-dataset",
 		"Output file name without extension, two files will be created: <output-file>.json and <output-file>.csv")
 	f.StringVar(&c.outputPath, "output-path", "", "Output path")
-	f.StringVar(&c.outputPath, "table-name", common.DefaultDSTableName, "Table name, default is 'llmd'")
+	f.StringVar(&c.tableName, "table-name", common.DefaultDSTableName, "Table name, default is 'llmd'")
 	f.IntVar(&c.maxRecords, "max-records", 10000, "Maximum number of source dataset records to process; if the dataset contains more, the rest are discarded")
 	f.StringVar(&c.renderURL, "render-url", c.renderURL, "URL of the tokenizer render service")
 	f.DurationVar(&c.renderTimeout, "render-timeout", c.renderTimeout, "Timeout for tokenizer render requests")

--- a/pkg/dataset/ds_tool_config_test.go
+++ b/pkg/dataset/ds_tool_config_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataset
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestDSToolConfigurationOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		outputPath string
+		tableName  string
+	}{
+		{name: "defaults", tableName: "llmd"},
+		{name: "table name after output path", args: []string{"--output-path", "output", "--table-name", "custom"}, outputPath: "output", tableName: "custom"},
+		{name: "output path after table name", args: []string{"--table-name", "custom", "--output-path", "output"}, outputPath: "output", tableName: "custom"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			originalArgs := os.Args
+			t.Cleanup(func() { os.Args = originalArgs })
+			os.Args = append([]string{"dataset-tool", "--model", "test", "--local-path", ".", "--input-file", "input.json", "--render-url", "http://localhost:8082"}, tt.args...)
+			cfg := NewDefaultDSToolConfiguration()
+			if err := cfg.LoadConfig(); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.outputPath != tt.outputPath || cfg.tableName != tt.tableName {
+				t.Fatalf("output path = %q, table name = %q; want %q, %q", cfg.outputPath, cfg.tableName, tt.outputPath, tt.tableName)
+			}
+			if tt.outputPath != "" {
+				if err := os.Mkdir(tt.outputPath, 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			tool := &DatasetTool{config: cfg, sqlHelper: newSqliteHelper(cfg.tableName, logr.Discard()), logger: logr.Discard()}
+			if err := tool.storeToSQLite(context.Background(), nil); err != nil {
+				t.Fatal(err)
+			}
+			dbPath := filepath.Join(tt.outputPath, "inference-sim-dataset.sqlite3")
+			if _, err := os.Stat(dbPath); err != nil {
+				t.Fatal(err)
+			}
+			db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := db.Close(); err != nil {
+					t.Error(err)
+				}
+			})
+			var tableName string
+			if err := db.QueryRow("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?", tt.tableName).Scan(&tableName); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Bind `dataset-tool --table-name` to the SQLite table name, independently of `--output-path`.

## Why is this change needed?

The flag writes into `outputPath`, so its default changes the output directory to `llmd`. Passing `--table-name custom` after `--output-path output` redirects files to `custom`; reversing the arguments keeps the output directory but still creates the `llmd` table.

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual testing performed

Regression coverage checks the default output directory and both flag orders against the generated SQLite file and table. `CGO_ENABLED=0 go test ./pkg/dataset -run '^TestDSToolConfigurationOutput$' -count=1` passes.

Built and ran the CLI with an empty local dataset for all three cases; verified the SQLite, JSON, and dataset-card paths and table names. The same checks fail on the upstream baseline.

`make presubmit` passes formatting, linting, and module checks, then fails on existing `golang.org/x/crypto v0.55.0` findings GO-2026-6354 and GO-2026-6355. The same vulnerability check fails on unmodified upstream `0153b22`; dependencies are unchanged. The full test suite requires the vLLM render container and was not run. The commit has a GitHub-verified signature and DCO sign-off, and `scripts/check-commits.sh upstream/main` passes.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Found through code review; the existing dataset-tool documentation describes the expected output directory and table-name behavior.
