### PR TITLE
chore: use official release images in examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ endif
 
 .PHONY: presubmit
 presubmit: LINT_NEW_ONLY=true
-presubmit: git-branch-check signed-commits-check go-mod-check format lint vulncheck check-latest-tags ## Run all pre-merge checks
+presubmit: git-branch-check signed-commits-check go-mod-check format lint check-no-openpgp vulncheck check-latest-tags ## Run all pre-merge checks
 	@printf "\033[32;1m==== presubmit passed ====\033[0m\n"
 
 .PHONY: git-branch-check
@@ -101,9 +101,13 @@ vulncheck: check-go ## Run govulncheck
 	@GOBIN=$(LOCALBIN) go install golang.org/x/vuln/cmd/govulncheck@latest
 	$(LOCALBIN)/govulncheck ./...
 
+.PHONY: check-no-openpgp
+check-no-openpgp: check-go ## Reject deprecated OpenPGP dependencies, including tests
+	@./scripts/check-no-openpgp.sh
+
 .PHONY: check-latest-tags
-check-latest-tags: ## Warn on YAML using image :latest tag
-	@./scripts/check-latest-tags.sh
+check-latest-tags: ## Reject YAML using image :latest tags
+	@./scripts/check-latest-tags.sh --strict
 
 LINT_ARGS ?=
 ifeq ($(LINT_NEW_ONLY),true)

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           periodSeconds: 5
       containers:
       - name: vllm-sim
-        image: ghcr.io/llm-d/llm-d-inference-sim:latest
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.11.2@sha256:32144df791330a0006b747edfdf2b114a0fe728e023a9d1b3463eeb48d32abb9
         imagePullPolicy: IfNotPresent
         args:
         - "--model"

--- a/manifests/deployment_kvcache.yaml
+++ b/manifests/deployment_kvcache.yaml
@@ -55,7 +55,7 @@ spec:
         - --v=5
         - --render-url
         - http://localhost:8082
-        image: ghcr.io/llm-d/llm-d-inference-sim:latest
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.11.2@sha256:32144df791330a0006b747edfdf2b114a0fe728e023a9d1b3463eeb48d32abb9
         imagePullPolicy: IfNotPresent
         env:
           - name: POD_NAME

--- a/manifests/disaggregation/vllm-sim-pd.yaml
+++ b/manifests/disaggregation/vllm-sim-pd.yaml
@@ -47,7 +47,7 @@ spec:
           periodSeconds: 5
       containers:
         - name: vllm-prefill
-          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.11.2@sha256:32144df791330a0006b747edfdf2b114a0fe728e023a9d1b3463eeb48d32abb9
           imagePullPolicy: IfNotPresent
           args:
             - "--v=4"
@@ -119,7 +119,7 @@ spec:
         ports:
           - containerPort: 8000
       - name: vllm-decode
-        image: ghcr.io/llm-d/llm-d-inference-sim:latest
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.11.2@sha256:32144df791330a0006b747edfdf2b114a0fe728e023a9d1b3463eeb48d32abb9
         imagePullPolicy: IfNotPresent
         args:
           - "--v=4"

--- a/manifests/zmq-listener/deploy_listener.yaml
+++ b/manifests/zmq-listener/deploy_listener.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: listener
-          image: quay.io/mayab/zmq-listener:latest
+          image: quay.io/mayab/zmq-listener@sha256:2427928648d25b1195dc2e226304d3774974058b8f3f6d45099b07d4814430b6
           imagePullPolicy: Always
           env:
           - name: ZMQ_PORT  # Assumed env var in your listener app

--- a/manifests/zmq-listener/deploy_simulator.yaml
+++ b/manifests/zmq-listener/deploy_simulator.yaml
@@ -47,7 +47,7 @@ spec:
           periodSeconds: 5
       containers:
         - name: sim
-          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.11.2@sha256:32144df791330a0006b747edfdf2b114a0fe728e023a9d1b3463eeb48d32abb9
           args:
             - "--port=8000"
             - "--model=Qwen/Qwen3-0.6B"

--- a/scripts/check-no-openpgp.sh
+++ b/scripts/check-no-openpgp.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# GO-2026-5932 affects the unmaintained OpenPGP package, not all of x/crypto.
+set -euo pipefail
+
+packages=$(go list -mod=readonly -deps -test ./...)
+if [ -z "$packages" ]; then
+  echo "ERROR: no Go packages found." >&2
+  exit 1
+fi
+
+if matches=$(printf '%s\n' "$packages" | grep -E '^golang\.org/x/crypto/openpgp(/|$)'); then
+  echo "ERROR: deprecated OpenPGP dependency detected (GO-2026-5932)." >&2
+  printf '%s\n' "$matches" >&2
+  exit 1
+fi
+
+echo "No deprecated OpenPGP packages found in dependencies (including tests)."


### PR DESCRIPTION
## What does this PR do?

Use v0.11.2 release tags for the simulator examples and ghcr.io/llm-d/zmq-listener:v0.11.2 for the listener. Make the existing latest-tag check fail presubmit.

## Why is this change needed?

Examples should reference published releases and the official listener image. Version tags keep the manifests readable and avoid introducing a digest-update policy. The existing govulncheck remains responsible for vulnerability checks; no OpenPGP import guard is included.

## How was this tested?

- make check-latest-tags passed.
- git diff --check passed.
- No Go runtime code changed; no deployment was performed.

## Related Issues

Related to #688. Release-update policy remains under maintainer discussion; this PR remains a draft.