### PR TITLE
Extract ToolCallConfig, DatasetConfig, SSLConfig, and LoraConfig from Configuration

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -38,7 +38,7 @@ In addition, a set of the vLLM HTTP endpoints are supported:
 
 The simulator exposes `GET` and `POST` on `/admin/config` for runtime configuration introspection and partial updates. This endpoint is simulator-specific and is intended for adjusting behavior (currently failure injection, fake metrics, and request latencies) during a test run without restarting the process.
 
-- **`GET /admin/config`** returns the current configuration as JSON. Internal helper fields (`LoraModulesString`, `LorasString`) are stripped, `LoraModules` is exposed as `lora-modules`, and the per-rank `port` is omitted when running with `--data-parallel-size > 1`.
+- **`GET /admin/config`** returns the current configuration as JSON. Internal helper fields (`LoraModulesString`, `LorasString`) are stripped, `LoraModules` is exposed as `lora-modules` nested under `lora` (matching how `kvcache` fields are already nested), and the per-rank `port` is omitted when running with `--data-parallel-size > 1`.
 - **`POST /admin/config`** applies a partial JSON update and returns the new configuration. The request body must be a JSON object whose keys are a subset of the admin-configurable fields:
   - `failure-injection-rate` — integer in `[0, 100]`
   - `failure-types` — array of strings from `rate_limit`, `invalid_api_key`, `context_length`, `server_error`, `invalid_request`, `model_not_found`

--- a/docs/api.md
+++ b/docs/api.md
@@ -38,7 +38,7 @@ In addition, a set of the vLLM HTTP endpoints are supported:
 
 The simulator exposes `GET` and `POST` on `/admin/config` for runtime configuration introspection and partial updates. This endpoint is simulator-specific and is intended for adjusting behavior (currently failure injection, fake metrics, and request latencies) during a test run without restarting the process.
 
