### PR TITLE
Add --dial-paths: serve the DIAL Core ingress paths

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,85 @@
+# Fork delta
+
+This fork adds one thing to `llm-d/llm-d-inference-sim`: the ingress paths DIAL Core forwards
+on, behind an off-by-default flag. Everything else is upstream.
+
+Keep this list short. **Anything that needs an upstream line to change goes upstream as a PR
+instead of into this fork** — that is what keeps rebasing onto a new tag a 15-minute job.
+
+## The delta
+
+| File | Change |
+|---|---|
+| `pkg/communication/dial_paths.go` | **new** — `registerDialRoutes`, the alias table |
+| `pkg/communication/http.go` | one call site, after the `/v1/embeddings` registration |
+| `pkg/common/config.go` | `DialPaths` field |
+| `pkg/common/parser.go` | `--dial-paths` flag |
+| `pkg/tests/dial_paths_test.go` | **new** — paths served with the flag, 404 without it |
+| `FORK.md` | this file |
+
+Four added lines in upstream files, two new files.
+
+## Why
+
+DIAL Core appends the inbound ingress path to a deployment's `interfaces.<type>.base_url`
+(`DeploymentEndpointUtil.resolveRequestUri`), so a target addressed through the `interfaces`
+map must serve the DIAL path, not the API's own:
+
+| Interface | DIAL ingress path | Simulator's own path |
+|---|---|---|
+| `anthropicMessages` | `/anthropic/v1/messages` | `/v1/messages` |
+| `openaiResponses` | `/openai/v1/responses` | `/v1/responses` |
+| `openaiChatCompletions` | `/openai/deployments/{model}/chat/completions` | `/v1/chat/completions` |
+| `openaiEmbeddings` | `/openai/deployments/{model}/embeddings` | `/v1/embeddings` |
+
+Without the aliases the simulator is reachable only through Core's legacy complete-url fields
+(`endpoint`, `responsesEndpoint`). Those cannot express `anthropicMessages` at all — Core's
+`resolveLegacyEndpoint` returns null for it — and the single `endpoint` field serves the whole
+deployments-POST family, so chat completions and embeddings cannot both be right at once.
+
+With `--dial-paths`, one `interfaces.base_url` serves every interface, which is how DIAL
+addresses an adapter.
+
+## Usage
+
+```bash
+llm-d-inference-sim --model llm-d-sim --port 8000 --dial-paths
+```
+
+DIAL Core model entity:
+
+```json
+{
+  "type": "chat",
+  "overrideName": "llm-d-sim",
+  "baseUrl": "https://<sim-host>",
+  "interfaces": {
+    "openaiChatCompletions": {},
+    "openaiResponses": {},
+    "anthropicMessages": {}
+  },
+  "userRoles": ["default"],
+  "upstreams": [{ "id": "sim-1" }]
+}
+```
+
+`upstreams[].id` is required — Core answers `503 Upstream is missing required id` on the
+responses and messages paths for an upstream without one, while chat completions tolerates it.
+
+## Upstreaming
+
+The DIAL paths themselves do not belong upstream. The generic form does: a route-alias or
+path-prefix flag that lets any caller map extra paths onto the existing handlers. If upstream
+takes that, this fork disappears and we go back to stock images.
+
+## Rebasing
+
+```bash
+git fetch upstream --tags
+git rebase upstream/<tag>
+```
+
+Expect conflicts only in `pkg/communication/http.go` (the call site), `pkg/common/config.go`
+and `pkg/common/parser.go` — all three are one-line additions next to
+`enable-request-id-headers` / `/v1/embeddings`. Re-run `make test` afterwards; the added test
+fails if a handler is renamed or a route moves.

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -310,6 +310,10 @@ type Configuration struct {
 	// EnableRequestIDHeaders enables including X-Request-Id header in responses
 	EnableRequestIDHeaders bool `yaml:"enable-request-id-headers" json:"enable-request-id-headers"`
 
+	// DialPaths additionally serves the ingress paths DIAL Core forwards on, so the simulator can
+	// sit behind a DIAL deployment's interfaces base_url. See pkg/communication/dial_paths.go.
+	DialPaths bool `yaml:"dial-paths" json:"dial-paths"`
+
 	// LogHTTP logs full HTTP request and response details (method, URI, headers, bodies where buffered, status) for each request.
 	LogHTTP bool `yaml:"log-http" json:"log-http"`
 

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -178,6 +178,7 @@ func ParseCommandParamsAndLoadConfig() (*Configuration, error) {
 
 	addToggle(f, &config.EnableSleepMode, "enable-sleep-mode", "Enable sleep mode", "Disable sleep mode")
 	f.BoolVar(&config.EnableRequestIDHeaders, "enable-request-id-headers", config.EnableRequestIDHeaders, "Enable including X-Request-Id header in responses")
+	f.BoolVar(&config.DialPaths, "dial-paths", config.DialPaths, "Also serve the DIAL Core ingress paths (/anthropic/v1/messages, /openai/v1/responses, /openai/deployments/{model}/...)")
 	f.BoolVar(&config.LogHTTP, "log-http", config.LogHTTP, "Log full HTTP request and response (method, URI, headers, bodies when buffered, status); streamed bodies are not logged")
 	f.BoolVar(&config.SkipToolValidation, "skip-tool-validation", config.SkipToolValidation, "Skip the built-in validation of incoming tool schemas, matching real vLLM which forwards them to the model verbatim")
 

--- a/pkg/communication/dial_paths.go
+++ b/pkg/communication/dial_paths.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package communication
+
+import "github.com/buaazp/fasthttprouter"
+
+// registerDialRoutes aliases the ingress paths DIAL Core forwards on to the handlers that
+// already serve their standard counterparts. Nothing else changes: the handlers read the
+// model from the request body, so the :model path segment is ignored, exactly as it is by
+// the providers DIAL addresses this way.
+//
+// DIAL Core appends the inbound ingress path to a deployment's interfaces base_url
+// (DeploymentEndpointUtil.resolveRequestUri), so a target reachable through the interfaces
+// map has to serve the DIAL path rather than the API's own. Without these aliases the
+// simulator is reachable only through the legacy complete-url fields (endpoint,
+// responsesEndpoint), which cannot express anthropicMessages at all and cannot express
+// chat completions and embeddings at the same time.
+//
+// Off by default: pass --dial-paths (or dial-paths: true) to enable.
+func (c *Communication) registerDialRoutes(r *fasthttprouter.Router) {
+	if !c.runtime.Config().DialPaths {
+		return
+	}
+
+	// named in the request body, no deployment segment
+	r.POST("/anthropic/v1/messages", c.HandleMessages)
+	r.POST("/openai/v1/responses", c.HandleResponses)
+
+	// the deployments-POST family; Core rewrites :model to the deployment's overrideName
+	r.POST("/openai/deployments/:model/chat/completions", c.HandleChatCompletions)
+	r.POST("/openai/deployments/:model/completions", c.HandleTextCompletions)
+	if !c.runtime.Config().MMEncoderOnly {
+		r.POST("/openai/deployments/:model/embeddings", c.HandleEmbeddings)
+	}
+}

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -76,6 +76,8 @@ func (c *Communication) startHTTPServer(ctx context.Context, listener net.Listen
 	if !c.runtime.Config().MMEncoderOnly {
 		r.POST("/v1/embeddings", c.HandleEmbeddings)
 	}
+	// fork-only: DIAL Core ingress aliases, see dial_paths.go and FORK.md
+	c.registerDialRoutes(r)
 	// supports /models API
 	r.GET("/v1/models", c.HandleModels)
 	// support load/unload of lora adapter

--- a/pkg/tests/dial_paths_test.go
+++ b/pkg/tests/dial_paths_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The llm-d-inference-sim Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/llm-d/llm-d-inference-sim/pkg/common"
+)
+
+// The DIAL ingress paths and a body each one accepts.
+var dialPathCases = []struct {
+	path string
+	body string
+}{
+	{
+		"/anthropic/v1/messages",
+		`{"model":"` + common.TestModelName + `","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}`,
+	},
+	{
+		"/openai/v1/responses",
+		`{"model":"` + common.TestModelName + `","input":[{"type":"message","role":"user",` +
+			`"content":[{"type":"input_text","text":"Hello"}]}],"max_output_tokens":10}`,
+	},
+	{
+		"/openai/deployments/" + common.TestModelName + "/chat/completions",
+		`{"model":"` + common.TestModelName + `","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}`,
+	},
+	{
+		"/openai/deployments/" + common.TestModelName + "/completions",
+		`{"model":"` + common.TestModelName + `","prompt":"Hello","max_tokens":10}`,
+	},
+	{
+		"/openai/deployments/" + common.TestModelName + "/embeddings",
+		`{"model":"` + common.TestModelName + `","input":["Hello"]}`,
+	},
+}
+
+func postDialPath(client *http.Client, path string, body string) int {
+	resp, err := client.Post("http://localhost"+path, "application/json", strings.NewReader(body))
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close() //nolint:errcheck
+	return resp.StatusCode
+}
+
+var _ = Describe("DIAL ingress paths", func() {
+	It("Should serve the DIAL paths when --dial-paths is set", func() {
+		client, err := startServerWithArgs(context.TODO(),
+			[]string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom, "--dial-paths"})
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, c := range dialPathCases {
+			Expect(postDialPath(client, c.path, c.body)).To(Equal(http.StatusOK), "path: %s", c.path)
+		}
+	})
+
+	It("Should keep serving the standard paths when --dial-paths is set", func() {
+		client, err := startServerWithArgs(context.TODO(),
+			[]string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom, "--dial-paths"})
+		Expect(err).NotTo(HaveOccurred())
+
+		body := `{"model":"` + common.TestModelName + `","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}`
+		Expect(postDialPath(client, "/v1/chat/completions", body)).To(Equal(http.StatusOK))
+		Expect(postDialPath(client, "/v1/messages", body)).To(Equal(http.StatusOK))
+	})
+
+	It("Should not serve the DIAL paths by default", func() {
+		client, err := startServerWithArgs(context.TODO(),
+			[]string{"cmd", "--model", common.TestModelName, "--mode", common.ModeRandom})
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, c := range dialPathCases {
+			Expect(postDialPath(client, c.path, c.body)).To(Equal(http.StatusNotFound), "path: %s", c.path)
+		}
+	})
+})


### PR DESCRIPTION
DIAL Core appends the inbound ingress path to a deployment's interfaces.<type>.base_url, so a target addressed through the interfaces map must serve /anthropic/v1/messages, /openai/v1/responses and /openai/deployments/{model}/... rather than the API's own paths. Alias those onto the existing handlers behind an off-by-default flag; the handlers read the model from the body, so the :model segment is ignored.

Without this the simulator is reachable only through Core's legacy complete-url fields, which cannot express anthropicMessages at all and cannot serve chat completions and embeddings correctly at the same time.

Delta kept to two new files plus four added lines in upstream files; see FORK.md.

## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](https://github.com/llm-d/.github/blob/main/PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](https://github.com/llm-d/.github/blob/main/CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