-- **`GET /admin/config`** returns the current configuration as JSON. Internal helper fields (`LoraModulesString`, `LorasString`) are stripped, `LoraModules` is exposed as `lora-modules` nested under `lora` (matching how `kvcache` fields are already nested), and the per-rank `port` is omitted when running with `--data-parallel-size > 1`.
+- **`GET /admin/config`** returns the current configuration as JSON. Internal helper fields (`LoraModulesString`, `LorasString`) are stripped, `LoraModules` is exposed as `lora-modules` nested under `lora`, and the per-rank `port` is omitted when running with `--data-parallel-size > 1`.
 - **`POST /admin/config`** applies a partial JSON update and returns the new configuration. The request body must be a JSON object whose keys are a subset of the admin-configurable fields:
   - `failure-injection-rate` — integer in `[0, 100]`
   - `failure-types` — array of strings from `rate_limit`, `invalid_api_key`, `context_length`, `server_error`, `invalid_request`, `model_not_found`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,9 +17,6 @@ Some environment variables (for example `POD_NAME`, `POD_NAMESPACE`) are not ove
 - `max-request-body-size-mb`: maximum allowed size of an HTTP request body in megabytes, optional, default is 4 (matching the fasthttp built-in default). Must be between 1 and 512.
 - `model`: the currently 'loaded' model, mandatory. If you omit `--model` on the command line, a non-empty `SIM_MODEL` environment variable can supply the model; see [Configuration precedence](#configuration-precedence) and [Environment variables](#environment-variables).
 - `served-model-name`: model names exposed by the API (a list of space-separated strings)
-- `lora-modules`: a list of LoRA adapters (a list of space-separated JSON strings): '{"name": "name", "path": "lora_path", "base_model_name": "id"}', optional, empty by default
-- `max-loras`: maximum number of LoRAs in a single batch, optional, default is one
-- `max-cpu-loras`: maximum number of LoRAs to store in CPU memory, optional, must be >= than max-loras, default is max-loras
 - `max-model-len`: model's context window, maximum number of tokens in a single request including input and output, optional, default is 1024
 - `max-num-seqs`: maximum number of sequences per iteration (maximum number of inference requests that could be processed at the same time), default is 5
 - `max-waiting-queue-length`: maximum length of inference requests waiting queue, default is 1000
@@ -33,6 +30,13 @@ Some environment variables (for example `POD_NAME`, `POD_NAMESPACE`) are not ove
 - `mm-encoder-only`, `no-mm-encoder-only`: Skip  (or don't skip) the language component of the model.
 - `omni`, `no-omni`: Enable or disable omni mode. When enabled, the simulator appends a synthetic image (a 1×1 transparent PNG, `data:image/png;base64,…`) to `/v1/chat/completions` responses in two cases: the `X-Send-Image: true` request header is present, or a random roll succeeds against `--image-emission-rate`. In non-streaming responses the assistant message `content` becomes a structured array — a `text` block carrying the generated tokens followed by an `image_url` block. In streaming responses an extra SSE chunk with `"modality":"image"` is emitted after the token stream, carrying the same image in its delta `content`. When `--omni` is not set (the default), both mechanisms are disabled and the response is a normal text response.
 - `image-emission-rate`: probability (0–100) of emitting a synthetic image chunk per `/v1/chat/completions` request when omni mode is enabled. 0 (the default) means the rate mechanism never fires; 100 means every request gets an image. The `X-Send-Image: true` header triggers emission independently of this rate. Updatable at runtime via `POST /admin/config`.
+
+## LoRA
+Command-line flag names are as listed below. In a YAML config file, these settings may be nested under a top-level `lora:` key using the same key names; the old flat top-level keys are still accepted for backward compatibility.
+
+- `lora-modules`: a list of LoRA adapters (a list of space-separated JSON strings): '{"name": "name", "path": "lora_path", "base_model_name": "id"}', optional, empty by default
+- `max-loras`: maximum number of LoRAs in a single batch, optional, default is one
+- `max-cpu-loras`: maximum number of LoRAs to store in CPU memory, optional, must be >= than max-loras, default is max-loras
 
 ## Latency 
 All latency-related parameters are defined in duration format, e.g., 100ms. Integer format is deprecated.
@@ -68,6 +72,8 @@ For a detailed explanation of how the simulator models inference time and what e
 - `time-factor-under-load`: a multiplicative factor that affects the overall time taken for requests when parallel requests are being processed. The value of this factor must be >= 1.0, with a default of 1.0. If this factor is 1.0, no extra time is added.  When the factor is x (where x > 1.0) and there are `max-num-seqs` requests, the total time will be multiplied by x. The extra time then decreases multiplicatively to 1.0 when the number of requests is less than `max-num-seqs`.
 
 ## Tools 
+Command-line flag names are as listed below. In a YAML config file, these settings may be nested under a top-level `tool-calls:` key using the same key names; the old flat top-level keys are still accepted for backward compatibility.
+
 - `max-tool-call-integer-param`: the maximum possible value of integer parameters in a tool call, optional, defaults to 100
 - `min-tool-call-integer-param`: the minimum possible value of integer parameters in a tool call, optional, defaults to 0
 - `max-tool-call-number-param`: the maximum possible value of number (float) parameters in a tool call, optional, defaults to 100
@@ -105,6 +111,8 @@ Command-line flag names are as listed below. In a YAML config file, these settin
 - `data-parallel-rank`: the rank of this instance, used only when running Data Parallel ranks as separate processes. If set, `data-parallel-size` is ignored and a single simulator starts with this rank index embedded in its ZMQ event batches.
 
 ## Datasets
+Command-line flag names are as listed below. In a YAML config file, these settings may be nested under a top-level `dataset:` key using the same key names; the old flat top-level keys are still accepted for backward compatibility.
+
 - `dataset-path`: Optional local file path to the SQLite database file used for generating responses from a dataset.
   - If not set, hardcoded preset responses will be used.
   - If set but the file does not exist the `dataset-url` will be used to download the database to the path specified by `dataset-path`.
@@ -128,6 +136,8 @@ Command-line flag names are as listed below. In a YAML config file, these settin
 - `default-embedding-dimensions`: default size of embedding vectors returned by `/v1/embeddings` when the request does not specify a `dimensions` field, optional, defaults to 384.
 
 ## SSL
+Command-line flag names are as listed below. In a YAML config file, these settings may be nested under a top-level `ssl:` key using the same key names; the old flat top-level keys are still accepted for backward compatibility.
+
 - `ssl-certfile`: Path to SSL certificate file for HTTPS (optional)
 - `ssl-keyfile`: Path to SSL private key file for HTTPS (optional)
 - `self-signed-certs`: Enable automatic generation of self-signed certificates for HTTPS

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -79,21 +79,24 @@ var (
 )
 
 type Configuration struct {
+	// Model defines the current base model name
+	Model string `yaml:"model" json:"model"`
+	// EngineName is the inference engine backend being simulated. Currently only "vllm" is supported.
+	EngineName string `yaml:"engine" json:"engine"`
+	// Mode defines the simulator response generation mode, valid values: echo, random
+	Mode string `yaml:"mode" json:"mode"`
+
 	// IP defines on which IP the simulator runs, loaded from env
 	IP string
 	// Port defines on which port the simulator runs
 	Port int `yaml:"port" json:"port"`
-	// Model defines the current base model name
-	Model string `yaml:"model" json:"model"`
+
 	// DisplayModelName defines the model name that will be shown in API responses
 	// If ServedModelNames are not set, it defaults to the value of Model
 	DisplayModelName string
 	// ServedModelNames is one or many model names exposed by the API
 	ServedModelNames []string `yaml:"served-model-name" json:"served-model-name"`
-	// MaxLoras defines maximum number of loaded LoRAs
-	MaxLoras int `yaml:"max-loras" json:"max-loras"`
-	// MaxCPULoras defines maximum number of LoRAs to store in CPU memory
-	MaxCPULoras int `yaml:"max-cpu-loras" json:"max-cpu-loras"`
+
 	// MaxNumSeqs is maximum number of sequences per iteration (the maximum
 	// number of inference requests that could be processed at the same time)
 	MaxNumSeqs int `yaml:"max-num-seqs" json:"max-num-seqs"`
@@ -102,10 +105,9 @@ type Configuration struct {
 	// MaxModelLen is the model's context window, the maximum number of tokens
 	// in a single request including input and output. Default value is 1024.
 	MaxModelLen int `yaml:"max-model-len" json:"max-model-len"`
-	// LoraModulesString is a list of LoRA adapters as strings (YAML parse helper; omitted from external output)
-	LoraModulesString []string `yaml:"lora-modules" json:"-"`
-	// LoraModules is a list of LoRA adapters
-	LoraModules []LoraModule `json:"lora-modules"`
+
+	// Lora groups the LoRA adapter settings.
+	Lora LoraConfig `yaml:"lora" json:"lora"`
 
 	// PodNameSpace specifies the Kubernetes namespace in which the simulator pod is running.
 	// Useful for multi-namespace deployments and resource scoping.
@@ -126,54 +128,17 @@ type Configuration struct {
 	// foldFlatLatencies) still accept the legacy flat top-level keys too,
 	// folded into "latencies" before unmarshalling into a Configuration.
 	Latencies LatenciesConfig `yaml:"latencies" json:"latencies"`
-
 	// LatencyCalculator is the name of the latency calculator to use in the simulation of the response latencies.
 	// The default calculation is based on the current load of the simulator and on the configured latency
 	// parameters, e.g., time-to-first-token and prefill-time-per-token. It is a top-level flag, not part of
 	// LatenciesConfig, since it selects a calculation strategy rather than a latency value.
 	LatencyCalculator string `yaml:"latency-calculator" json:"latency-calculator" admin:"configurable" rebuild:"latency"`
 
-	// Mode defines the simulator response generation mode, valid values: echo, random
-	Mode string `yaml:"mode" json:"mode"`
 	// Seed defines random seed for operations
 	Seed int64 `yaml:"seed" json:"seed"`
 
-	// MaxToolCallIntegerParam defines the maximum possible value of integer parameters in a tool call,
-	// optional, defaults to 100
-	MaxToolCallIntegerParam int `yaml:"max-tool-call-integer-param" json:"max-tool-call-integer-param"`
-	// MinToolCallIntegerParam defines the minimum possible value of integer parameters in a tool call,
-	// optional, defaults to 0
-	MinToolCallIntegerParam int `yaml:"min-tool-call-integer-param" json:"min-tool-call-integer-param"`
-	// MaxToolCallNumberParam defines the maximum possible value of number (float) parameters in a tool call,
-	// optional, defaults to 100
-	MaxToolCallNumberParam float64 `yaml:"max-tool-call-number-param" json:"max-tool-call-number-param"`
-	// MinToolCallNumberParam defines the minimum possible value of number (float) parameters in a tool call,
-	// optional, defaults to 0
-	MinToolCallNumberParam float64 `yaml:"min-tool-call-number-param" json:"min-tool-call-number-param"`
-
-	// MaxToolCallArrayParamLength defines the maximum possible length of array parameters in a tool call,
-	// optional, defaults to 5
-	MaxToolCallArrayParamLength int `yaml:"max-tool-call-array-param-length" json:"max-tool-call-array-param-length"`
-	// MinToolCallArrayParamLength defines the minimum possible length of array parameters in a tool call,
-	// optional, defaults to 1
-	MinToolCallArrayParamLength int `yaml:"min-tool-call-array-param-length" json:"min-tool-call-array-param-length"`
-
-	// ToolCallNotRequiredParamProbability is the probability to add a parameter, that is not required,
-	// in a tool call, optional, defaults to 50
-	ToolCallNotRequiredParamProbability int `yaml:"tool-call-not-required-param-probability" json:"tool-call-not-required-param-probability"`
-	// ObjectToolCallNotRequiredParamProbability is the probability to add a field, that is not required,
-	// in an object in a tool call, optional, defaults to 50
-	ObjectToolCallNotRequiredParamProbability int `yaml:"object-tool-call-not-required-field-probability" json:"object-tool-call-not-required-field-probability"`
-	// SkipToolValidation disables the built-in meta-validation of incoming tool schemas.
-	// Real vLLM forwards tool schemas to the model verbatim, so schemas using fields outside
-	// the simulator's whitelist are rejected here but accepted upstream. Optional, defaults to false.
-	SkipToolValidation bool `yaml:"skip-tool-validation" json:"skip-tool-validation"`
-	// ToolCallExtraCallProbability is the probability (0-100) to make one additional tool call beyond the
-	// minimum. Rolls repeat until a roll fails or len(availableTools) is reached, so the number of calls
-	// follows a truncated geometric distribution that almost always equals the minimum but can reach
-	// the total number of available tools. A value of 0 always produces the minimum number of calls;
-	// a value of 100 always produces len(availableTools) calls. Optional, defaults to 45.
-	ToolCallExtraCallProbability int `yaml:"tool-call-extra-call-probability" json:"tool-call-extra-call-probability"`
+	// ToolCalls groups the tool-call generation parameters.
+	ToolCalls ToolCallConfig `yaml:"tool-calls" json:"tool-calls"`
 
 	// GlobalCacheHitThreshold is the default cache hit threshold (0-1] for all requests.
 	// If a request specifies cache_hit_threshold, it takes precedence over this global value.
@@ -185,7 +150,6 @@ type Configuration struct {
 
 	// FakeMetrics is a set of metrics to send to Prometheus instead of the real data
 	FakeMetrics *FakeMetrics `yaml:"fake-metrics" json:"fake-metrics" admin:"configurable"`
-
 	// FakeMetricsRefreshInterval defines how often function-based fake metrics are recalculated, defaults to 100ms
 	FakeMetricsRefreshInterval time.Duration `yaml:"fake-metrics-refresh-interval" json:"fake-metrics-refresh-interval"`
 
@@ -196,35 +160,15 @@ type Configuration struct {
 
 	// DPSize is data parallel size - a number of ranks to run, minimum is 1, maximum is 8, default is 1
 	DPSize int `yaml:"data-parallel-size" json:"data-parallel-size"`
-
 	// Rank specifies the rank of this instance. Only used when running Data Parallel
 	// ranks as separate processes. If set, data-parallel-size is ignored
 	Rank int `yaml:"data-parallel-rank" json:"data-parallel-rank"`
 
-	// SSLCertFile is the path to the SSL certificate file for HTTPS
-	SSLCertFile string `yaml:"ssl-certfile" json:"ssl-certfile"`
-	// SSLKeyFile is the path to the SSL private key file for HTTPS
-	SSLKeyFile string `yaml:"ssl-keyfile" json:"ssl-keyfile"`
-	// SelfSignedCerts enables automatic generation of self-signed certificates for HTTPS
-	SelfSignedCerts bool `yaml:"self-signed-certs" json:"self-signed-certs"`
+	// SSL groups the HTTPS certificate settings.
+	SSL SSLConfig `yaml:"ssl" json:"ssl"`
 
-	// DatasetPath Optional local file path to the SQLite database file used for generating responses from a dataset.
-	//   - If not set, hardcoded preset responses will be used.
-	//   - If set but the file does not exist the `dataset-url` will be used to download the database to the path specified by `dataset-path`.
-	//   - If the file exists but is currently occupied by another process, responses will be randomly generated from preset text (the same behavior as if the path were not set).
-	//   - Responses are retrieved from the dataset by the hash of the conversation history, with a fallback to a random dataset response, constrained by the maximum output tokens and EoS token handling, if no matching history is found.
-	//   - Refer to [llm-d converted ShareGPT](https://huggingface.co/datasets/hf07397/inference-sim-datasets/blob/0b7ac1a4daf0aace1556326964bd75633372299e/README.md) for detailed information on the expected format of the SQLite database file.
-	DatasetPath string `yaml:"dataset-path" json:"dataset-path"`
-	// DatasetURL Optional URL for downloading the SQLite database file used for response generation.
-	//   - This parameter is only used if the `dataset-path` is also set and the file does not exist at that path.
-	//   - If the file needs to be downloaded, it will be saved to the location specified by `dataset-path`.
-	//   - If the file already exists at the `dataset-path`, it will not be downloaded again
-	//   - Example URL `https://huggingface.co/datasets/hf07397/inference-sim-datasets/resolve/91ffa7aafdfd6b3b1af228a517edc1e8f22cd274/huggingface/ShareGPT_Vicuna_unfiltered/conversations.sqlite3`
-	DatasetURL string `yaml:"dataset-url" json:"dataset-url"`
-	// DatasetInMemory defines whether to load the entire dataset into memory for faster access.
-	DatasetInMemory bool `yaml:"dataset-in-memory" json:"dataset-in-memory"`
-	// DatasetTableName defines custom SQLite dataset table name
-	DatasetTableName string `yaml:"dataset-table-name" json:"dataset-table-name"`
+	// Dataset groups the response-dataset source settings.
+	Dataset DatasetConfig `yaml:"dataset" json:"dataset"`
 
 	// RenderURL is the URL of the tokenizer render service. When set, the
 	// simulator uses a HuggingFace tokenizer served over HTTP. When empty,
@@ -288,9 +232,6 @@ type Configuration struct {
 	// MaxRequestBodySizeMB sets the maximum allowed request body size in megabytes for the HTTP server.
 	// Default is 4 (matching the fasthttp built-in default). Must be between 1 and 512.
 	MaxRequestBodySizeMB int `yaml:"max-request-body-size-mb" json:"max-request-body-size-mb"`
-
-	// EngineName is the inference engine backend being simulated. Currently only "vllm" is supported.
-	EngineName string `yaml:"engine" json:"engine"`
 }
 
 type LoraModule struct {
@@ -300,6 +241,18 @@ type LoraModule struct {
 	Path string `json:"path"`
 	// BaseModelName is the LoRA's base model
 	BaseModelName string `json:"base_model_name"`
+}
+
+// LoraConfig groups the LoRA adapter settings.
+type LoraConfig struct {
+	// MaxLoras defines maximum number of loaded LoRAs
+	MaxLoras int `yaml:"max-loras" json:"max-loras"`
+	// MaxCPULoras defines maximum number of LoRAs to store in CPU memory
+	MaxCPULoras int `yaml:"max-cpu-loras" json:"max-cpu-loras"`
+	// LoraModulesString is a list of LoRA adapters as strings (YAML parse helper; omitted from external output)
+	LoraModulesString []string `yaml:"lora-modules" json:"-"`
+	// LoraModules is a list of LoRA adapters
+	LoraModules []LoraModule `json:"lora-modules"`
 }
 
 // KVCacheConfig groups the KV-cache sizing, hashing, and ZMQ event settings.
@@ -334,6 +287,82 @@ type KVCacheConfig struct {
 	// UseVllmMapEventFormat encodes KV cache events as msgpack maps with named fields (vLLM PR #42892 format)
 	// instead of the legacy positional array format. Default is false (legacy array format).
 	UseVllmMapEventFormat bool `yaml:"use-vllm-map-event-format" json:"use-vllm-map-event-format"`
+}
+
+// ToolCallConfig groups the tool-call generation parameters.
+type ToolCallConfig struct {
+	// MaxToolCallIntegerParam defines the maximum possible value of integer parameters in a tool call,
+	// optional, defaults to 100
+	MaxToolCallIntegerParam int `yaml:"max-tool-call-integer-param" json:"max-tool-call-integer-param"`
+	// MinToolCallIntegerParam defines the minimum possible value of integer parameters in a tool call,
+	// optional, defaults to 0
+	MinToolCallIntegerParam int `yaml:"min-tool-call-integer-param" json:"min-tool-call-integer-param"`
+	// MaxToolCallNumberParam defines the maximum possible value of number (float) parameters in a tool call,
+	// optional, defaults to 100
+	MaxToolCallNumberParam float64 `yaml:"max-tool-call-number-param" json:"max-tool-call-number-param"`
+	// MinToolCallNumberParam defines the minimum possible value of number (float) parameters in a tool call,
+	// optional, defaults to 0
+	MinToolCallNumberParam float64 `yaml:"min-tool-call-number-param" json:"min-tool-call-number-param"`
+
+	// MaxToolCallArrayParamLength defines the maximum possible length of array parameters in a tool call,
+	// optional, defaults to 5
+	MaxToolCallArrayParamLength int `yaml:"max-tool-call-array-param-length" json:"max-tool-call-array-param-length"`
+	// MinToolCallArrayParamLength defines the minimum possible length of array parameters in a tool call,
+	// optional, defaults to 1
+	MinToolCallArrayParamLength int `yaml:"min-tool-call-array-param-length" json:"min-tool-call-array-param-length"`
+
+	// ToolCallNotRequiredParamProbability is the probability to add a parameter, that is not required,
+	// in a tool call, optional, defaults to 50
+	ToolCallNotRequiredParamProbability int `yaml:"tool-call-not-required-param-probability" json:"tool-call-not-required-param-probability"`
+	// ObjectToolCallNotRequiredParamProbability is the probability to add a field, that is not required,
+	// in an object in a tool call, optional, defaults to 50
+	ObjectToolCallNotRequiredParamProbability int `yaml:"object-tool-call-not-required-field-probability" json:"object-tool-call-not-required-field-probability"`
+	// SkipToolValidation disables the built-in meta-validation of incoming tool schemas.
+	// Real vLLM forwards tool schemas to the model verbatim, so schemas using fields outside
+	// the simulator's whitelist are rejected here but accepted upstream. Optional, defaults to false.
+	SkipToolValidation bool `yaml:"skip-tool-validation" json:"skip-tool-validation"`
+	// ToolCallExtraCallProbability is the probability (0-100) to make one additional tool call beyond the
+	// minimum. Rolls repeat until a roll fails or len(availableTools) is reached, so the number of calls
+	// follows a truncated geometric distribution that almost always equals the minimum but can reach
+	// the total number of available tools. A value of 0 always produces the minimum number of calls;
+	// a value of 100 always produces len(availableTools) calls. Optional, defaults to 45.
+	ToolCallExtraCallProbability int `yaml:"tool-call-extra-call-probability" json:"tool-call-extra-call-probability"`
+}
+
+// SSLConfig groups the HTTPS certificate settings.
+type SSLConfig struct {
+	// SSLCertFile is the path to the SSL certificate file for HTTPS
+	SSLCertFile string `yaml:"ssl-certfile" json:"ssl-certfile"`
+	// SSLKeyFile is the path to the SSL private key file for HTTPS
+	SSLKeyFile string `yaml:"ssl-keyfile" json:"ssl-keyfile"`
+	// SelfSignedCerts enables automatic generation of self-signed certificates for HTTPS
+	SelfSignedCerts bool `yaml:"self-signed-certs" json:"self-signed-certs"`
+}
+
+// Enabled returns true if SSL is enabled either via certificate files or self-signed certificates
+func (s *SSLConfig) Enabled() bool {
+	return (s.SSLCertFile != "" && s.SSLKeyFile != "") || s.SelfSignedCerts
+}
+
+// DatasetConfig groups the response-dataset source settings.
+type DatasetConfig struct {
+	// DatasetPath Optional local file path to the SQLite database file used for generating responses from a dataset.
+	//   - If not set, hardcoded preset responses will be used.
+	//   - If set but the file does not exist the `dataset-url` will be used to download the database to the path specified by `dataset-path`.
+	//   - If the file exists but is currently occupied by another process, responses will be randomly generated from preset text (the same behavior as if the path were not set).
+	//   - Responses are retrieved from the dataset by the hash of the conversation history, with a fallback to a random dataset response, constrained by the maximum output tokens and EoS token handling, if no matching history is found.
+	//   - Refer to [llm-d converted ShareGPT](https://huggingface.co/datasets/hf07397/inference-sim-datasets/blob/0b7ac1a4daf0aace1556326964bd75633372299e/README.md) for detailed information on the expected format of the SQLite database file.
+	DatasetPath string `yaml:"dataset-path" json:"dataset-path"`
+	// DatasetURL Optional URL for downloading the SQLite database file used for response generation.
+	//   - This parameter is only used if the `dataset-path` is also set and the file does not exist at that path.
+	//   - If the file needs to be downloaded, it will be saved to the location specified by `dataset-path`.
+	//   - If the file already exists at the `dataset-path`, it will not be downloaded again
+	//   - Example URL `https://huggingface.co/datasets/hf07397/inference-sim-datasets/resolve/91ffa7aafdfd6b3b1af228a517edc1e8f22cd274/huggingface/ShareGPT_Vicuna_unfiltered/conversations.sqlite3`
+	DatasetURL string `yaml:"dataset-url" json:"dataset-url"`
+	// DatasetInMemory defines whether to load the entire dataset into memory for faster access.
+	DatasetInMemory bool `yaml:"dataset-in-memory" json:"dataset-in-memory"`
+	// DatasetTableName defines custom SQLite dataset table name
+	DatasetTableName string `yaml:"dataset-table-name" json:"dataset-table-name"`
 }
 
 // LatenciesConfig groups the request-latency simulation parameters.
@@ -393,23 +422,25 @@ type LatenciesConfig struct {
 // NewConfig returns a Configuration populated with its documented defaults.
 func NewConfig() *Configuration {
 	return &Configuration{
-		EngineName:                          "vllm",
-		IP:                                  os.Getenv(podIPEnv),
-		Port:                                8000,
-		MaxLoras:                            1,
-		MaxNumSeqs:                          5,
-		MaxWaitingQueueLength:               1000,
-		MaxModelLen:                         1024,
-		Mode:                                ModeRandom,
-		Seed:                                time.Now().UnixNano(),
-		Latencies:                           LatenciesConfig{TimeFactorUnderLoad: 1.0},
-		MaxToolCallIntegerParam:             100,
-		MaxToolCallNumberParam:              100,
-		MaxToolCallArrayParamLength:         5,
-		MinToolCallArrayParamLength:         1,
-		ToolCallNotRequiredParamProbability: 50,
-		ObjectToolCallNotRequiredParamProbability: 50,
-		ToolCallExtraCallProbability:              45,
+		EngineName:            "vllm",
+		IP:                    os.Getenv(podIPEnv),
+		Port:                  8000,
+		Lora:                  LoraConfig{MaxLoras: 1},
+		MaxNumSeqs:            5,
+		MaxWaitingQueueLength: 1000,
+		MaxModelLen:           1024,
+		Mode:                  ModeRandom,
+		Seed:                  time.Now().UnixNano(),
+		Latencies:             LatenciesConfig{TimeFactorUnderLoad: 1.0},
+		ToolCalls: ToolCallConfig{
+			MaxToolCallIntegerParam:                   100,
+			MaxToolCallNumberParam:                    100,
+			MaxToolCallArrayParamLength:               5,
+			MinToolCallArrayParamLength:               1,
+			ToolCallNotRequiredParamProbability:       50,
+			ObjectToolCallNotRequiredParamProbability: 50,
+			ToolCallExtraCallProbability:              45,
+		},
 		KVCache: KVCacheConfig{
 			KVCacheSize:             1024,
 			TokenBlockSize:          16,
@@ -419,7 +450,7 @@ func NewConfig() *Configuration {
 		},
 		DPSize:                     1,
 		Rank:                       -1,
-		DatasetTableName:           DefaultDSTableName,
+		Dataset:                    DatasetConfig{DatasetTableName: DefaultDSTableName},
 		DefaultEmbeddingDimensions: 384,
 		FakeMetricsRefreshInterval: 100 * time.Millisecond,
 		MaxRequestBodySizeMB:       4,
@@ -443,6 +474,18 @@ func (c *Configuration) load(configFile string) error {
 		return err
 	}
 	if err := foldLegacyKeys(raw, "latencies", latenciesYAMLKeys); err != nil {
+		return err
+	}
+	if err := foldLegacyKeys(raw, "tool-calls", toolCallYAMLKeys); err != nil {
+		return err
+	}
+	if err := foldLegacyKeys(raw, "dataset", datasetYAMLKeys); err != nil {
+		return err
+	}
+	if err := foldLegacyKeys(raw, "ssl", sslYAMLKeys); err != nil {
+		return err
+	}
+	if err := foldLegacyKeys(raw, "lora", loraYAMLKeys); err != nil {
 		return err
 	}
 
@@ -570,25 +613,25 @@ func (c *Configuration) validate() error {
 		return errors.New("max waiting queue size cannot be less than 0")
 	}
 
-	if c.MaxToolCallIntegerParam < c.MinToolCallIntegerParam {
+	if c.ToolCalls.MaxToolCallIntegerParam < c.ToolCalls.MinToolCallIntegerParam {
 		return errors.New("MaxToolCallIntegerParam cannot be less than MinToolCallIntegerParam")
 	}
-	if c.MaxToolCallNumberParam < c.MinToolCallNumberParam {
+	if c.ToolCalls.MaxToolCallNumberParam < c.ToolCalls.MinToolCallNumberParam {
 		return errors.New("MaxToolCallNumberParam cannot be less than MinToolCallNumberParam")
 	}
-	if c.MaxToolCallArrayParamLength < c.MinToolCallArrayParamLength {
+	if c.ToolCalls.MaxToolCallArrayParamLength < c.ToolCalls.MinToolCallArrayParamLength {
 		return errors.New("MaxToolCallArrayParamLength cannot be less than MinToolCallArrayParamLength")
 	}
-	if c.MinToolCallArrayParamLength < 0 {
+	if c.ToolCalls.MinToolCallArrayParamLength < 0 {
 		return errors.New("MinToolCallArrayParamLength cannot be negative")
 	}
-	if c.ToolCallNotRequiredParamProbability < 0 || c.ToolCallNotRequiredParamProbability > 100 {
+	if c.ToolCalls.ToolCallNotRequiredParamProbability < 0 || c.ToolCalls.ToolCallNotRequiredParamProbability > 100 {
 		return errors.New("ToolCallNotRequiredParamProbability should be between 0 and 100")
 	}
-	if c.ObjectToolCallNotRequiredParamProbability < 0 || c.ObjectToolCallNotRequiredParamProbability > 100 {
+	if c.ToolCalls.ObjectToolCallNotRequiredParamProbability < 0 || c.ToolCalls.ObjectToolCallNotRequiredParamProbability > 100 {
 		return errors.New("ObjectToolCallNotRequiredParamProbability should be between 0 and 100")
 	}
-	if c.ToolCallExtraCallProbability < 0 || c.ToolCallExtraCallProbability > 100 {
+	if c.ToolCalls.ToolCallExtraCallProbability < 0 || c.ToolCalls.ToolCallExtraCallProbability > 100 {
 		return errors.New("ToolCallExtraCallProbability should be between 0 and 100")
 	}
 
@@ -624,19 +667,19 @@ func (c *Configuration) validate() error {
 		return errors.New("data parallel rank must be between 0 and 7")
 	}
 
-	if (c.SSLCertFile == "") != (c.SSLKeyFile == "") {
+	if (c.SSL.SSLCertFile == "") != (c.SSL.SSLKeyFile == "") {
 		return errors.New("both ssl-certfile and ssl-keyfile must be provided together")
 	}
 
-	if c.SelfSignedCerts && (c.SSLCertFile != "" || c.SSLKeyFile != "") {
+	if c.SSL.SelfSignedCerts && (c.SSL.SSLCertFile != "" || c.SSL.SSLKeyFile != "") {
 		return errors.New("cannot use both self-signed-certs and explicit ssl-certfile/ssl-keyfile")
 	}
 
-	if c.DatasetPath == "" && c.DatasetURL != "" {
+	if c.Dataset.DatasetPath == "" && c.Dataset.DatasetURL != "" {
 		return errors.New("dataset-path is required when dataset-url is set")
 	}
 
-	if c.Mode == ModeEcho && (c.DatasetPath != "" || c.DatasetURL != "") {
+	if c.Mode == ModeEcho && (c.Dataset.DatasetPath != "" || c.Dataset.DatasetURL != "") {
 		return errors.New("dataset cannot be defined in echo mode")
 	}
 
@@ -661,20 +704,17 @@ func (c *Configuration) validate() error {
 	return nil
 }
 
-// SSLEnabled returns true if SSL is enabled either via certificate files or self-signed certificates
-func (c *Configuration) SSLEnabled() bool {
-	return (c.SSLCertFile != "" && c.SSLKeyFile != "") || c.SelfSignedCerts
-}
-
 // durationFields holds the JSON key names of all time.Duration fields in
 // Configuration and LatenciesConfig.
 // configurableFields maps each admin-configurable JSON field key to its rebuild tag
 // (value of the rebuild struct tag, e.g. "latency"), or "" for fields with no rebuild tag.
-// kvCacheYAMLKeys and latenciesYAMLKeys hold the YAML key names of every KVCacheConfig
-// and LatenciesConfig field respectively. Since those names are identical to the fields'
-// JSON key names, load() also reuses them to fold legacy flat top-level YAML keys into
-// the nested "kvcache"/"latencies" blocks, and Update's foldFlatLatencies reuses
-// latenciesYAMLKeys the same way for the legacy flat POST /admin/config body shape.
+// kvCacheYAMLKeys, latenciesYAMLKeys, toolCallYAMLKeys, datasetYAMLKeys, sslYAMLKeys, and
+// loraYAMLKeys hold the YAML key names of every field of KVCacheConfig, LatenciesConfig,
+// ToolCallConfig, DatasetConfig, SSLConfig, and LoraConfig respectively. Since those names
+// are identical to the fields' JSON key names, load() also reuses them to fold legacy flat
+// top-level YAML keys into the nested "kvcache"/"latencies"/"tool-calls"/"dataset"/"ssl"/"lora"
+// blocks, and Update's foldFlatLatencies reuses latenciesYAMLKeys the same way for the
+// legacy flat POST /admin/config body shape.
 // latenciesYAMLKeySet is the same set as latenciesYAMLKeys, for membership checks;
 // unfoldNestedLatencies uses it to reject fields that are admin-configurable but not
 // part of LatenciesConfig (e.g. latency-calculator) inside the nested "latencies" object.
@@ -686,6 +726,10 @@ var (
 	kvCacheYAMLKeys     []string
 	latenciesYAMLKeys   []string
 	latenciesYAMLKeySet map[string]bool
+	toolCallYAMLKeys    []string
+	datasetYAMLKeys     []string
+	sslYAMLKeys         []string
+	loraYAMLKeys        []string
 )
 
 func init() {
@@ -701,6 +745,10 @@ func init() {
 	kvCacheYAMLKeys = yamlKeysOf(reflect.TypeOf(KVCacheConfig{}))
 	latenciesYAMLKeys = yamlKeysOf(reflect.TypeOf(LatenciesConfig{}))
 	latenciesYAMLKeySet = make(map[string]bool, len(latenciesYAMLKeys))
+	toolCallYAMLKeys = yamlKeysOf(reflect.TypeOf(ToolCallConfig{}))
+	datasetYAMLKeys = yamlKeysOf(reflect.TypeOf(DatasetConfig{}))
+	sslYAMLKeys = yamlKeysOf(reflect.TypeOf(SSLConfig{}))
+	loraYAMLKeys = yamlKeysOf(reflect.TypeOf(LoraConfig{}))
 	for _, key := range latenciesYAMLKeys {
 		latenciesYAMLKeySet[key] = true
 	}

--- a/pkg/common/config_test.go
+++ b/pkg/common/config_test.go
@@ -46,13 +46,13 @@ func createDefaultConfig(model string, servedModelNames []string) *Configuration
 	c := createConfigWithModel(model, servedModelNames)
 
 	c.MaxNumSeqs = 5
-	c.MaxLoras = 2
-	c.MaxCPULoras = 5
+	c.Lora.MaxLoras = 2
+	c.Lora.MaxCPULoras = 5
 	c.Latencies.TimeToFirstToken = 2000 * time.Millisecond
 	c.Latencies.InterTokenLatency = 1000 * time.Millisecond
 	c.Latencies.KVCacheTransferLatency = 100 * time.Millisecond
 	c.Seed = 100100100
-	c.LoraModules = []LoraModule{}
+	c.Lora.LoraModules = []LoraModule{}
 	return c
 }
 
@@ -235,6 +235,29 @@ var _ = Describe("Configuration.MarshalCleaned", func() {
 		Expect(m).To(HaveKey("latency-calculator"), "latency-calculator is a top-level field, not part of latencies")
 		Expect(latencies).ToNot(HaveKey("latency-calculator"))
 	})
+
+	DescribeTable("nests fields under their own group and none remain at the top level",
+		func(groupKey string, groupYAMLKeys []string) {
+			c := createDefaultConfig("model", nil)
+			data, err := c.MarshalCleaned()
+			Expect(err).ToNot(HaveOccurred())
+
+			var m map[string]any
+			Expect(json.Unmarshal(data, &m)).To(Succeed())
+
+			Expect(m).To(HaveKey(groupKey))
+			_, ok := m[groupKey].(map[string]any)
+			Expect(ok).To(BeTrue())
+
+			for _, key := range groupYAMLKeys {
+				Expect(m).ToNot(HaveKey(key), "field %q must not remain at the top level", key)
+			}
+		},
+		Entry("tool-calls", "tool-calls", toolCallYAMLKeys),
+		Entry("dataset", "dataset", datasetYAMLKeys),
+		Entry("ssl", "ssl", sslYAMLKeys),
+		Entry("lora", "lora", loraYAMLKeys),
+	)
 })
 
 var _ = Describe("Configuration.Copy", func() {
@@ -450,6 +473,222 @@ model: test-model
 time-to-first-token: 100ms
 latencies:
   inter-token-latency: 10ms
+`))).ToNot(Succeed())
+	})
+})
+
+var _ = Describe("Configuration.load tool-calls YAML folding", func() {
+	writeConfig := func(contents string) string {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		Expect(os.WriteFile(path, []byte(contents), 0o644)).To(Succeed())
+		return path
+	}
+
+	It("populates ToolCalls from the nested tool-calls block", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+tool-calls:
+  max-tool-call-integer-param: 50
+  skip-tool-validation: true
+`))).To(Succeed())
+
+		Expect(c.ToolCalls.MaxToolCallIntegerParam).To(Equal(50))
+		Expect(c.ToolCalls.SkipToolValidation).To(BeTrue())
+	})
+
+	It("populates ToolCalls from legacy flat top-level keys", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+max-tool-call-integer-param: 50
+skip-tool-validation: true
+`))).To(Succeed())
+
+		Expect(c.ToolCalls.MaxToolCallIntegerParam).To(Equal(50))
+		Expect(c.ToolCalls.SkipToolValidation).To(BeTrue())
+	})
+
+	It("errors when tool-call settings mix the flat and nested layouts", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+max-tool-call-integer-param: 50
+tool-calls:
+  max-tool-call-integer-param: 60
+`))).ToNot(Succeed())
+	})
+
+	It("errors when a flat tool-call key is set alongside an unrelated nested key", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+max-tool-call-integer-param: 50
+tool-calls:
+  skip-tool-validation: true
+`))).ToNot(Succeed())
+	})
+})
+
+var _ = Describe("Configuration.load dataset YAML folding", func() {
+	writeConfig := func(contents string) string {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		Expect(os.WriteFile(path, []byte(contents), 0o644)).To(Succeed())
+		return path
+	}
+
+	It("populates Dataset from the nested dataset block", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+dataset:
+  dataset-path: /tmp/data.db
+  dataset-in-memory: true
+`))).To(Succeed())
+
+		Expect(c.Dataset.DatasetPath).To(Equal("/tmp/data.db"))
+		Expect(c.Dataset.DatasetInMemory).To(BeTrue())
+	})
+
+	It("populates Dataset from legacy flat top-level keys", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+dataset-path: /tmp/data.db
+dataset-in-memory: true
+`))).To(Succeed())
+
+		Expect(c.Dataset.DatasetPath).To(Equal("/tmp/data.db"))
+		Expect(c.Dataset.DatasetInMemory).To(BeTrue())
+	})
+
+	It("errors when dataset settings mix the flat and nested layouts", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+dataset-path: /tmp/data.db
+dataset:
+  dataset-path: /tmp/other.db
+`))).ToNot(Succeed())
+	})
+
+	It("errors when a flat dataset key is set alongside an unrelated nested key", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+dataset-path: /tmp/data.db
+dataset:
+  dataset-in-memory: true
+`))).ToNot(Succeed())
+	})
+})
+
+var _ = Describe("Configuration.load ssl YAML folding", func() {
+	writeConfig := func(contents string) string {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		Expect(os.WriteFile(path, []byte(contents), 0o644)).To(Succeed())
+		return path
+	}
+
+	It("populates SSL from the nested ssl block", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+ssl:
+  ssl-certfile: /tmp/cert.pem
+  ssl-keyfile: /tmp/key.pem
+`))).To(Succeed())
+
+		Expect(c.SSL.SSLCertFile).To(Equal("/tmp/cert.pem"))
+		Expect(c.SSL.SSLKeyFile).To(Equal("/tmp/key.pem"))
+	})
+
+	It("populates SSL from legacy flat top-level keys", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+ssl-certfile: /tmp/cert.pem
+ssl-keyfile: /tmp/key.pem
+`))).To(Succeed())
+
+		Expect(c.SSL.SSLCertFile).To(Equal("/tmp/cert.pem"))
+		Expect(c.SSL.SSLKeyFile).To(Equal("/tmp/key.pem"))
+	})
+
+	It("errors when ssl settings mix the flat and nested layouts", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+ssl-certfile: /tmp/cert.pem
+ssl:
+  ssl-certfile: /tmp/other.pem
+`))).ToNot(Succeed())
+	})
+
+	It("errors when a flat ssl key is set alongside an unrelated nested key", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+ssl-certfile: /tmp/cert.pem
+ssl:
+  self-signed-certs: true
+`))).ToNot(Succeed())
+	})
+})
+
+var _ = Describe("Configuration.load lora YAML folding", func() {
+	writeConfig := func(contents string) string {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		Expect(os.WriteFile(path, []byte(contents), 0o644)).To(Succeed())
+		return path
+	}
+
+	It("populates Lora from the nested lora block", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+lora:
+  max-loras: 4
+  max-cpu-loras: 8
+`))).To(Succeed())
+
+		Expect(c.Lora.MaxLoras).To(Equal(4))
+		Expect(c.Lora.MaxCPULoras).To(Equal(8))
+	})
+
+	It("populates Lora from legacy flat top-level keys", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+max-loras: 4
+max-cpu-loras: 8
+`))).To(Succeed())
+
+		Expect(c.Lora.MaxLoras).To(Equal(4))
+		Expect(c.Lora.MaxCPULoras).To(Equal(8))
+	})
+
+	It("errors when lora settings mix the flat and nested layouts", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+max-loras: 4
+lora:
+  max-loras: 8
+`))).ToNot(Succeed())
+	})
+
+	It("errors when a flat lora key is set alongside an unrelated nested key", func() {
+		c := NewConfig()
+		Expect(c.load(writeConfig(`
+model: test-model
+max-loras: 4
+lora:
+  max-cpu-loras: 8
 `))).ToNot(Succeed())
 	})
 })

--- a/pkg/common/parser.go
+++ b/pkg/common/parser.go
@@ -158,23 +158,23 @@ func ParseCommandParamsAndLoadConfig(eng Engine) (*Configuration, error) {
 	f.Int64Var(&config.Seed, "seed", config.Seed, "Random seed for operations (if not set, current Unix time in nanoseconds is used)")
 	f.Float64Var(&config.Latencies.TimeFactorUnderLoad, "time-factor-under-load", config.Latencies.TimeFactorUnderLoad, "Time factor under load (must be >= 1.0)")
 
-	f.IntVar(&config.MaxToolCallIntegerParam, "max-tool-call-integer-param", config.MaxToolCallIntegerParam, "Maximum possible value of integer parameters in a tool call")
-	f.IntVar(&config.MinToolCallIntegerParam, "min-tool-call-integer-param", config.MinToolCallIntegerParam, "Minimum possible value of integer parameters in a tool call")
-	f.Float64Var(&config.MaxToolCallNumberParam, "max-tool-call-number-param", config.MaxToolCallNumberParam, "Maximum possible value of number (float) parameters in a tool call")
-	f.Float64Var(&config.MinToolCallNumberParam, "min-tool-call-number-param", config.MinToolCallNumberParam, "Minimum possible value of number (float) parameters in a tool call")
-	f.IntVar(&config.MaxToolCallArrayParamLength, "max-tool-call-array-param-length", config.MaxToolCallArrayParamLength, "Maximum possible length of array parameters in a tool call")
-	f.IntVar(&config.MinToolCallArrayParamLength, "min-tool-call-array-param-length", config.MinToolCallArrayParamLength, "Minimum possible length of array parameters in a tool call")
-	f.IntVar(&config.ToolCallNotRequiredParamProbability, "tool-call-not-required-param-probability", config.ToolCallNotRequiredParamProbability, "Probability to add a parameter, that is not required, in a tool call")
-	f.IntVar(&config.ObjectToolCallNotRequiredParamProbability, "object-tool-call-not-required-field-probability", config.ObjectToolCallNotRequiredParamProbability, "Probability to add a field, that is not required, in an object in a tool call")
-	f.IntVar(&config.ToolCallExtraCallProbability, "tool-call-extra-call-probability", config.ToolCallExtraCallProbability, "Probability (0-100) to make one additional tool call beyond the minimum; rolls repeat until a roll fails or all tools are called")
+	f.IntVar(&config.ToolCalls.MaxToolCallIntegerParam, "max-tool-call-integer-param", config.ToolCalls.MaxToolCallIntegerParam, "Maximum possible value of integer parameters in a tool call")
+	f.IntVar(&config.ToolCalls.MinToolCallIntegerParam, "min-tool-call-integer-param", config.ToolCalls.MinToolCallIntegerParam, "Minimum possible value of integer parameters in a tool call")
+	f.Float64Var(&config.ToolCalls.MaxToolCallNumberParam, "max-tool-call-number-param", config.ToolCalls.MaxToolCallNumberParam, "Maximum possible value of number (float) parameters in a tool call")
+	f.Float64Var(&config.ToolCalls.MinToolCallNumberParam, "min-tool-call-number-param", config.ToolCalls.MinToolCallNumberParam, "Minimum possible value of number (float) parameters in a tool call")
+	f.IntVar(&config.ToolCalls.MaxToolCallArrayParamLength, "max-tool-call-array-param-length", config.ToolCalls.MaxToolCallArrayParamLength, "Maximum possible length of array parameters in a tool call")
+	f.IntVar(&config.ToolCalls.MinToolCallArrayParamLength, "min-tool-call-array-param-length", config.ToolCalls.MinToolCallArrayParamLength, "Minimum possible length of array parameters in a tool call")
+	f.IntVar(&config.ToolCalls.ToolCallNotRequiredParamProbability, "tool-call-not-required-param-probability", config.ToolCalls.ToolCallNotRequiredParamProbability, "Probability to add a parameter, that is not required, in a tool call")
+	f.IntVar(&config.ToolCalls.ObjectToolCallNotRequiredParamProbability, "object-tool-call-not-required-field-probability", config.ToolCalls.ObjectToolCallNotRequiredParamProbability, "Probability to add a field, that is not required, in an object in a tool call")
+	f.IntVar(&config.ToolCalls.ToolCallExtraCallProbability, "tool-call-extra-call-probability", config.ToolCalls.ToolCallExtraCallProbability, "Probability (0-100) to make one additional tool call beyond the minimum; rolls repeat until a roll fails or all tools are called")
 
 	f.IntVar(&config.DPSize, "data-parallel-size", config.DPSize, "Number of ranks to run")
 	f.IntVar(&config.Rank, "data-parallel-rank", config.Rank, "The rank when running each rank in a process. If set, data-parallel-size is ignored")
 
-	f.StringVar(&config.DatasetPath, "dataset-path", config.DatasetPath, "Local path to the sqlite db file for response generation from a dataset")
-	f.StringVar(&config.DatasetURL, "dataset-url", config.DatasetURL, "URL to download the sqlite db file for response generation from a dataset")
-	f.BoolVar(&config.DatasetInMemory, "dataset-in-memory", config.DatasetInMemory, "Load the entire dataset into memory for faster access")
-	f.StringVar(&config.DatasetTableName, "dataset-table-name", config.DatasetTableName, "Table name for custom dataset, default is 'llmd'")
+	f.StringVar(&config.Dataset.DatasetPath, "dataset-path", config.Dataset.DatasetPath, "Local path to the sqlite db file for response generation from a dataset")
+	f.StringVar(&config.Dataset.DatasetURL, "dataset-url", config.Dataset.DatasetURL, "URL to download the sqlite db file for response generation from a dataset")
+	f.BoolVar(&config.Dataset.DatasetInMemory, "dataset-in-memory", config.Dataset.DatasetInMemory, "Load the entire dataset into memory for faster access")
+	f.StringVar(&config.Dataset.DatasetTableName, "dataset-table-name", config.Dataset.DatasetTableName, "Table name for custom dataset, default is 'llmd'")
 
 	f.StringVar(&config.RenderURL, "render-url", config.RenderURL, "URL of the tokenizer render service; when unset the simulated tokenizer is used")
 	f.DurationVar(&config.RenderTimeout, "render-timeout", config.RenderTimeout, "Timeout for tokenizer render requests (e.g. 30s)")
@@ -186,7 +186,7 @@ func ParseCommandParamsAndLoadConfig(eng Engine) (*Configuration, error) {
 
 	f.BoolVar(&config.EnableRequestIDHeaders, "enable-request-id-headers", config.EnableRequestIDHeaders, "Enable including X-Request-Id header in responses")
 	f.BoolVar(&config.LogHTTP, "log-http", config.LogHTTP, "Log full HTTP request and response (method, URI, headers, bodies when buffered, status); streamed bodies are not logged")
-	f.BoolVar(&config.SkipToolValidation, "skip-tool-validation", config.SkipToolValidation, "Skip the built-in validation of incoming tool schemas, matching real vLLM which forwards them to the model verbatim")
+	f.BoolVar(&config.ToolCalls.SkipToolValidation, "skip-tool-validation", config.ToolCalls.SkipToolValidation, "Skip the built-in validation of incoming tool schemas, matching real vLLM which forwards them to the model verbatim")
 
 	f.IntVar(&config.FailureInjectionRate, "failure-injection-rate", config.FailureInjectionRate, "Probability (0-100) of injecting failures")
 	failureTypes := GetParamValueFromArgs("failure-types")
@@ -198,9 +198,9 @@ func ParseCommandParamsAndLoadConfig(eng Engine) (*Configuration, error) {
 	f.Lookup("failure-types").NoOptDefVal = dummy
 	f.Lookup("failure-types").DefValue = ""
 
-	f.StringVar(&config.SSLCertFile, "ssl-certfile", config.SSLCertFile, "Path to SSL certificate file for HTTPS (optional)")
-	f.StringVar(&config.SSLKeyFile, "ssl-keyfile", config.SSLKeyFile, "Path to SSL private key file for HTTPS (optional)")
-	f.BoolVar(&config.SelfSignedCerts, "self-signed-certs", config.SelfSignedCerts, "Enable automatic generation of self-signed certificates for HTTPS")
+	f.StringVar(&config.SSL.SSLCertFile, "ssl-certfile", config.SSL.SSLCertFile, "Path to SSL certificate file for HTTPS (optional)")
+	f.StringVar(&config.SSL.SSLKeyFile, "ssl-keyfile", config.SSL.SSLKeyFile, "Path to SSL private key file for HTTPS (optional)")
+	f.BoolVar(&config.SSL.SelfSignedCerts, "self-signed-certs", config.SSL.SelfSignedCerts, "Enable automatic generation of self-signed certificates for HTTPS")
 
 	f.StringVar(&config.LatencyCalculator, "latency-calculator", config.LatencyCalculator,
 		`Name of the latency calculator to be used in the response generation (optional). The default calculation is based on the current load of the simulator and on

--- a/pkg/communication/http.go
+++ b/pkg/communication/http.go
@@ -110,7 +110,7 @@ func (c *Communication) startHTTPServer(ctx context.Context, listener net.Listen
 
 	errCh := make(chan error, 1)
 	go func() {
-		if c.runtime.Config().SSLEnabled() {
+		if c.runtime.Config().SSL.Enabled() {
 			c.logger.V(logging.INFO).Info("Server starting", "protocol", "HTTPS", "port", c.runtime.Config().Port)
 			errCh <- server.ServeTLS(listener, "", "")
 		} else {

--- a/pkg/communication/http_server_test.go
+++ b/pkg/communication/http_server_test.go
@@ -52,9 +52,9 @@ var _ = Describe("Server", func() {
 			os.Args = []string{"cmd", "--model", common.TestModelName, "--ssl-certfile", certFile, "--ssl-keyfile", keyFile}
 			config, err := common.ParseCommandParamsAndLoadConfig(noopEngine{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(config.SSLEnabled()).To(BeTrue())
-			Expect(config.SSLCertFile).To(Equal(certFile))
-			Expect(config.SSLKeyFile).To(Equal(keyFile))
+			Expect(config.SSL.Enabled()).To(BeTrue())
+			Expect(config.SSL.SSLCertFile).To(Equal(certFile))
+			Expect(config.SSL.SSLKeyFile).To(Equal(keyFile))
 		})
 
 		It("Should parse self-signed certificate configuration correctly", func() {
@@ -66,8 +66,8 @@ var _ = Describe("Server", func() {
 			os.Args = []string{"cmd", "--model", common.TestModelName, "--self-signed-certs"}
 			config, err := common.ParseCommandParamsAndLoadConfig(noopEngine{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(config.SSLEnabled()).To(BeTrue())
-			Expect(config.SelfSignedCerts).To(BeTrue())
+			Expect(config.SSL.Enabled()).To(BeTrue())
+			Expect(config.SSL.SelfSignedCerts).To(BeTrue())
 		})
 
 		It("Should create self-signed TLS certificate successfully", func() {

--- a/pkg/communication/http_server_tls.go
+++ b/pkg/communication/http_server_tls.go
@@ -37,7 +37,7 @@ import (
 
 // Based on: https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/8d01161ec48d6b49cd371f179551b35da46e6fd6/internal/tls/tls.go
 func (c *Communication) configureSSL(ctx context.Context, server *fasthttp.Server) error {
-	if !c.runtime.Config().SSLEnabled() {
+	if !c.runtime.Config().SSL.Enabled() {
 		return nil
 	}
 
@@ -53,7 +53,7 @@ func (c *Communication) configureSSL(ctx context.Context, server *fasthttp.Serve
 		},
 	}
 
-	cfg := c.runtime.Config()
+	cfg := &c.runtime.Config().SSL
 
 	if cfg.SSLCertFile != "" && cfg.SSLKeyFile != "" {
 		c.logger.V(logging.INFO).Info("HTTPS server starting with certificate files", "cert", cfg.SSLCertFile, "key", cfg.SSLKeyFile)

--- a/pkg/dataset/custom_dataset_downloader.go
+++ b/pkg/dataset/custom_dataset_downloader.go
@@ -57,7 +57,7 @@ func newDsDownloader(logger logr.Logger) *customDatasetDownloader {
 }
 
 func Init(ctx context.Context, config *common.Configuration, logger logr.Logger) error {
-	if config.DatasetURL != "" && config.Model != common.ModeEcho {
+	if config.Dataset.DatasetURL != "" && config.Model != common.ModeEcho {
 		if config.MMEncoderOnly {
 			logger.V(logging.WARN).Info("MM encoder-only mode: skipping dataset loading and use")
 			return nil
@@ -65,7 +65,7 @@ func Init(ctx context.Context, config *common.Configuration, logger logr.Logger)
 
 		// if should use remote responses dataset, download it first (it can take time)
 		downloader := newDsDownloader(logger)
-		if err := downloader.downloadDataset(ctx, config.DatasetURL, config.DatasetPath); err != nil {
+		if err := downloader.downloadDataset(ctx, config.Dataset.DatasetURL, config.Dataset.DatasetPath); err != nil {
 			return err
 		}
 	}

--- a/pkg/endpoint/chat_completion.go
+++ b/pkg/endpoint/chat_completion.go
@@ -170,7 +170,7 @@ func (c *chatCompletionReqCtx) createToolCalls() ([]api.ToolCall, int, string, e
 	if !isToolChoiceNone(req.GetToolChoice()) &&
 		req.GetTools() != nil {
 		toolCalls, completionTokens, err :=
-			createToolCalls(req.GetTools(), req.GetToolChoice(), c.runtime.Config(), c.runtime.GetRandom(), c.runtime.GetTokenizer(), c.toolIDPrefix)
+			createToolCalls(req.GetTools(), req.GetToolChoice(), &c.runtime.Config().ToolCalls, c.runtime.GetRandom(), c.runtime.GetTokenizer(), c.toolIDPrefix)
 		finishReason := common.ToolsFinishReason
 		return toolCalls, completionTokens, finishReason, err
 	}

--- a/pkg/endpoint/responses.go
+++ b/pkg/endpoint/responses.go
@@ -196,7 +196,7 @@ func (r *responsesReqCtx) createToolCalls() ([]api.ToolCall, int, string, error)
 	}
 
 	toolCalls, completionTokens, err := createSingleToolCall(
-		req.GetTools(), toolChoice, r.runtime.Config(), r.runtime.GetRandom(), r.runtime.GetTokenizer(), r.toolIDPrefix)
+		req.GetTools(), toolChoice, &r.runtime.Config().ToolCalls, r.runtime.GetRandom(), r.runtime.GetTokenizer(), r.toolIDPrefix)
 	if err != nil {
 		return nil, 0, "", err
 	}

--- a/pkg/endpoint/responses_test.go
+++ b/pkg/endpoint/responses_test.go
@@ -47,14 +47,16 @@ func mustTool(name string) api.Tool {
 
 func newResponsesToolTestCtx(tools []api.Tool, choice api.ToolChoice, input []api.InputItem) *responsesReqCtx {
 	cfg := &common.Configuration{
-		MaxToolCallIntegerParam:                   100,
-		MinToolCallIntegerParam:                   0,
-		MaxToolCallNumberParam:                    100,
-		MinToolCallNumberParam:                    0,
-		MaxToolCallArrayParamLength:               5,
-		MinToolCallArrayParamLength:               1,
-		ToolCallNotRequiredParamProbability:       50,
-		ObjectToolCallNotRequiredParamProbability: 50,
+		ToolCalls: common.ToolCallConfig{
+			MaxToolCallIntegerParam:                   100,
+			MinToolCallIntegerParam:                   0,
+			MaxToolCallNumberParam:                    100,
+			MinToolCallNumberParam:                    0,
+			MaxToolCallArrayParamLength:               5,
+			MinToolCallArrayParamLength:               1,
+			ToolCallNotRequiredParamProbability:       50,
+			ObjectToolCallNotRequiredParamProbability: 50,
+		},
 	}
 	runtime := &fakeRuntime{
 		config:    cfg,
@@ -281,7 +283,7 @@ var _ = Describe("Responses tokenizedPromptForEcho", func() {
 
 var _ = Describe("createSingleToolCall", func() {
 	It("never returns more than one call", func() {
-		cfg := &common.Configuration{
+		cfg := &common.ToolCallConfig{
 			MaxToolCallIntegerParam:                   100,
 			MinToolCallIntegerParam:                   0,
 			MaxToolCallNumberParam:                    100,

--- a/pkg/endpoint/tools_arg_generator_test.go
+++ b/pkg/endpoint/tools_arg_generator_test.go
@@ -27,14 +27,12 @@ import (
 
 var _ = Describe("createArgument with under-specified schemas", func() {
 	var (
-		config *common.Configuration
+		config *common.ToolCallConfig
 		random *common.Random
 	)
 
 	BeforeEach(func() {
-		config = &common.Configuration{
-			Model:                                     "test",
-			ServedModelNames:                          []string{"test"},
+		config = &common.ToolCallConfig{
 			MinToolCallArrayParamLength:               1,
 			MaxToolCallArrayParamLength:               5,
 			MinToolCallIntegerParam:                   0,

--- a/pkg/endpoint/tools_arg_type_test.go
+++ b/pkg/endpoint/tools_arg_type_test.go
@@ -27,14 +27,12 @@ import (
 
 var _ = Describe("createArgument type normalization", func() {
 	var (
-		config *common.Configuration
+		config *common.ToolCallConfig
 		random *common.Random
 	)
 
 	BeforeEach(func() {
-		config = &common.Configuration{
-			Model:                                     "test",
-			ServedModelNames:                          []string{"test"},
+		config = &common.ToolCallConfig{
 			MinToolCallArrayParamLength:               1,
 			MaxToolCallArrayParamLength:               3,
 			MinToolCallIntegerParam:                   0,

--- a/pkg/endpoint/tools_callcount_test.go
+++ b/pkg/endpoint/tools_callcount_test.go
@@ -67,9 +67,7 @@ var _ = Describe("createToolCalls call-count distribution", func() {
 
 	DescribeTable("number of calls follows the ToolCallExtraCallProbability",
 		func(probability, expectedCalls int) {
-			config := &common.Configuration{
-				Model:                        "test",
-				ServedModelNames:             []string{"test"},
+			config := &common.ToolCallConfig{
 				ToolCallExtraCallProbability: probability,
 			}
 
@@ -91,9 +89,7 @@ var _ = Describe("createToolCalls call-count distribution", func() {
 	)
 
 	It("with default probability 45, mostly produces minCalls but can reach maxCalls", func() {
-		config := &common.Configuration{
-			Model:                        "test",
-			ServedModelNames:             []string{"test"},
+		config := &common.ToolCallConfig{
 			ToolCallExtraCallProbability: 45,
 		}
 
@@ -119,9 +115,7 @@ var _ = Describe("createToolCalls call-count distribution", func() {
 
 	It("with tool_choice auto (minCalls=0), p=0 produces no tool calls", func() {
 		autoTC := api.ToolChoice{}
-		config := &common.Configuration{
-			Model:                        "test",
-			ServedModelNames:             []string{"test"},
+		config := &common.ToolCallConfig{
 			ToolCallExtraCallProbability: 0,
 		}
 

--- a/pkg/endpoint/tools_utils.go
+++ b/pkg/endpoint/tools_utils.go
@@ -128,7 +128,7 @@ func (v *ToolsValidator) validateTool(tool []byte) error {
 func createToolCalls(
 	tools []api.Tool,
 	toolChoice api.ToolChoice,
-	config *common.Configuration,
+	config *common.ToolCallConfig,
 	random *common.Random,
 	tokenizer tokenizer.Tokenizer,
 	idPrefix string,
@@ -230,7 +230,7 @@ func createToolCalls(
 func createSingleToolCall(
 	tools []api.Tool,
 	toolChoice api.ToolChoice,
-	config *common.Configuration,
+	config *common.ToolCallConfig,
 	random *common.Random,
 	tokenizer tokenizer.Tokenizer,
 	idPrefix string,
@@ -243,7 +243,7 @@ func createSingleToolCall(
 	return calls, countTokensForToolCalls(calls), nil
 }
 
-func generateToolArguments(tool api.Tool, config *common.Configuration, random *common.Random) (map[string]any, error) {
+func generateToolArguments(tool api.Tool, config *common.ToolCallConfig, random *common.Random) (map[string]any, error) {
 	arguments := make(map[string]any)
 	properties, _ := tool.Function.Parameters["properties"].(map[string]any)
 
@@ -297,7 +297,7 @@ func resolveParamType(paramType any) any {
 	}
 }
 
-func createArgument(property any, config *common.Configuration, random *common.Random) (any, error) {
+func createArgument(property any, config *common.ToolCallConfig, random *common.Random) (any, error) {
 	propertyMap, _ := property.(map[string]any)
 	paramType := resolveParamType(propertyMap["type"])
 

--- a/pkg/engine/vllm/flags.go
+++ b/pkg/engine/vllm/flags.go
@@ -31,8 +31,8 @@ const dummy = " "
 // file already loaded into cfg, or from the command line) into their
 // structured fields. Must be called before f.Parse.
 func (Engine) BindFlags(f *pflag.FlagSet, cfg *common.Configuration) error {
-	f.IntVar(&cfg.MaxLoras, "max-loras", cfg.MaxLoras, "Maximum number of LoRAs in a single batch")
-	f.IntVar(&cfg.MaxCPULoras, "max-cpu-loras", cfg.MaxCPULoras, "Maximum number of LoRAs to store in CPU memory")
+	f.IntVar(&cfg.Lora.MaxLoras, "max-loras", cfg.Lora.MaxLoras, "Maximum number of LoRAs in a single batch")
+	f.IntVar(&cfg.Lora.MaxCPULoras, "max-cpu-loras", cfg.Lora.MaxCPULoras, "Maximum number of LoRAs to store in CPU memory")
 
 	f.DurationVar(&cfg.Latencies.KVCacheTransferTimePerToken, "kv-cache-transfer-time-per-token", cfg.Latencies.KVCacheTransferTimePerToken, "Time for KV-cache transfer per token from a remote vLLM, e.g. 100ms")
 	f.DurationVar(&cfg.Latencies.KVCacheTransferTimeStdDev, "kv-cache-transfer-time-std-dev", cfg.Latencies.KVCacheTransferTimeStdDev, "Standard deviation for time for KV-cache transfer per token from a remote vLLM, e.g. 100ms")
@@ -105,7 +105,7 @@ func (Engine) BindFlags(f *pflag.FlagSet, cfg *common.Configuration) error {
 		}
 	}
 	if loraModuleNames != nil {
-		cfg.LoraModulesString = loraModuleNames
+		cfg.Lora.LoraModulesString = loraModuleNames
 		if err := unmarshalLoras(cfg); err != nil {
 			return err
 		}
@@ -135,16 +135,16 @@ func (l *multiString) Type() string {
 	return "strings"
 }
 
-// unmarshalLoras reconciles cfg.LoraModulesString (raw JSON strings, from a
-// YAML config file or the --lora-modules flag) into cfg.LoraModules.
+// unmarshalLoras reconciles cfg.Lora.LoraModulesString (raw JSON strings, from a
+// YAML config file or the --lora-modules flag) into cfg.Lora.LoraModules.
 func unmarshalLoras(cfg *common.Configuration) error {
-	cfg.LoraModules = make([]common.LoraModule, 0)
-	for _, jsonStr := range cfg.LoraModulesString {
+	cfg.Lora.LoraModules = make([]common.LoraModule, 0)
+	for _, jsonStr := range cfg.Lora.LoraModulesString {
 		var lora common.LoraModule
 		if err := json.Unmarshal([]byte(jsonStr), &lora); err != nil {
 			return err
 		}
-		cfg.LoraModules = append(cfg.LoraModules, lora)
+		cfg.Lora.LoraModules = append(cfg.Lora.LoraModules, lora)
 	}
 	return nil
 }

--- a/pkg/engine/vllm/flags_test.go
+++ b/pkg/engine/vllm/flags_test.go
@@ -60,13 +60,13 @@ func createDefaultConfig(model string, servedModelNames []string) *common.Config
 	c := createConfigWithModel(model, servedModelNames)
 
 	c.MaxNumSeqs = 5
-	c.MaxLoras = 2
-	c.MaxCPULoras = 5
+	c.Lora.MaxLoras = 2
+	c.Lora.MaxCPULoras = 5
 	c.Latencies.TimeToFirstToken = 2000 * time.Millisecond
 	c.Latencies.InterTokenLatency = 1000 * time.Millisecond
 	c.Latencies.KVCacheTransferLatency = 100 * time.Millisecond
 	c.Seed = 100100100
-	c.LoraModules = []common.LoraModule{}
+	c.Lora.LoraModules = []common.LoraModule{}
 	return c
 }
 
@@ -83,7 +83,7 @@ var _ = Describe("Simulator configuration", func() {
 
 	// Simple config with a few parameters
 	c := createConfigWithModel(common.TestModelName, nil)
-	c.MaxCPULoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Seed = 100
 	test := testCase{
 		name:           "simple",
@@ -95,13 +95,13 @@ var _ = Describe("Simulator configuration", func() {
 	// Config from config.yaml file
 	c = createDefaultConfig(common.QwenModelName, []string{"model1", "model2"})
 	c.Port = 8001
-	c.LoraModules = []common.LoraModule{{Name: "lora1", Path: "/path/to/lora1"}, {Name: "lora2", Path: "/path/to/lora2"}}
+	c.Lora.LoraModules = []common.LoraModule{{Name: "lora1", Path: "/path/to/lora1"}, {Name: "lora2", Path: "/path/to/lora2"}}
 	test = testCase{
 		name:           "config file",
 		args:           []string{"cmd", "--config", "../../../manifests/config.yaml"},
 		expectedConfig: c,
 	}
-	c.LoraModulesString = []string{
+	c.Lora.LoraModulesString = []string{
 		"{\"name\":\"lora1\",\"path\":\"/path/to/lora1\"}",
 		"{\"name\":\"lora2\",\"path\":\"/path/to/lora2\"}",
 	}
@@ -111,8 +111,8 @@ var _ = Describe("Simulator configuration", func() {
 	c = createDefaultConfig(common.TestModelName, []string{"alias1", "alias2"})
 	c.Port = 8002
 	c.Seed = 100
-	c.LoraModules = []common.LoraModule{{Name: "lora3", Path: "/path/to/lora3"}, {Name: "lora4", Path: "/path/to/lora4"}}
-	c.LoraModulesString = []string{
+	c.Lora.LoraModules = []common.LoraModule{{Name: "lora3", Path: "/path/to/lora3"}, {Name: "lora4", Path: "/path/to/lora4"}}
+	c.Lora.LoraModulesString = []string{
 		"{\"name\":\"lora3\",\"path\":\"/path/to/lora3\"}",
 		"{\"name\":\"lora4\",\"path\":\"/path/to/lora4\"}",
 	}
@@ -133,8 +133,8 @@ var _ = Describe("Simulator configuration", func() {
 	// Config from config.yaml file plus command line args with different format
 	c = createDefaultConfig(common.TestModelName, nil)
 	c.Port = 8002
-	c.LoraModules = []common.LoraModule{{Name: "lora3", Path: "/path/to/lora3"}}
-	c.LoraModulesString = []string{
+	c.Lora.LoraModules = []common.LoraModule{{Name: "lora3", Path: "/path/to/lora3"}}
+	c.Lora.LoraModulesString = []string{
 		"{\"name\":\"lora3\",\"path\":\"/path/to/lora3\"}",
 	}
 	test = testCase{
@@ -150,8 +150,8 @@ var _ = Describe("Simulator configuration", func() {
 	// Config from config.yaml file plus command line args with empty string
 	c = createDefaultConfig(common.TestModelName, nil)
 	c.Port = 8002
-	c.LoraModules = []common.LoraModule{{Name: "lora3", Path: "/path/to/lora3"}}
-	c.LoraModulesString = []string{
+	c.Lora.LoraModules = []common.LoraModule{{Name: "lora3", Path: "/path/to/lora3"}}
+	c.Lora.LoraModulesString = []string{
 		"{\"name\":\"lora3\",\"path\":\"/path/to/lora3\"}",
 	}
 	test = testCase{
@@ -167,7 +167,7 @@ var _ = Describe("Simulator configuration", func() {
 	// Config from config.yaml file plus command line args with empty string for loras
 	c = createDefaultConfig(common.QwenModelName, []string{"model1", "model2"})
 	c.Port = 8001
-	c.LoraModulesString = []string{}
+	c.Lora.LoraModulesString = []string{}
 	test = testCase{
 		name:           "config file with command line args with empty string for loras",
 		args:           []string{"cmd", "--config", "../../../manifests/config.yaml", "--lora-modules", ""},
@@ -178,7 +178,7 @@ var _ = Describe("Simulator configuration", func() {
 	// Config from config.yaml file plus command line args with empty parameter for loras
 	c = createDefaultConfig(common.QwenModelName, []string{"model1", "model2"})
 	c.Port = 8001
-	c.LoraModulesString = []string{}
+	c.Lora.LoraModulesString = []string{}
 	test = testCase{
 		name:           "config file with command line args with empty parameter for loras",
 		args:           []string{"cmd", "--config", "../../../manifests/config.yaml", "--lora-modules"},
@@ -189,7 +189,7 @@ var _ = Describe("Simulator configuration", func() {
 	// Config from config_with_duration_latency.yaml file plus command line args with empty parameter for loras
 	c = createDefaultConfig(common.QwenModelName, []string{"model1", "model2"})
 	c.Port = 8001
-	c.LoraModulesString = []string{}
+	c.Lora.LoraModulesString = []string{}
 	c.Latencies.TimeToFirstToken = 4 * time.Second
 	c.Latencies.InterTokenLatency = 2 * time.Second
 	c.Latencies.KVCacheTransferLatency = time.Second
@@ -204,8 +204,8 @@ var _ = Describe("Simulator configuration", func() {
 	c = createDefaultConfig(common.QwenModelName, nil)
 	c.Port = 8001
 	// basic config file does not contain properties related to lora
-	c.MaxLoras = 1
-	c.MaxCPULoras = 1
+	c.Lora.MaxLoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Latencies.KVCacheTransferLatency = 50 * time.Millisecond
 	test = testCase{
 		name:           "basic config file with command line args with time to transfer kv-cache",
@@ -217,8 +217,8 @@ var _ = Describe("Simulator configuration", func() {
 	// Config with image generation latencies
 	c = createDefaultConfig(common.QwenModelName, nil)
 	c.Port = 8001
-	c.MaxLoras = 1
-	c.MaxCPULoras = 1
+	c.Lora.MaxLoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Latencies.TimeToGenerateImage = 500 * time.Millisecond
 	c.Latencies.TimeToGenerateImageStdDev = 50 * time.Millisecond
 	test = testCase{
@@ -277,7 +277,7 @@ var _ = Describe("Simulator configuration", func() {
 
 	// Fake metrics from command line
 	c = createConfigWithModel(common.TestModelName, nil)
-	c.MaxCPULoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Seed = 100
 	c.FakeMetrics = &common.FakeMetrics{
 		RunningRequests: &common.FakeMetricWithFunction{
@@ -332,7 +332,7 @@ var _ = Describe("Simulator configuration", func() {
 
 	// max-request-body-size-mb set to exactly 1 MB (lower boundary)
 	c = createConfigWithModel(common.TestModelName, nil)
-	c.MaxCPULoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Seed = 100
 	c.MaxRequestBodySizeMB = 1
 	test = testCase{
@@ -344,7 +344,7 @@ var _ = Describe("Simulator configuration", func() {
 
 	// kv-events-replay-endpoint set via CLI flag
 	c = createConfigWithModel(common.TestModelName, nil)
-	c.MaxCPULoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Seed = 100
 	c.KVCache = common.NewConfig().KVCache
 	c.KVCache.EnableKVCache = true
@@ -359,7 +359,7 @@ var _ = Describe("Simulator configuration", func() {
 
 	// kv-events-replay-endpoint not set — defaults to empty (disabled)
 	c = createConfigWithModel(common.TestModelName, nil)
-	c.MaxCPULoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Seed = 100
 	test = testCase{
 		name:           "kv-events-replay-endpoint disabled by default",
@@ -371,7 +371,7 @@ var _ = Describe("Simulator configuration", func() {
 	// kv-cache-only flags without --enable-kvcache are inert: the whole
 	// KVCache block reports all-zero rather than the flag values.
 	c = createConfigWithModel(common.TestModelName, nil)
-	c.MaxCPULoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Seed = 100
 	test = testCase{
 		name: "kv-cache flags without --enable-kvcache report an all-zero KVCache block",
@@ -384,7 +384,7 @@ var _ = Describe("Simulator configuration", func() {
 
 	// tensor-parallel-size is accepted for vLLM command line compatibility and ignored
 	c = createConfigWithModel(common.TestModelName, nil)
-	c.MaxCPULoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Seed = 100
 	c.TPSize = 2
 	test = testCase{
@@ -397,7 +397,7 @@ var _ = Describe("Simulator configuration", func() {
 	// zmq-endpoint and kv-events-replay-endpoint ports far enough apart that
 	// they don't collide even once each rank's offset (0..data-parallel-size-1) is applied
 	c = createConfigWithModel(common.TestModelName, nil)
-	c.MaxCPULoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Seed = 100
 	c.DPSize = 3
 	c.KVCache = common.NewConfig().KVCache
@@ -419,7 +419,7 @@ var _ = Describe("Simulator configuration", func() {
 	// being set here. These ports (range [5557,5559] vs [5600,5602]) don't collide
 	// either way.
 	c = createConfigWithModel(common.TestModelName, nil)
-	c.MaxCPULoras = 1
+	c.Lora.MaxCPULoras = 1
 	c.Seed = 100
 	c.DPSize = 3
 	c.Rank = 2

--- a/pkg/engine/vllm/validate.go
+++ b/pkg/engine/vllm/validate.go
@@ -48,18 +48,18 @@ func (Engine) ValidateConfig(cfg *common.Configuration) error {
 		return errors.New("kv-cache transfer standard deviation cannot be more than 30% of kv-cache transfer")
 	}
 
-	if cfg.MaxLoras < 1 {
+	if cfg.Lora.MaxLoras < 1 {
 		return errors.New("max LoRAs cannot be less than 1")
 	}
-	if cfg.MaxCPULoras == 0 {
+	if cfg.Lora.MaxCPULoras == 0 {
 		// max CPU LoRAs by default is same as max LoRAs
-		cfg.MaxCPULoras = cfg.MaxLoras
+		cfg.Lora.MaxCPULoras = cfg.Lora.MaxLoras
 	}
-	if cfg.MaxCPULoras < cfg.MaxLoras {
+	if cfg.Lora.MaxCPULoras < cfg.Lora.MaxLoras {
 		return errors.New("max CPU LoRAs cannot be less than max LoRAs")
 	}
 
-	for _, lora := range cfg.LoraModules {
+	for _, lora := range cfg.Lora.LoraModules {
 		if lora.Name == "" {
 			return errors.New("empty LoRA name")
 		}

--- a/pkg/simulator/context.go
+++ b/pkg/simulator/context.go
@@ -182,11 +182,11 @@ func (s *SimContext) initialize(ctx context.Context) error {
 
 	s.rebuildLatencyCalculator()
 
-	for _, lora := range s.Config().LoraModules {
+	for _, lora := range s.Config().Lora.LoraModules {
 		s.loraAdaptors.Store(lora.Name, lora.Path)
 	}
-	s.loras.maxLoras = s.Config().MaxLoras
-	s.loras.loraIDs = make([]string, s.Config().MaxLoras)
+	s.loras.maxLoras = s.Config().Lora.MaxLoras
+	s.loras.loraIDs = make([]string, s.Config().Lora.MaxLoras)
 	s.loras.loraRemovable = common.Channel[int]{
 		Channel: make(chan int, s.Config().MaxNumSeqs),
 		Name:    "loraRemovable",
@@ -234,7 +234,7 @@ func (s *SimContext) initDataset(ctx context.Context) error {
 		return nil
 	}
 
-	if s.Config().DatasetPath == "" && s.Config().DatasetURL == "" {
+	if s.Config().Dataset.DatasetPath == "" && s.Config().Dataset.DatasetURL == "" {
 		// use predefined sentences as responses
 		randDataset := &dataset.DefaultDataset{}
 		err := randDataset.Init(ctx, s.logger, s.Random, s.Config().MaxModelLen, s.Tokenizer)
@@ -248,8 +248,8 @@ func (s *SimContext) initDataset(ctx context.Context) error {
 
 	// use dataset containing responses
 	custDataset := &dataset.CustomDataset{}
-	err := custDataset.Init(ctx, s.logger, s.Random, s.Config().DatasetPath, s.Config().DatasetTableName,
-		s.Config().DatasetInMemory, s.Config().MaxModelLen, s.Tokenizer)
+	err := custDataset.Init(ctx, s.logger, s.Random, s.Config().Dataset.DatasetPath, s.Config().Dataset.DatasetTableName,
+		s.Config().Dataset.DatasetInMemory, s.Config().MaxModelLen, s.Tokenizer)
 
 	if err == nil {
 		s.dataset = custDataset

--- a/pkg/simulator/fake_metrics.go
+++ b/pkg/simulator/fake_metrics.go
@@ -386,13 +386,13 @@ func (s *SimContext) updateFakeMetrics(update *common.FakeMetrics, old *common.F
 		if len(update.LoraMetrics) != 0 {
 			for _, metrics := range update.LoraMetrics {
 				s.metrics.loraInfo.WithLabelValues(
-					strconv.Itoa(s.Config().MaxLoras),
+					strconv.Itoa(s.Config().Lora.MaxLoras),
 					metrics.RunningLoras,
 					metrics.WaitingLoras).Set(metrics.Timestamp)
 			}
 		} else {
 			s.metrics.loraInfo.WithLabelValues(
-				strconv.Itoa(s.Config().MaxLoras),
+				strconv.Itoa(s.Config().Lora.MaxLoras),
 				"",
 				"").Set(float64(time.Now().Unix()))
 		}

--- a/pkg/simulator/metrics.go
+++ b/pkg/simulator/metrics.go
@@ -428,7 +428,7 @@ func (s *SimContext) setInitialPrometheusMetrics(cacheConfig *prometheus.GaugeVe
 	s.metrics.kvCacheUsagePercentage.WithLabelValues(s.Config().DisplayModelName).Set(0)
 
 	s.metrics.loraInfo.WithLabelValues(
-		strconv.Itoa(s.Config().MaxLoras),
+		strconv.Itoa(s.Config().Lora.MaxLoras),
 		"",
 		"").Set(float64(time.Now().Unix()))
 
@@ -461,7 +461,7 @@ func (s *SimContext) reportLoras() {
 	})
 
 	s.metrics.loraInfo.WithLabelValues(
-		strconv.Itoa(s.Config().MaxLoras),
+		strconv.Itoa(s.Config().Lora.MaxLoras),
 		strings.Join(runningLoras, ","),
 		strings.Join(waitingLoras, ",")).Set(float64(time.Now().Unix()))
 }

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -89,7 +89,7 @@ func New(logger logr.Logger) (*Simulator, error) {
 	// updates, so read it per call rather than capturing the flag here.
 	sim.toolsValidator.Skip = func() bool {
 		config := sim.Context.Config()
-		return config != nil && config.SkipToolValidation
+		return config != nil && config.ToolCalls.SkipToolValidation
 	}
 
 	return sim, nil


### PR DESCRIPTION
Groups the tool-call generation, dataset, SSL, and LoRA settings into their own named structs, mirroring the existing `KVCacheConfig`/`LatenciesConfig` split.  Each nests under its own `YAML`/`JSON` key while still accepting the legacy flat top-level keys for backward compatibility. CLI flag names are unchanged. `GET /admin/config` now nests lora-modules under `lora`.